### PR TITLE
feat(symphony): A1 PR2 automatic triage route publication

### DIFF
--- a/apps/symphony/Cargo.lock
+++ b/apps/symphony/Cargo.lock
@@ -2270,7 +2270,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symphony"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/apps/symphony/src/main.rs
+++ b/apps/symphony/src/main.rs
@@ -488,6 +488,19 @@ impl BootstrapDeps for RuntimeBootstrapDeps {
                     event = "triage_runtime_disabled",
                     "triage.enabled is false; triage runtime not started"
                 );
+                match symphony::triage::runtime::TriageRuntime::try_open_dispatch_guard_store(
+                    &context.effective_config,
+                ) {
+                    Ok(Some(store)) => {
+                        orchestrator.attach_dispatch_guard_store(store);
+                    }
+                    Ok(None) => {}
+                    Err(err) => {
+                        return Err(format!(
+                            "failed to open triage dispatch guard store while triage is disabled: {err}"
+                        ));
+                    }
+                }
             }
             Err(err) => {
                 return Err(format!("failed to start triage runtime: {err}"));

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -2868,6 +2868,7 @@ impl Orchestrator {
         tracing::info!(phase = "dispatch", "starting orchestrator tick phase");
 
         let candidates = port.fetch_candidate_issues()?;
+        let candidates = self.filter_pending_automatic_publication(candidates);
         let sorted_candidates = self.sort_issues_for_dispatch(candidates);
         let candidate_ids: std::collections::HashSet<String> =
             sorted_candidates.iter().map(|i| i.id.clone()).collect();
@@ -4909,6 +4910,10 @@ impl Orchestrator {
             return false;
         }
 
+        if self.issue_blocked_by_pending_automatic_publication(issue) {
+            return false;
+        }
+
         // NOTE: blocker checks are done at the dispatch loop level via
         // is_blocked_by_dependency() which needs access to all candidates.
 
@@ -5053,6 +5058,62 @@ impl Orchestrator {
             .map(|l| l.trim().to_ascii_lowercase())
             .filter(|l| !l.is_empty())
             .any(|l| excluded.contains(l.as_str()))
+    }
+
+    /// Drop candidates that still have a nonterminal automatic triage publication.
+    ///
+    /// Uses durable store state so the guard remains effective even if triage is
+    /// disabled or its intake label is reloaded mid-publication.
+    fn filter_pending_automatic_publication(&self, candidates: Vec<Issue>) -> Vec<Issue> {
+        let Some(runtime) = self.triage_runtime.as_ref() else {
+            return candidates;
+        };
+        let guards = match runtime.pending_automatic_dispatch_guards() {
+            Ok(guards) => guards,
+            Err(err) => {
+                tracing::warn!(
+                    event = "triage_dispatch_guard_read_failed",
+                    error = %err,
+                    "failed to read pending automatic publication guards; failing closed"
+                );
+                return Vec::new();
+            }
+        };
+        if guards.is_empty() {
+            return candidates;
+        }
+        candidates
+            .into_iter()
+            .filter(|issue| !Self::issue_matches_automatic_dispatch_guard(issue, &guards))
+            .collect()
+    }
+
+    fn issue_blocked_by_pending_automatic_publication(&self, issue: &Issue) -> bool {
+        let Some(runtime) = self.triage_runtime.as_ref() else {
+            return false;
+        };
+        match runtime.pending_automatic_dispatch_guards() {
+            Ok(guards) => Self::issue_matches_automatic_dispatch_guard(issue, &guards),
+            Err(err) => {
+                tracing::warn!(
+                    event = "triage_dispatch_guard_read_failed",
+                    issue_id = %issue.id,
+                    error = %err,
+                    "failed to read pending automatic publication guards; blocking dispatch"
+                );
+                true
+            }
+        }
+    }
+
+    fn issue_matches_automatic_dispatch_guard(
+        issue: &Issue,
+        guards: &[crate::triage::store::PendingAutomaticDispatchGuard],
+    ) -> bool {
+        // Reject the durable issue ID for every nonterminal automatic intent.
+        // Guards also carry the recorded intake label so handoff stays tied to
+        // the publication intent rather than live triage config.
+        guards.iter().any(|guard| guard.issue_id == issue.id)
     }
 
     /// Returns `true` if the issue has at least one non-terminal blocker,

--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -29,7 +29,8 @@ use crate::session_summary::{compact_session_id, normalize_whitespace, truncate_
 use crate::shared_context::SharedContextStore;
 use crate::ssh::{self, WorkerHostSelection};
 use crate::supervisor::{SupervisorAgent, SupervisorDependencies};
-use crate::triage::runtime::TriageRuntime;
+use crate::triage::runtime::{SharedFactoryStore, TriageRuntime};
+use crate::triage::storage_path::forge_host_from_endpoint;
 use crate::workflow_store::WorkflowStore;
 use crate::{docker, path_safety, prompt_builder, workspace};
 
@@ -2071,6 +2072,11 @@ pub struct Orchestrator {
     supervisor_agent: Option<SupervisorAgent>,
     /// Optional A1 triage runtime (preview/automatic factory stage).
     triage_runtime: Option<TriageRuntime>,
+    /// Durable factory store used for automatic publication dispatch guards.
+    ///
+    /// Kept separately from [`Self::triage_runtime`] so guards remain effective
+    /// when `triage.enabled` is false after a prior automatic publication.
+    dispatch_guard_store: Option<SharedFactoryStore>,
     /// The prompt template from the WORKFLOW.md body, used to render per-issue prompts.
     prompt_template: String,
     /// Resolved workflow path used by worker helpers and workflow-relative paths.
@@ -2165,6 +2171,7 @@ impl Orchestrator {
             ),
             supervisor_agent: None,
             triage_runtime: None,
+            dispatch_guard_store: None,
             prompt_template,
             workflow_path,
         }
@@ -4555,7 +4562,13 @@ impl Orchestrator {
                 }));
             }
         }
+        self.dispatch_guard_store = Some(runtime.store());
         self.triage_runtime = Some(runtime);
+    }
+
+    /// Attach a store-backed dispatch guard source when triage intake is disabled.
+    pub fn attach_dispatch_guard_store(&mut self, store: SharedFactoryStore) {
+        self.dispatch_guard_store = Some(store);
     }
 
     pub fn triage_runtime_mut(&mut self) -> Option<&mut TriageRuntime> {
@@ -5065,10 +5078,10 @@ impl Orchestrator {
     /// Uses durable store state so the guard remains effective even if triage is
     /// disabled or its intake label is reloaded mid-publication.
     fn filter_pending_automatic_publication(&self, candidates: Vec<Issue>) -> Vec<Issue> {
-        let Some(runtime) = self.triage_runtime.as_ref() else {
+        let Some(store) = self.dispatch_guard_store.as_ref() else {
             return candidates;
         };
-        let guards = match runtime.pending_automatic_dispatch_guards() {
+        let guards = match store.pending_automatic_dispatch_guards() {
             Ok(guards) => guards,
             Err(err) => {
                 tracing::warn!(
@@ -5084,16 +5097,16 @@ impl Orchestrator {
         }
         candidates
             .into_iter()
-            .filter(|issue| !Self::issue_matches_automatic_dispatch_guard(issue, &guards))
+            .filter(|issue| !self.issue_matches_automatic_dispatch_guard(issue, &guards))
             .collect()
     }
 
     fn issue_blocked_by_pending_automatic_publication(&self, issue: &Issue) -> bool {
-        let Some(runtime) = self.triage_runtime.as_ref() else {
+        let Some(store) = self.dispatch_guard_store.as_ref() else {
             return false;
         };
-        match runtime.pending_automatic_dispatch_guards() {
-            Ok(guards) => Self::issue_matches_automatic_dispatch_guard(issue, &guards),
+        match store.pending_automatic_dispatch_guards() {
+            Ok(guards) => self.issue_matches_automatic_dispatch_guard(issue, &guards),
             Err(err) => {
                 tracing::warn!(
                     event = "triage_dispatch_guard_read_failed",
@@ -5106,14 +5119,42 @@ impl Orchestrator {
         }
     }
 
+    fn configured_tracker_identity(&self) -> Option<(String, String)> {
+        let owner = self
+            .config
+            .tracker
+            .repo_owner
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())?;
+        let repo = self
+            .config
+            .tracker
+            .repo_name
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())?;
+        let forge_host = forge_host_from_endpoint(&self.config.tracker.endpoint);
+        Some((forge_host, format!("{owner}/{repo}")))
+    }
+
     fn issue_matches_automatic_dispatch_guard(
+        &self,
         issue: &Issue,
         guards: &[crate::triage::store::PendingAutomaticDispatchGuard],
     ) -> bool {
-        // Reject the durable issue ID for every nonterminal automatic intent.
-        // Guards also carry the recorded intake label so handoff stays tied to
-        // the publication intent rather than live triage config.
-        guards.iter().any(|guard| guard.issue_id == issue.id)
+        // Reject by forge/repository/issue-id for every nonterminal automatic
+        // intent. Intake labels are recorded on the guard for handoff identity
+        // but are not used as a cross-issue match key.
+        let tracker = self.configured_tracker_identity();
+        guards.iter().any(|guard| match tracker.as_ref() {
+            Some((forge_host, repository)) => {
+                guard.forge_host.eq_ignore_ascii_case(forge_host)
+                    && guard.repository.eq_ignore_ascii_case(repository)
+                    && guard.issue_id == issue.id
+            }
+            None => guard.issue_id == issue.id,
+        })
     }
 
     /// Returns `true` if the issue has at least one non-terminal blocker,

--- a/apps/symphony/src/triage/comment.rs
+++ b/apps/symphony/src/triage/comment.rs
@@ -23,6 +23,25 @@ pub struct IneligibleCommentInput<'a> {
     pub remediation: &'a str,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AutomaticCommentPhase {
+    Pending,
+    RouteEffectsApplied,
+    Applied,
+}
+
+#[derive(Debug, Clone)]
+pub struct AutomaticCommentInput<'a> {
+    pub intent_id: &'a str,
+    pub run_id: &'a str,
+    pub stage_run_id: &'a str,
+    pub attempt: u32,
+    pub artifact: &'a TriageArtifact,
+    pub route_label: &'a str,
+    pub project_state: Option<&'a str>,
+    pub phase: AutomaticCommentPhase,
+}
+
 pub fn render_preview_comment(input: &PreviewCommentInput<'_>) -> String {
     let artifact = input.artifact;
     let mut body = String::new();
@@ -94,6 +113,89 @@ pub fn render_ineligible_diagnostic_comment(input: &IneligibleCommentInput<'_>) 
         bounded(input.run_id, 200),
         bounded(input.intent_id, 200)
     )
+}
+
+pub fn render_automatic_comment(input: &AutomaticCommentInput<'_>) -> String {
+    let artifact = input.artifact;
+    let mut body = String::new();
+    body.push_str(&marker(input.intent_id));
+    body.push_str("\n\n## Symphony triage publication\n\n");
+    match input.phase {
+        AutomaticCommentPhase::Pending => {
+            body.push_str("Publication: `pending`\n\n");
+        }
+        AutomaticCommentPhase::RouteEffectsApplied => {
+            body.push_str("Route effects: `applied`; publication: `pending`\n\n");
+            body.push_str(&format!(
+                "- Applied route label: `{}`\n",
+                bounded(input.route_label, COMMENT_FIELD_MAX_BYTES)
+            ));
+            if let Some(state) = input.project_state {
+                body.push_str(&format!(
+                    "- Applied project state: `{}`\n",
+                    bounded(state, COMMENT_FIELD_MAX_BYTES)
+                ));
+            }
+            body.push('\n');
+        }
+        AutomaticCommentPhase::Applied => {
+            body.push_str("Publication: `applied`\n\n");
+            body.push_str(&format!(
+                "- Applied route label: `{}`\n",
+                bounded(input.route_label, COMMENT_FIELD_MAX_BYTES)
+            ));
+            if let Some(state) = input.project_state {
+                body.push_str(&format!(
+                    "- Applied project state: `{}`\n",
+                    bounded(state, COMMENT_FIELD_MAX_BYTES)
+                ));
+            }
+            body.push('\n');
+        }
+    }
+
+    body.push_str(&format!("- Route: `{}`\n", artifact.route));
+    body.push_str(&format!("- Risk: `{}`\n", artifact.risk_class));
+    body.push_str(&format!(
+        "- Rationale: {}\n",
+        bounded(&artifact.rationale, COMMENT_FIELD_MAX_BYTES)
+    ));
+    body.push_str(&format!(
+        "- Next action: {}\n",
+        bounded(&artifact.next_action, COMMENT_FIELD_MAX_BYTES)
+    ));
+    if let Some(question) = artifact.clarification_question.as_deref() {
+        body.push_str(&format!(
+            "- Clarification question: {}\n",
+            bounded(question, COMMENT_FIELD_MAX_BYTES)
+        ));
+    }
+
+    body.push_str("\n### Evidence\n");
+    for evidence in artifact.evidence.iter().take(COMMENT_EVIDENCE_MAX_ITEMS) {
+        body.push_str(&format!(
+            "- `{}` `{}`: {}\n",
+            evidence.kind,
+            bounded(&evidence.reference, COMMENT_FIELD_MAX_BYTES),
+            bounded(&evidence.summary, COMMENT_FIELD_MAX_BYTES)
+        ));
+    }
+
+    body.push_str("\n### Run\n");
+    body.push_str(&format!(
+        "- Factory run: `{}`\n",
+        bounded(input.run_id, 200)
+    ));
+    body.push_str(&format!(
+        "- Stage attempt: `{}` attempt `{}`\n",
+        bounded(input.stage_run_id, 200),
+        input.attempt
+    ));
+    body.push_str(&format!(
+        "- Publication intent: `{}`\n",
+        bounded(input.intent_id, 200)
+    ));
+    body
 }
 
 pub fn marker(intent_id: &str) -> String {

--- a/apps/symphony/src/triage/coordinator.rs
+++ b/apps/symphony/src/triage/coordinator.rs
@@ -309,8 +309,7 @@ where
             let issue_number = parse_issue_number(&run.issue_id)?;
             let kind = desired_kind(&intent.desired_effects);
 
-            if intent.mode == PublicationMode::Automatic || kind == Some(DESIRED_KIND_AUTOMATIC)
-            {
+            if intent.mode == PublicationMode::Automatic || kind == Some(DESIRED_KIND_AUTOMATIC) {
                 let Some(artifact_id) = intent.artifact_id.as_deref() else {
                     return Err(SymphonyError::TriageError(format!(
                         "automatic intent {} is missing artifact_id",

--- a/apps/symphony/src/triage/coordinator.rs
+++ b/apps/symphony/src/triage/coordinator.rs
@@ -11,7 +11,7 @@ use crate::path_safety;
 use crate::repo_url::repo_is_remote;
 use crate::triage::domain::{
     FactoryError, FactoryEventRecord, FactoryRunStatus, PublicationMode, PublicationStatus,
-    TRIAGE_LEASE_RENEW_INTERVAL_MS, TRIAGE_STAGE_NAME,
+    TriageMode, TRIAGE_LEASE_RENEW_INTERVAL_MS, TRIAGE_STAGE_NAME,
 };
 use crate::triage::fingerprint::{
     configuration_revision, issue_revision, route_mapping_hash, ConfigurationRevisionInput,
@@ -19,7 +19,8 @@ use crate::triage::fingerprint::{
 };
 use crate::triage::intake::{TriageIntakeIssue, TriageIntakePort};
 use crate::triage::publisher::{
-    IneligiblePublishRequest, PreviewPublishRequest, PreviewPublisher, TriageCommentPort,
+    AutomaticPublishRequest, AutomaticPublisher, IneligiblePublishRequest, PreviewPublishRequest,
+    PreviewPublisher, TriageCommentPort, TriageRoutingPort,
 };
 use crate::triage::runner::{
     effective_pi_model, TriageHarness, TriageIssueIdentity, TriageProgress, TriageProgressSink,
@@ -36,6 +37,7 @@ const INELIGIBLE_REMEDIATION: &str =
     "Add the issue to the configured GitHub Project, then leave the intake label in place.";
 const DESIRED_KIND_PREVIEW: &str = "preview_comment";
 const DESIRED_KIND_INELIGIBLE: &str = "ineligible_diagnostic";
+const DESIRED_KIND_AUTOMATIC: &str = "automatic_route";
 
 /// Live triage event sink (optional). Durable events are always written to the store.
 pub trait EventEmitter: Send + Sync {
@@ -82,7 +84,9 @@ pub struct TriagePollSummary {
 pub struct TriageCoordinator<S, I, C, X = DefaultTriageExecutor> {
     store: S,
     intake: I,
+    comments: C,
     publisher: PreviewPublisher<C>,
+    routing: Option<Arc<dyn TriageRoutingPort>>,
     executor: X,
     config: TriageCoordinatorConfig,
     events: Option<Arc<dyn EventEmitter>>,
@@ -94,7 +98,7 @@ impl<S, I, C> TriageCoordinator<S, I, C, DefaultTriageExecutor>
 where
     S: FactoryRunStore,
     I: TriageIntakePort,
-    C: TriageCommentPort,
+    C: TriageCommentPort + Clone,
 {
     pub fn new(store: S, intake: I, comments: C, config: TriageCoordinatorConfig) -> Self {
         Self::with_executor(store, intake, comments, config, DefaultTriageExecutor)
@@ -105,7 +109,7 @@ impl<S, I, C, X> TriageCoordinator<S, I, C, X>
 where
     S: FactoryRunStore,
     I: TriageIntakePort,
-    C: TriageCommentPort,
+    C: TriageCommentPort + Clone,
     X: TriageExecutor,
 {
     pub fn with_executor(
@@ -118,13 +122,20 @@ where
         Self {
             store,
             intake,
+            comments: comments.clone(),
             publisher: PreviewPublisher::new(comments),
+            routing: None,
             executor,
             config,
             events: None,
             sessions: None,
             max_pages: 100,
         }
+    }
+
+    pub fn with_routing(mut self, routing: impl TriageRoutingPort + 'static) -> Self {
+        self.routing = Some(Arc::new(routing));
+        self
     }
 
     pub fn with_events(mut self, events: Arc<dyn EventEmitter>) -> Self {
@@ -187,8 +198,9 @@ where
         &mut self.store
     }
 
-    pub async fn reconcile_pending(&mut self) -> Result<()> {
-        self.reconcile_pending_intents(self.max_pages).await?;
+    pub async fn reconcile_pending(&mut self, service: &ServiceConfig) -> Result<()> {
+        self.reconcile_pending_intents(service, self.max_pages)
+            .await?;
         Ok(())
     }
 
@@ -208,7 +220,9 @@ where
         };
 
         self.store.interrupt_stale_attempts()?;
-        summary.reconciled_intents = self.reconcile_pending_intents(self.max_pages).await?;
+        summary.reconciled_intents = self
+            .reconcile_pending_intents(service, self.max_pages)
+            .await?;
 
         if !service.triage.enabled {
             return Ok(summary);
@@ -281,7 +295,11 @@ where
         Ok(summary)
     }
 
-    async fn reconcile_pending_intents(&mut self, max_pages: u32) -> Result<u32> {
+    async fn reconcile_pending_intents(
+        &mut self,
+        service: &ServiceConfig,
+        max_pages: u32,
+    ) -> Result<u32> {
         let pending = self.store.list_pending_intents(PENDING_INTENT_BATCH)?;
         let mut reconciled = 0u32;
         for intent in pending {
@@ -290,6 +308,43 @@ where
             };
             let issue_number = parse_issue_number(&run.issue_id)?;
             let kind = desired_kind(&intent.desired_effects);
+
+            if intent.mode == PublicationMode::Automatic || kind == Some(DESIRED_KIND_AUTOMATIC)
+            {
+                let Some(artifact_id) = intent.artifact_id.as_deref() else {
+                    return Err(SymphonyError::TriageError(format!(
+                        "automatic intent {} is missing artifact_id",
+                        intent.intent_id
+                    )));
+                };
+                let Some(artifact) = self.store.get_artifact_by_id(artifact_id)? else {
+                    return Err(SymphonyError::TriageError(format!(
+                        "artifact {artifact_id} missing for intent {}",
+                        intent.intent_id
+                    )));
+                };
+                let stage = self
+                    .store
+                    .get_stage_run(&artifact.stage_run_id)?
+                    .ok_or_else(|| {
+                        SymphonyError::TriageError(format!(
+                            "stage run {} missing for artifact {artifact_id}",
+                            artifact.stage_run_id
+                        ))
+                    })?;
+                self.publish_automatic_intent(
+                    service,
+                    &intent,
+                    issue_number,
+                    &run.run_id,
+                    &stage.stage_run_id,
+                    stage.attempt,
+                    &artifact.artifact,
+                )
+                .await?;
+                reconciled += 1;
+                continue;
+            }
 
             if intent.artifact_id.is_some() || kind == Some(DESIRED_KIND_PREVIEW) {
                 let Some(artifact_id) = intent.artifact_id.as_deref() else {
@@ -471,8 +526,9 @@ where
             )? {
                 // Artifact may exist without a publication intent if the process
                 // crashed (or intent creation failed) after store_artifact.
-                // Ensure a preview intent exists and publish if still pending.
-                self.recover_orphaned_preview_artifact(issue, service, mapping_hash, &artifact)
+                // In automatic mode, promote a matching preview artifact or
+                // resume a pending automatic intent without re-running the agent.
+                self.recover_or_promote_artifact(issue, service, mapping_hash, &artifact)
                     .await?;
                 return Ok(IssuePollOutcome::Skipped);
             }
@@ -682,8 +738,18 @@ where
             usage: success.usage,
         })?;
 
-        let intent =
-            self.ensure_preview_intent_for_artifact(issue, service, mapping_hash, &artifact)?;
+        let stage = self.store.get_stage_run(stage_run_id)?.ok_or_else(|| {
+            SymphonyError::TriageError(format!("stage run {stage_run_id} missing after store"))
+        })?;
+
+        let intent = match service.triage.mode {
+            TriageMode::Preview => {
+                self.ensure_preview_intent_for_artifact(issue, service, mapping_hash, &artifact)?
+            }
+            TriageMode::Automatic => {
+                self.ensure_automatic_intent_for_artifact(issue, service, mapping_hash, &artifact)?
+            }
+        };
 
         self.emit_event(
             "triage_completed",
@@ -716,26 +782,43 @@ where
             }),
         )?;
 
-        let stage = self.store.get_stage_run(stage_run_id)?.ok_or_else(|| {
-            SymphonyError::TriageError(format!("stage run {stage_run_id} missing after store"))
-        })?;
-        self.publisher
-            .reconcile_preview(
-                &mut self.store,
-                PreviewPublishRequest {
-                    intent: &intent,
-                    issue_number: issue.issue_number,
-                    run_id: &artifact.run_id,
-                    stage_run_id,
-                    attempt: stage.attempt,
-                    artifact: &success.artifact,
-                    max_pages: self.max_pages,
-                },
-            )
-            .await?;
-
-        self.store
-            .mark_run_status(&artifact.run_id, FactoryRunStatus::Completed)?;
+        match service.triage.mode {
+            TriageMode::Preview => {
+                self.publisher
+                    .reconcile_preview(
+                        &mut self.store,
+                        PreviewPublishRequest {
+                            intent: &intent,
+                            issue_number: issue.issue_number,
+                            run_id: &artifact.run_id,
+                            stage_run_id,
+                            attempt: stage.attempt,
+                            artifact: &success.artifact,
+                            max_pages: self.max_pages,
+                        },
+                    )
+                    .await?;
+                self.store
+                    .mark_run_status(&artifact.run_id, FactoryRunStatus::Completed)?;
+            }
+            TriageMode::Automatic => {
+                let status = self
+                    .publish_automatic_intent(
+                        service,
+                        &intent,
+                        issue.issue_number,
+                        &artifact.run_id,
+                        stage_run_id,
+                        stage.attempt,
+                        &success.artifact,
+                    )
+                    .await?;
+                if status == PublicationStatus::Applied {
+                    self.store
+                        .mark_run_status(&artifact.run_id, FactoryRunStatus::Completed)?;
+                }
+            }
+        }
         Ok(())
     }
 
@@ -746,7 +829,7 @@ where
     /// crash between `store_artifact` and intent creation.
     fn ensure_preview_intent_for_artifact(
         &mut self,
-        issue: &TriageIntakeIssue,
+        _issue: &TriageIntakeIssue,
         service: &ServiceConfig,
         mapping_hash: &str,
         artifact: &crate::triage::domain::ArtifactRecord,
@@ -773,13 +856,249 @@ where
                     "kind": DESIRED_KIND_PREVIEW,
                     "route": artifact.artifact.route.as_str(),
                 }),
-                observed_baseline: serde_json::json!({
-                    "labels": issue.labels,
-                }),
-                expected_projection: serde_json::json!({
-                    "labels": issue.labels,
-                }),
+                observed_baseline: serde_json::json!({}),
+                expected_projection: serde_json::json!({}),
             })
+    }
+
+    fn ensure_automatic_intent_for_artifact(
+        &mut self,
+        _issue: &TriageIntakeIssue,
+        service: &ServiceConfig,
+        mapping_hash: &str,
+        artifact: &crate::triage::domain::ArtifactRecord,
+    ) -> Result<crate::triage::domain::PublicationIntentRecord> {
+        let existing = self.store.list_intents_for_run(&artifact.run_id)?;
+        if let Some(intent) = existing.into_iter().find(|record| {
+            record.artifact_id.as_deref() == Some(artifact.artifact_id.as_str())
+                && record.mode == PublicationMode::Automatic
+        }) {
+            return Ok(intent);
+        }
+
+        let route_mapping = service.triage.routes.mapping_for(artifact.artifact.route);
+        self.store
+            .create_publication_intent(CreatePublicationIntentRequest {
+                run_id: artifact.run_id.clone(),
+                artifact_id: Some(artifact.artifact_id.clone()),
+                mode: PublicationMode::Automatic,
+                intake_label: service.triage.intake_label.clone(),
+                route_label: route_mapping.label.clone(),
+                project_state: route_mapping.state.clone(),
+                route_mapping_hash: mapping_hash.to_string(),
+                desired_effects: serde_json::json!({
+                    "kind": DESIRED_KIND_AUTOMATIC,
+                    "route": artifact.artifact.route.as_str(),
+                    "route_labels": {
+                        "implement": service.triage.routes.implement.label.clone(),
+                        "spec": service.triage.routes.spec.label.clone(),
+                        "needs_information": service.triage.routes.needs_information.label.clone(),
+                        "park": service.triage.routes.park.label.clone(),
+                        "human_owned": service.triage.routes.human_owned.label.clone(),
+                    },
+                }),
+                observed_baseline: serde_json::json!({}),
+                expected_projection: serde_json::json!({}),
+            })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn publish_automatic_intent(
+        &mut self,
+        service: &ServiceConfig,
+        intent: &crate::triage::domain::PublicationIntentRecord,
+        issue_number: u64,
+        run_id: &str,
+        stage_run_id: &str,
+        attempt: u32,
+        artifact: &crate::triage::domain::TriageArtifact,
+    ) -> Result<PublicationStatus> {
+        let routing = self.routing.clone().ok_or_else(|| {
+            SymphonyError::TriageError(
+                "automatic triage publication requires a routing port".to_string(),
+            )
+        })?;
+        let publisher = AutomaticPublisher::new(self.comments.clone(), routing);
+        let status = publisher
+            .reconcile_automatic(
+                &mut self.store,
+                AutomaticPublishRequest {
+                    intent,
+                    issue_number,
+                    run_id,
+                    stage_run_id,
+                    attempt,
+                    artifact,
+                    managed_labels: &service.triage.routes.managed_labels(),
+                    max_pages: self.max_pages,
+                },
+            )
+            .await?;
+
+        match status {
+            PublicationStatus::Applied => {
+                self.emit_event(
+                    "triage_route_applied",
+                    Some(&format!("#{issue_number}")),
+                    Some(run_id),
+                    Some(stage_run_id),
+                    serde_json::json!({
+                        "run_id": run_id,
+                        "stage_run_id": stage_run_id,
+                        "publication_intent_id": intent.intent_id,
+                        "route": artifact.route.as_str(),
+                        "route_label": intent.route_label,
+                        "project_state": intent.project_state,
+                        "status": "applied",
+                        "error_code": serde_json::Value::Null,
+                    }),
+                )?;
+            }
+            PublicationStatus::Conflict => {
+                self.emit_event(
+                    "triage_publication_conflict",
+                    Some(&format!("#{issue_number}")),
+                    Some(run_id),
+                    Some(stage_run_id),
+                    serde_json::json!({
+                        "run_id": run_id,
+                        "stage_run_id": stage_run_id,
+                        "publication_intent_id": intent.intent_id,
+                        "status": "conflict",
+                        "error_code": "human_conflict",
+                    }),
+                )?;
+            }
+            PublicationStatus::Blocked => {
+                self.emit_event(
+                    "triage_publication_blocked",
+                    Some(&format!("#{issue_number}")),
+                    Some(run_id),
+                    Some(stage_run_id),
+                    serde_json::json!({
+                        "run_id": run_id,
+                        "stage_run_id": stage_run_id,
+                        "publication_intent_id": intent.intent_id,
+                        "status": "blocked",
+                        "error_code": "publication_blocked",
+                    }),
+                )?;
+            }
+            PublicationStatus::Pending | PublicationStatus::None => {}
+        }
+        Ok(status)
+    }
+
+    /// Recover preview publication, or promote/resume automatic publication.
+    async fn recover_or_promote_artifact(
+        &mut self,
+        issue: &TriageIntakeIssue,
+        service: &ServiceConfig,
+        mapping_hash: &str,
+        artifact: &crate::triage::domain::ArtifactRecord,
+    ) -> Result<()> {
+        match service.triage.mode {
+            TriageMode::Preview => {
+                self.recover_orphaned_preview_artifact(issue, service, mapping_hash, artifact)
+                    .await
+            }
+            TriageMode::Automatic => {
+                self.promote_or_resume_automatic(issue, service, mapping_hash, artifact)
+                    .await
+            }
+        }
+    }
+
+    async fn promote_or_resume_automatic(
+        &mut self,
+        issue: &TriageIntakeIssue,
+        service: &ServiceConfig,
+        mapping_hash: &str,
+        artifact: &crate::triage::domain::ArtifactRecord,
+    ) -> Result<()> {
+        // Resume an existing automatic intent for this artifact when present.
+        let existing = self.store.list_intents_for_run(&artifact.run_id)?;
+        if let Some(intent) = existing.iter().find(|record| {
+            record.artifact_id.as_deref() == Some(artifact.artifact_id.as_str())
+                && record.mode == PublicationMode::Automatic
+        }) {
+            if intent.status == PublicationStatus::Applied {
+                return Ok(());
+            }
+            let stage = self
+                .store
+                .get_stage_run(&artifact.stage_run_id)?
+                .ok_or_else(|| {
+                    SymphonyError::TriageError(format!(
+                        "stage run {} missing for automatic artifact {}",
+                        artifact.stage_run_id, artifact.artifact_id
+                    ))
+                })?;
+            let status = self
+                .publish_automatic_intent(
+                    service,
+                    intent,
+                    issue.issue_number,
+                    &artifact.run_id,
+                    &artifact.stage_run_id,
+                    stage.attempt,
+                    &artifact.artifact,
+                )
+                .await?;
+            if status == PublicationStatus::Applied {
+                self.store
+                    .mark_run_status(&artifact.run_id, FactoryRunStatus::Completed)?;
+            }
+            return Ok(());
+        }
+
+        // Promote an immutable preview artifact only when revision + mapping still match.
+        if artifact.route_mapping_hash != mapping_hash {
+            return Ok(());
+        }
+        let intent =
+            self.ensure_automatic_intent_for_artifact(issue, service, mapping_hash, artifact)?;
+        let stage = self
+            .store
+            .get_stage_run(&artifact.stage_run_id)?
+            .ok_or_else(|| {
+                SymphonyError::TriageError(format!(
+                    "stage run {} missing for promoted artifact {}",
+                    artifact.stage_run_id, artifact.artifact_id
+                ))
+            })?;
+        self.emit_event(
+            "triage_publication_started",
+            Some(&issue.identifier),
+            Some(&artifact.run_id),
+            Some(&artifact.stage_run_id),
+            serde_json::json!({
+                "run_id": artifact.run_id,
+                "stage_run_id": artifact.stage_run_id,
+                "artifact_id": artifact.artifact_id,
+                "publication_intent_id": intent.intent_id,
+                "route": artifact.artifact.route.as_str(),
+                "status": "pending",
+                "error_code": serde_json::Value::Null,
+                "promoted_from_preview": true,
+            }),
+        )?;
+        let status = self
+            .publish_automatic_intent(
+                service,
+                &intent,
+                issue.issue_number,
+                &artifact.run_id,
+                &artifact.stage_run_id,
+                stage.attempt,
+                &artifact.artifact,
+            )
+            .await?;
+        if status == PublicationStatus::Applied {
+            self.store
+                .mark_run_status(&artifact.run_id, FactoryRunStatus::Completed)?;
+        }
+        Ok(())
     }
 
     /// Recover when a durable artifact exists without a published preview.

--- a/apps/symphony/src/triage/coordinator.rs
+++ b/apps/symphony/src/triage/coordinator.rs
@@ -918,6 +918,14 @@ where
             )
         })?;
         let publisher = AutomaticPublisher::new(self.comments.clone(), routing);
+        // Prefer the five route labels persisted on the intent so a live mapping
+        // reload cannot reinterpret an in-flight automatic publication.
+        let managed_from_intent = managed_labels_from_automatic_intent(intent);
+        let live_managed = service.triage.routes.managed_labels();
+        let managed_labels = managed_from_intent
+            .as_deref()
+            .unwrap_or(live_managed.as_slice());
+        let prior_status = intent.status;
         let status = publisher
             .reconcile_automatic(
                 &mut self.store,
@@ -928,7 +936,7 @@ where
                     stage_run_id,
                     attempt,
                     artifact,
-                    managed_labels: &service.triage.routes.managed_labels(),
+                    managed_labels,
                     max_pages: self.max_pages,
                 },
             )
@@ -953,7 +961,7 @@ where
                     }),
                 )?;
             }
-            PublicationStatus::Conflict => {
+            PublicationStatus::Conflict if prior_status != PublicationStatus::Conflict => {
                 self.emit_event(
                     "triage_publication_conflict",
                     Some(&format!("#{issue_number}")),
@@ -968,7 +976,7 @@ where
                     }),
                 )?;
             }
-            PublicationStatus::Blocked => {
+            PublicationStatus::Blocked if prior_status != PublicationStatus::Blocked => {
                 self.emit_event(
                     "triage_publication_blocked",
                     Some(&format!("#{issue_number}")),
@@ -983,9 +991,49 @@ where
                     }),
                 )?;
             }
-            PublicationStatus::Pending | PublicationStatus::None => {}
+            PublicationStatus::Pending
+            | PublicationStatus::None
+            | PublicationStatus::Conflict
+            | PublicationStatus::Blocked => {}
         }
         Ok(status)
+    }
+
+    /// Finish run completion + durable applied event when an intent is already
+    /// applied but a prior crash skipped finalization.
+    fn finalize_applied_automatic_publication(
+        &mut self,
+        issue_number: u64,
+        run_id: &str,
+        stage_run_id: &str,
+        intent: &crate::triage::domain::PublicationIntentRecord,
+        artifact: &crate::triage::domain::TriageArtifact,
+    ) -> Result<()> {
+        let Some(run) = self.store.get_run_by_id(run_id)? else {
+            return Ok(());
+        };
+        if run.status == FactoryRunStatus::Completed {
+            return Ok(());
+        }
+        self.emit_event(
+            "triage_route_applied",
+            Some(&format!("#{issue_number}")),
+            Some(run_id),
+            Some(stage_run_id),
+            serde_json::json!({
+                "run_id": run_id,
+                "stage_run_id": stage_run_id,
+                "publication_intent_id": intent.intent_id,
+                "route": artifact.route.as_str(),
+                "route_label": intent.route_label,
+                "project_state": intent.project_state,
+                "status": "applied",
+                "error_code": serde_json::Value::Null,
+            }),
+        )?;
+        self.store
+            .mark_run_status(run_id, FactoryRunStatus::Completed)?;
+        Ok(())
     }
 
     /// Recover preview publication, or promote/resume automatic publication.
@@ -1022,6 +1070,13 @@ where
                 && record.mode == PublicationMode::Automatic
         }) {
             if intent.status == PublicationStatus::Applied {
+                self.finalize_applied_automatic_publication(
+                    issue.issue_number,
+                    &artifact.run_id,
+                    &artifact.stage_run_id,
+                    intent,
+                    &artifact.artifact,
+                )?;
                 return Ok(());
             }
             let stage = self
@@ -1291,6 +1346,29 @@ fn triage_model(service: &ServiceConfig) -> Option<String> {
 
 fn desired_kind(value: &serde_json::Value) -> Option<&str> {
     value.get("kind").and_then(|kind| kind.as_str())
+}
+
+/// Reconstruct the managed route-label vocabulary from a persisted automatic intent.
+fn managed_labels_from_automatic_intent(
+    intent: &crate::triage::domain::PublicationIntentRecord,
+) -> Option<Vec<String>> {
+    let labels = intent.desired_effects.get("route_labels")?.as_object()?;
+    let keys = [
+        "implement",
+        "spec",
+        "needs_information",
+        "park",
+        "human_owned",
+    ];
+    let mut out = Vec::with_capacity(keys.len());
+    for key in keys {
+        let label = labels.get(key)?.as_str()?.trim();
+        if label.is_empty() {
+            return None;
+        }
+        out.push(label.to_string());
+    }
+    Some(out)
 }
 
 fn parse_issue_number(issue_id: &str) -> Result<u64> {

--- a/apps/symphony/src/triage/domain.rs
+++ b/apps/symphony/src/triage/domain.rs
@@ -493,6 +493,90 @@ pub struct PublicationIntentRecord {
     pub updated_at: DateTime<Utc>,
 }
 
+/// Managed GitHub state the publisher is allowed to compare and mutate: the
+/// configured route labels plus intake label, and the Projects v2 state.
+///
+/// Values are normalized for comparison, so a projection is only meaningful as
+/// a conflict-detection artifact and never as display text.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ManagedProjection {
+    #[serde(default)]
+    pub managed_labels: std::collections::BTreeSet<String>,
+    #[serde(default)]
+    pub project_state: Option<String>,
+}
+
+impl ManagedProjection {
+    /// Project `labels` down to the managed vocabulary, discarding every label
+    /// Symphony does not own.
+    pub fn observe<'a>(
+        labels: impl IntoIterator<Item = &'a str>,
+        managed_labels: &std::collections::BTreeSet<String>,
+        project_state: Option<&str>,
+    ) -> Self {
+        let managed_labels = labels
+            .into_iter()
+            .map(normalize_managed_value)
+            .filter(|label| managed_labels.contains(label))
+            .collect();
+        Self {
+            managed_labels,
+            project_state: project_state.map(normalize_managed_value).filter(|state| !state.is_empty()),
+        }
+    }
+
+    /// Parse a persisted projection. Returns `None` when no projection was
+    /// recorded yet, which is distinct from an empty projection.
+    pub fn from_json(value: &serde_json::Value) -> Option<Self> {
+        value.get("managed_labels")?;
+        serde_json::from_value(value.clone()).ok()
+    }
+
+    pub fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "managed_labels": self.managed_labels,
+            "project_state": self.project_state,
+        })
+    }
+
+    pub fn with_label(&self, label: &str) -> Self {
+        let mut next = self.clone();
+        next.managed_labels.insert(normalize_managed_value(label));
+        next
+    }
+
+    pub fn without_label(&self, label: &str) -> Self {
+        let mut next = self.clone();
+        next.managed_labels.remove(&normalize_managed_value(label));
+        next
+    }
+
+    pub fn with_project_state(&self, state: &str) -> Self {
+        let mut next = self.clone();
+        next.project_state = Some(normalize_managed_value(state));
+        next
+    }
+
+    pub fn contains_label(&self, label: &str) -> bool {
+        self.managed_labels.contains(&normalize_managed_value(label))
+    }
+}
+
+/// Managed label vocabulary: configured route labels plus the recorded intake label.
+pub fn managed_label_set<'a>(
+    labels: impl IntoIterator<Item = &'a str>,
+) -> std::collections::BTreeSet<String> {
+    labels
+        .into_iter()
+        .map(normalize_managed_value)
+        .filter(|label| !label.is_empty())
+        .collect()
+}
+
+fn normalize_managed_value(value: &str) -> String {
+    value.trim().to_ascii_lowercase()
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct FactoryEventRecord {
     pub event_id: String,

--- a/apps/symphony/src/triage/domain.rs
+++ b/apps/symphony/src/triage/domain.rs
@@ -555,7 +555,9 @@ impl ManagedProjection {
 
     pub fn with_project_state(&self, state: &str) -> Self {
         let mut next = self.clone();
-        next.project_state = Some(normalize_managed_value(state));
+        let normalized = normalize_managed_value(state);
+        // Match observe(): blank/whitespace states are absent, not Some("").
+        next.project_state = (!normalized.is_empty()).then_some(normalized);
         next
     }
 
@@ -717,5 +719,16 @@ mod tests {
     fn truncation_preserves_utf8_boundaries() {
         assert_eq!(truncate_utf8_bytes("abcdef", 3), "abc");
         assert_eq!(truncate_utf8_bytes("ééé", 5), "éé");
+    }
+
+    #[test]
+    fn with_project_state_drops_blank_like_observe() {
+        let base = ManagedProjection::default();
+        assert_eq!(
+            base.with_project_state("Todo").project_state.as_deref(),
+            Some("todo")
+        );
+        assert_eq!(base.with_project_state("").project_state, None);
+        assert_eq!(base.with_project_state("   ").project_state, None);
     }
 }

--- a/apps/symphony/src/triage/domain.rs
+++ b/apps/symphony/src/triage/domain.rs
@@ -521,7 +521,9 @@ impl ManagedProjection {
             .collect();
         Self {
             managed_labels,
-            project_state: project_state.map(normalize_managed_value).filter(|state| !state.is_empty()),
+            project_state: project_state
+                .map(normalize_managed_value)
+                .filter(|state| !state.is_empty()),
         }
     }
 
@@ -558,7 +560,8 @@ impl ManagedProjection {
     }
 
     pub fn contains_label(&self, label: &str) -> bool {
-        self.managed_labels.contains(&normalize_managed_value(label))
+        self.managed_labels
+            .contains(&normalize_managed_value(label))
     }
 }
 

--- a/apps/symphony/src/triage/mod.rs
+++ b/apps/symphony/src/triage/mod.rs
@@ -6,6 +6,7 @@ pub mod fingerprint;
 pub mod intake;
 pub mod integrity;
 pub mod publisher;
+pub mod routing;
 pub mod runner;
 pub mod runtime;
 pub mod storage_path;

--- a/apps/symphony/src/triage/publisher.rs
+++ b/apps/symphony/src/triage/publisher.rs
@@ -3,15 +3,34 @@ use async_trait::async_trait;
 use crate::error::{Result, SymphonyError};
 use crate::github::client::{GithubClient, GithubIssueComment};
 use crate::triage::comment::{
-    self, extract_intent_id_from_marker, IneligibleCommentInput, PreviewCommentInput,
+    self, extract_intent_id_from_marker, AutomaticCommentInput, AutomaticCommentPhase,
+    IneligibleCommentInput, PreviewCommentInput,
 };
 use crate::triage::domain::{
-    PublicationIntentRecord, PublicationMode, PublicationStatus, TriageArtifact,
+    managed_label_set, FactoryError, ManagedProjection, PublicationIntentRecord, PublicationMode,
+    PublicationStatus, TriageArtifact,
 };
 use crate::triage::store::FactoryRunStore;
 
 pub const PREVIEW_COMMENT_STEP: &str = "preview_comment";
 pub const DIAGNOSTIC_COMMENT_STEP: &str = "ineligible_diagnostic";
+pub const COMMENT_PENDING_STEP: &str = "comment_pending";
+pub const ROUTE_LABEL_STEP: &str = "route_label";
+pub const PROJECT_STATE_STEP: &str = "project_state";
+pub const CONFLICT_CLEANUP_STEP: &str = "conflict_cleanup";
+pub const COMMENT_ROUTE_EFFECTS_STEP: &str = "comment_route_effects";
+pub const INTAKE_REMOVED_STEP: &str = "intake_removed";
+pub const COMMENT_APPLIED_STEP: &str = "comment_applied";
+
+const AUTOMATIC_STEPS: &[&str] = &[
+    COMMENT_PENDING_STEP,
+    ROUTE_LABEL_STEP,
+    PROJECT_STATE_STEP,
+    CONFLICT_CLEANUP_STEP,
+    COMMENT_ROUTE_EFFECTS_STEP,
+    INTAKE_REMOVED_STEP,
+    COMMENT_APPLIED_STEP,
+];
 
 #[derive(Debug, Clone)]
 pub struct PreviewPublishRequest<'a> {
@@ -207,10 +226,9 @@ where
                 ))
             }
             PublicationMode::Automatic => {
-                // Automatic route label/state application is PR2.
                 let _ = (issue_number, max_pages);
                 Err(SymphonyError::TriageError(
-                    "automatic publication is not implemented in the preview slice".to_string(),
+                    "automatic publication requires AutomaticPublisher".to_string(),
                 ))
             }
         }
@@ -309,6 +327,523 @@ where
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct AutomaticPublishRequest<'a> {
+    pub intent: &'a PublicationIntentRecord,
+    pub issue_number: u64,
+    pub run_id: &'a str,
+    pub stage_run_id: &'a str,
+    pub attempt: u32,
+    pub artifact: &'a TriageArtifact,
+    pub managed_labels: &'a [String],
+    pub max_pages: u32,
+}
+
+#[async_trait]
+pub trait TriageRoutingPort: Send + Sync {
+    async fn list_issue_labels(&self, issue_number: u64) -> Result<Vec<String>>;
+    async fn issue_project_state(&self, issue_number: u64) -> Result<Option<String>>;
+    async fn add_issue_label(&self, issue_number: u64, label: &str) -> Result<()>;
+    async fn remove_issue_label(&self, issue_number: u64, label: &str) -> Result<()>;
+    async fn set_issue_project_state(&self, issue_number: u64, state: &str) -> Result<()>;
+}
+
+#[async_trait]
+impl TriageRoutingPort for std::sync::Arc<dyn TriageRoutingPort> {
+    async fn list_issue_labels(&self, issue_number: u64) -> Result<Vec<String>> {
+        (**self).list_issue_labels(issue_number).await
+    }
+
+    async fn issue_project_state(&self, issue_number: u64) -> Result<Option<String>> {
+        (**self).issue_project_state(issue_number).await
+    }
+
+    async fn add_issue_label(&self, issue_number: u64, label: &str) -> Result<()> {
+        (**self).add_issue_label(issue_number, label).await
+    }
+
+    async fn remove_issue_label(&self, issue_number: u64, label: &str) -> Result<()> {
+        (**self).remove_issue_label(issue_number, label).await
+    }
+
+    async fn set_issue_project_state(&self, issue_number: u64, state: &str) -> Result<()> {
+        (**self).set_issue_project_state(issue_number, state).await
+    }
+}
+
+/// Automatic-mode publisher: marked comments plus deterministic label/state effects.
+pub struct AutomaticPublisher<C, R> {
+    comments: C,
+    routing: R,
+}
+
+impl<C, R> AutomaticPublisher<C, R>
+where
+    C: TriageCommentPort,
+    R: TriageRoutingPort,
+{
+    pub fn new(comments: C, routing: R) -> Self {
+        Self { comments, routing }
+    }
+
+    pub async fn reconcile_automatic(
+        &self,
+        store: &mut dyn FactoryRunStore,
+        request: AutomaticPublishRequest<'_>,
+    ) -> Result<PublicationStatus> {
+        if request.intent.mode != PublicationMode::Automatic {
+            return Err(SymphonyError::TriageError(format!(
+                "automatic publisher cannot reconcile mode={}",
+                request.intent.mode.as_str()
+            )));
+        }
+
+        let mut intent = store
+            .get_publication_intent(&request.intent.intent_id)?
+            .ok_or_else(|| {
+                SymphonyError::TriageError(format!(
+                    "publication intent {} missing",
+                    request.intent.intent_id
+                ))
+            })?;
+
+        if matches!(
+            intent.status,
+            PublicationStatus::Applied | PublicationStatus::Conflict | PublicationStatus::Blocked
+        ) {
+            return Ok(intent.status);
+        }
+
+        let vocabulary = publication_vocabulary(request.managed_labels, &intent.intake_label);
+        self.ensure_baseline(store, &intent, request.issue_number, &vocabulary)
+            .await?;
+        intent = reload_intent(store, &intent.intent_id)?;
+
+        for step in AUTOMATIC_STEPS {
+            if intent.completed_steps.iter().any(|done| done == *step) {
+                continue;
+            }
+            match self
+                .reconcile_step(store, &mut intent, &request, &vocabulary, step)
+                .await?
+            {
+                PublicationStatus::Pending => {}
+                terminal => return Ok(terminal),
+            }
+            intent = reload_intent(store, &intent.intent_id)?;
+        }
+
+        Ok(PublicationStatus::Applied)
+    }
+
+    async fn ensure_baseline(
+        &self,
+        store: &mut dyn FactoryRunStore,
+        intent: &PublicationIntentRecord,
+        issue_number: u64,
+        vocabulary: &std::collections::BTreeSet<String>,
+    ) -> Result<()> {
+        if ManagedProjection::from_json(&intent.observed_baseline).is_some() {
+            return Ok(());
+        }
+        let current = self.observe_current(issue_number, vocabulary).await?;
+        let json = current.to_json();
+        store.set_publication_baseline(&intent.intent_id, &json, &json)
+    }
+
+    async fn reconcile_step(
+        &self,
+        store: &mut dyn FactoryRunStore,
+        intent: &mut PublicationIntentRecord,
+        request: &AutomaticPublishRequest<'_>,
+        vocabulary: &std::collections::BTreeSet<String>,
+        step: &str,
+    ) -> Result<PublicationStatus> {
+        let expected = ManagedProjection::from_json(&intent.expected_projection)
+            .unwrap_or_default();
+        match step {
+            COMMENT_PENDING_STEP => {
+                let body = automatic_body(request, intent, AutomaticCommentPhase::Pending);
+                self.upsert_marked_comment(store, intent, request.issue_number, &body, request.max_pages)
+                    .await?;
+                store.record_publication_step(
+                    &intent.intent_id,
+                    COMMENT_PENDING_STEP,
+                    PublicationStatus::Pending,
+                    &expected.to_json(),
+                )?;
+                Ok(PublicationStatus::Pending)
+            }
+            ROUTE_LABEL_STEP => {
+                let desired = expected.with_label(&intent.route_label);
+                match self
+                    .reconcile_mutation(
+                        store,
+                        intent,
+                        request.issue_number,
+                        vocabulary,
+                        &expected,
+                        &desired,
+                        ROUTE_LABEL_STEP,
+                        MutationKind::AddLabel(intent.route_label.clone()),
+                    )
+                    .await?
+                {
+                    StepOutcome::Conflict => Ok(PublicationStatus::Conflict),
+                    StepOutcome::Done => Ok(PublicationStatus::Pending),
+                }
+            }
+            PROJECT_STATE_STEP => {
+                let Some(state) = intent.project_state.clone() else {
+                    store.record_publication_step(
+                        &intent.intent_id,
+                        PROJECT_STATE_STEP,
+                        PublicationStatus::Pending,
+                        &expected.to_json(),
+                    )?;
+                    return Ok(PublicationStatus::Pending);
+                };
+                let desired = expected.with_project_state(&state);
+                match self
+                    .reconcile_mutation(
+                        store,
+                        intent,
+                        request.issue_number,
+                        vocabulary,
+                        &expected,
+                        &desired,
+                        PROJECT_STATE_STEP,
+                        MutationKind::SetState(state),
+                    )
+                    .await?
+                {
+                    StepOutcome::Conflict => Ok(PublicationStatus::Conflict),
+                    StepOutcome::Done => Ok(PublicationStatus::Pending),
+                }
+            }
+            CONFLICT_CLEANUP_STEP => {
+                let desired = conflict_cleanup_desired(&expected, request.managed_labels, &intent.route_label);
+                let to_remove = conflicting_route_labels(
+                    &expected,
+                    request.managed_labels,
+                    &intent.route_label,
+                );
+                match self
+                    .reconcile_mutation(
+                        store,
+                        intent,
+                        request.issue_number,
+                        vocabulary,
+                        &expected,
+                        &desired,
+                        CONFLICT_CLEANUP_STEP,
+                        MutationKind::RemoveLabels(to_remove),
+                    )
+                    .await?
+                {
+                    StepOutcome::Conflict => Ok(PublicationStatus::Conflict),
+                    StepOutcome::Done => Ok(PublicationStatus::Pending),
+                }
+            }
+            COMMENT_ROUTE_EFFECTS_STEP => {
+                let body =
+                    automatic_body(request, intent, AutomaticCommentPhase::RouteEffectsApplied);
+                self.upsert_marked_comment(store, intent, request.issue_number, &body, request.max_pages)
+                    .await?;
+                store.record_publication_step(
+                    &intent.intent_id,
+                    COMMENT_ROUTE_EFFECTS_STEP,
+                    PublicationStatus::Pending,
+                    &expected.to_json(),
+                )?;
+                Ok(PublicationStatus::Pending)
+            }
+            INTAKE_REMOVED_STEP => {
+                let desired = expected.without_label(&intent.intake_label);
+                match self
+                    .reconcile_mutation(
+                        store,
+                        intent,
+                        request.issue_number,
+                        vocabulary,
+                        &expected,
+                        &desired,
+                        INTAKE_REMOVED_STEP,
+                        MutationKind::RemoveLabels(vec![intent.intake_label.clone()]),
+                    )
+                    .await?
+                {
+                    StepOutcome::Conflict => Ok(PublicationStatus::Conflict),
+                    StepOutcome::Done => Ok(PublicationStatus::Pending),
+                }
+            }
+            COMMENT_APPLIED_STEP => {
+                let body = automatic_body(request, intent, AutomaticCommentPhase::Applied);
+                self.upsert_marked_comment(store, intent, request.issue_number, &body, request.max_pages)
+                    .await?;
+                store.record_publication_step(
+                    &intent.intent_id,
+                    COMMENT_APPLIED_STEP,
+                    PublicationStatus::Applied,
+                    &expected.to_json(),
+                )?;
+                Ok(PublicationStatus::Applied)
+            }
+            other => Err(SymphonyError::TriageError(format!(
+                "unknown automatic publication step {other}"
+            ))),
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn reconcile_mutation(
+        &self,
+        store: &mut dyn FactoryRunStore,
+        intent: &PublicationIntentRecord,
+        issue_number: u64,
+        vocabulary: &std::collections::BTreeSet<String>,
+        expected: &ManagedProjection,
+        desired: &ManagedProjection,
+        step: &str,
+        mutation: MutationKind,
+    ) -> Result<StepOutcome> {
+        let current = self.observe_current(issue_number, vocabulary).await?;
+        if current == *desired {
+            store.record_publication_step(
+                &intent.intent_id,
+                step,
+                PublicationStatus::Pending,
+                &desired.to_json(),
+            )?;
+            return Ok(StepOutcome::Done);
+        }
+        if current != *expected {
+            let error = FactoryError::new(
+                "human_conflict",
+                "publisher",
+                format!(
+                    "managed GitHub state differs from both expected and desired projections at step {step}"
+                ),
+                false,
+                Some(step.to_string()),
+            );
+            store.update_publication_step(
+                &intent.intent_id,
+                "",
+                PublicationStatus::Conflict,
+                Some(error),
+            )?;
+            return Ok(StepOutcome::Conflict);
+        }
+
+        match mutation {
+            MutationKind::AddLabel(label) => {
+                self.routing.add_issue_label(issue_number, &label).await?;
+            }
+            MutationKind::SetState(state) => {
+                self.routing
+                    .set_issue_project_state(issue_number, &state)
+                    .await?;
+            }
+            MutationKind::RemoveLabels(labels) => {
+                for label in labels {
+                    if current.contains_label(&label) {
+                        self.routing
+                            .remove_issue_label(issue_number, &label)
+                            .await?;
+                    }
+                }
+            }
+        }
+
+        store.record_publication_step(
+            &intent.intent_id,
+            step,
+            PublicationStatus::Pending,
+            &desired.to_json(),
+        )?;
+        Ok(StepOutcome::Done)
+    }
+
+    async fn observe_current(
+        &self,
+        issue_number: u64,
+        vocabulary: &std::collections::BTreeSet<String>,
+    ) -> Result<ManagedProjection> {
+        let labels = self.routing.list_issue_labels(issue_number).await?;
+        let state = self.routing.issue_project_state(issue_number).await?;
+        Ok(ManagedProjection::observe(
+            labels.iter().map(String::as_str),
+            vocabulary,
+            state.as_deref(),
+        ))
+    }
+
+    async fn upsert_marked_comment(
+        &self,
+        store: &mut dyn FactoryRunStore,
+        intent: &PublicationIntentRecord,
+        issue_number: u64,
+        body: &str,
+        max_pages: u32,
+    ) -> Result<()> {
+        let publisher_login = self.comments.authenticated_login().await?;
+        let comment_id = match intent.comment_id.as_deref() {
+            Some(id) => parse_comment_id(id)?,
+            None => {
+                match self
+                    .recover_owned_comment(
+                        issue_number,
+                        &intent.intent_id,
+                        &publisher_login,
+                        max_pages,
+                    )
+                    .await?
+                {
+                    Some(id) => id,
+                    None => {
+                        let created = self.comments.create_comment(issue_number, body).await?;
+                        store.set_publication_comment(
+                            &intent.intent_id,
+                            &created.id.to_string(),
+                            &publisher_login,
+                        )?;
+                        return Ok(());
+                    }
+                }
+            }
+        };
+
+        let existing = self.comments.get_comment(comment_id).await?;
+        let author = existing
+            .user
+            .as_ref()
+            .map(|user| user.login.as_str())
+            .unwrap_or("");
+        if !author.eq_ignore_ascii_case(&publisher_login) {
+            return Err(SymphonyError::TriageError(format!(
+                "publication comment {comment_id} is not owned by publisher {publisher_login}"
+            )));
+        }
+
+        self.comments.update_comment(comment_id, body).await?;
+        if intent.comment_id.is_none()
+            || intent.publisher_login.as_deref() != Some(&publisher_login)
+        {
+            store.set_publication_comment(
+                &intent.intent_id,
+                &comment_id.to_string(),
+                &publisher_login,
+            )?;
+        }
+        Ok(())
+    }
+
+    async fn recover_owned_comment(
+        &self,
+        issue_number: u64,
+        intent_id: &str,
+        publisher_login: &str,
+        max_pages: u32,
+    ) -> Result<Option<u64>> {
+        let comments = self.comments.list_comments(issue_number, max_pages).await?;
+        for comment in comments {
+            let Some(body) = comment.body.as_deref() else {
+                continue;
+            };
+            let Some(found_intent) = extract_intent_id_from_marker(body) else {
+                continue;
+            };
+            if found_intent != intent_id {
+                continue;
+            }
+            let author = comment
+                .user
+                .as_ref()
+                .map(|user| user.login.as_str())
+                .unwrap_or("");
+            if author.eq_ignore_ascii_case(publisher_login) {
+                return Ok(Some(comment.id));
+            }
+        }
+        Ok(None)
+    }
+}
+
+enum MutationKind {
+    AddLabel(String),
+    SetState(String),
+    RemoveLabels(Vec<String>),
+}
+
+enum StepOutcome {
+    Done,
+    Conflict,
+}
+
+fn publication_vocabulary(
+    route_labels: &[String],
+    intake_label: &str,
+) -> std::collections::BTreeSet<String> {
+    let mut vocabulary = managed_label_set(route_labels.iter().map(String::as_str));
+    let intake = intake_label.trim().to_ascii_lowercase();
+    if !intake.is_empty() {
+        vocabulary.insert(intake);
+    }
+    vocabulary
+}
+
+fn conflicting_route_labels(
+    expected: &ManagedProjection,
+    managed_labels: &[String],
+    desired_route_label: &str,
+) -> Vec<String> {
+    let desired = desired_route_label.trim().to_ascii_lowercase();
+    managed_labels
+        .iter()
+        .map(|label| label.trim().to_ascii_lowercase())
+        .filter(|label| !label.is_empty() && *label != desired && expected.contains_label(label))
+        .collect()
+}
+
+fn conflict_cleanup_desired(
+    expected: &ManagedProjection,
+    managed_labels: &[String],
+    desired_route_label: &str,
+) -> ManagedProjection {
+    let mut next = expected.clone();
+    for label in conflicting_route_labels(expected, managed_labels, desired_route_label) {
+        next = next.without_label(&label);
+    }
+    next
+}
+
+fn automatic_body(
+    request: &AutomaticPublishRequest<'_>,
+    intent: &PublicationIntentRecord,
+    phase: AutomaticCommentPhase,
+) -> String {
+    comment::render_automatic_comment(&AutomaticCommentInput {
+        intent_id: &intent.intent_id,
+        run_id: request.run_id,
+        stage_run_id: request.stage_run_id,
+        attempt: request.attempt,
+        artifact: request.artifact,
+        route_label: &intent.route_label,
+        project_state: intent.project_state.as_deref(),
+        phase,
+    })
+}
+
+fn reload_intent(
+    store: &mut dyn FactoryRunStore,
+    intent_id: &str,
+) -> Result<PublicationIntentRecord> {
+    store.get_publication_intent(intent_id)?.ok_or_else(|| {
+        SymphonyError::TriageError(format!("publication intent {intent_id} missing after step"))
+    })
+}
+
 fn parse_comment_id(raw: &str) -> Result<u64> {
     raw.parse::<u64>().map_err(|err| {
         SymphonyError::TriageError(format!("invalid publication comment_id '{raw}': {err}"))
@@ -320,7 +855,8 @@ mod tests {
     use super::*;
     use crate::github::client::GithubUser;
     use crate::triage::domain::{
-        EvidenceKind, RiskClass, TriageEvidence, TriageRoute, TRIAGE_SCHEMA_VERSION,
+        EvidenceKind, RiskClass, TriageEvidence, TriageRoute, TriageRoutesConfig,
+        TRIAGE_SCHEMA_VERSION,
     };
     use crate::triage::store::{
         ClaimAttemptRequest, CreatePublicationIntentRequest, SqliteFactoryStore,
@@ -336,6 +872,7 @@ mod tests {
         next_id: Mutex<u64>,
         create_count: Mutex<u32>,
         update_count: Mutex<u32>,
+        history: Mutex<Vec<String>>,
     }
 
     impl MockComments {
@@ -346,6 +883,7 @@ mod tests {
                 next_id: Mutex::new(100),
                 create_count: Mutex::new(0),
                 update_count: Mutex::new(0),
+                history: Mutex::new(Vec::new()),
             })
         }
     }
@@ -387,6 +925,7 @@ mod tests {
             let id = *next;
             *next += 1;
             *self.create_count.lock().unwrap() += 1;
+            self.history.lock().unwrap().push(body.to_string());
             let comment = GithubIssueComment {
                 id,
                 user: Some(GithubUser {
@@ -403,6 +942,7 @@ mod tests {
 
         async fn update_comment(&self, comment_id: u64, body: &str) -> Result<GithubIssueComment> {
             *self.update_count.lock().unwrap() += 1;
+            self.history.lock().unwrap().push(body.to_string());
             let mut comments = self.comments.lock().unwrap();
             let comment =
                 comments
@@ -416,10 +956,75 @@ mod tests {
         }
     }
 
+    #[derive(Default)]
+    struct MockRouting {
+        labels: Mutex<Vec<String>>,
+        project_state: Mutex<Option<String>>,
+        calls: Mutex<Vec<String>>,
+    }
+
+    impl MockRouting {
+        fn new(labels: &[&str], project_state: Option<&str>) -> Arc<Self> {
+            Arc::new(Self {
+                labels: Mutex::new(labels.iter().map(|label| label.to_string()).collect()),
+                project_state: Mutex::new(project_state.map(str::to_string)),
+                calls: Mutex::new(Vec::new()),
+            })
+        }
+
+        fn calls(&self) -> Vec<String> {
+            self.calls.lock().unwrap().clone()
+        }
+
+        fn labels_now(&self) -> Vec<String> {
+            self.labels.lock().unwrap().clone()
+        }
+
+        fn state_now(&self) -> Option<String> {
+            self.project_state.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl TriageRoutingPort for Arc<MockRouting> {
+        async fn list_issue_labels(&self, _issue_number: u64) -> Result<Vec<String>> {
+            Ok(self.labels.lock().unwrap().clone())
+        }
+
+        async fn issue_project_state(&self, _issue_number: u64) -> Result<Option<String>> {
+            Ok(self.project_state.lock().unwrap().clone())
+        }
+
+        async fn add_issue_label(&self, _issue_number: u64, label: &str) -> Result<()> {
+            self.calls.lock().unwrap().push(format!("add:{label}"));
+            let mut labels = self.labels.lock().unwrap();
+            if !labels.iter().any(|value| value == label) {
+                labels.push(label.to_string());
+            }
+            Ok(())
+        }
+
+        async fn remove_issue_label(&self, _issue_number: u64, label: &str) -> Result<()> {
+            self.calls.lock().unwrap().push(format!("remove:{label}"));
+            self.labels.lock().unwrap().retain(|value| value != label);
+            Ok(())
+        }
+
+        async fn set_issue_project_state(&self, _issue_number: u64, state: &str) -> Result<()> {
+            self.calls.lock().unwrap().push(format!("state:{state}"));
+            *self.project_state.lock().unwrap() = Some(state.to_string());
+            Ok(())
+        }
+    }
+
     fn artifact() -> TriageArtifact {
+        artifact_for(TriageRoute::Implement)
+    }
+
+    fn artifact_for(route: TriageRoute) -> TriageArtifact {
         TriageArtifact {
             schema_version: TRIAGE_SCHEMA_VERSION,
-            route: TriageRoute::Implement,
+            route,
             risk_class: RiskClass::Low,
             rationale: "Bounded fix.".to_string(),
             evidence: vec![TriageEvidence {
@@ -428,12 +1033,52 @@ mod tests {
                 summary: "Exact replacement named.".to_string(),
             }],
             next_action: "Apply the fix.".to_string(),
-            clarification_question: None,
+            clarification_question: (route == TriageRoute::NeedsInformation)
+                .then(|| "Which fallback should Symphony use?".to_string()),
             reproduction: None,
         }
     }
 
+    fn managed_labels() -> Vec<String> {
+        TriageRoutesConfig::default().managed_labels()
+    }
+
+    fn store_with_automatic_intent(
+        route: TriageRoute,
+    ) -> (
+        tempfile::TempDir,
+        SqliteFactoryStore,
+        PublicationIntentRecord,
+    ) {
+        let routes = TriageRoutesConfig::default();
+        let mapping = routes.mapping_for(route);
+        store_with_intent(
+            PublicationMode::Automatic,
+            artifact_for(route),
+            &mapping.label,
+            mapping.state.clone(),
+        )
+    }
+
     fn store_with_preview_intent() -> (
+        tempfile::TempDir,
+        SqliteFactoryStore,
+        PublicationIntentRecord,
+    ) {
+        store_with_intent(
+            PublicationMode::Preview,
+            artifact(),
+            "ready-for-agent",
+            None,
+        )
+    }
+
+    fn store_with_intent(
+        mode: PublicationMode,
+        artifact: TriageArtifact,
+        route_label: &str,
+        project_state: Option<String>,
+    ) -> (
         tempfile::TempDir,
         SqliteFactoryStore,
         PublicationIntentRecord,
@@ -466,26 +1111,344 @@ mod tests {
                 issue_revision: "rev".to_string(),
                 configuration_revision: "cfg".to_string(),
                 route_mapping_hash: "routes".to_string(),
-                artifact: artifact(),
+                artifact,
                 bytes_len: 100,
                 usage: Default::default(),
             })
             .unwrap();
+        let desired_kind = match mode {
+            PublicationMode::Preview => "preview_comment",
+            PublicationMode::Automatic => "automatic_route",
+        };
         let intent = store
             .create_publication_intent(CreatePublicationIntentRequest {
                 run_id: artifact_record.run_id,
                 artifact_id: Some(artifact_record.artifact_id),
-                mode: PublicationMode::Preview,
+                mode,
                 intake_label: "needs-triage".to_string(),
-                route_label: "ready-for-agent".to_string(),
-                project_state: None,
+                route_label: route_label.to_string(),
+                project_state,
                 route_mapping_hash: "routes".to_string(),
-                desired_effects: serde_json::json!({"kind": "preview_comment"}),
+                desired_effects: serde_json::json!({"kind": desired_kind}),
                 observed_baseline: serde_json::json!({}),
                 expected_projection: serde_json::json!({}),
             })
             .unwrap();
         (temp, store, intent)
+    }
+
+    #[tokio::test]
+    async fn automatic_implement_route_applies_label_state_then_removes_intake_last() {
+        let (_temp, mut store, intent) = store_with_automatic_intent(TriageRoute::Implement);
+        let comments = MockComments::new("symphony-bot");
+        let routing = MockRouting::new(&["needs-triage", "docs"], Some("Backlog"));
+        let publisher = AutomaticPublisher::new(comments.clone(), routing.clone());
+        let artifact = artifact_for(TriageRoute::Implement);
+
+        let status = publisher
+            .reconcile_automatic(
+                &mut store,
+                AutomaticPublishRequest {
+                    intent: &intent,
+                    issue_number: 12,
+                    run_id: "run",
+                    stage_run_id: "stage",
+                    attempt: 1,
+                    artifact: &artifact,
+                    managed_labels: &managed_labels(),
+                    max_pages: 10,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(status, PublicationStatus::Applied);
+        assert_eq!(
+            routing.calls(),
+            vec![
+                "add:ready-for-agent".to_string(),
+                "state:Todo".to_string(),
+                "remove:needs-triage".to_string(),
+            ]
+        );
+        assert_eq!(
+            routing.labels_now(),
+            vec!["docs".to_string(), "ready-for-agent".to_string()]
+        );
+        assert_eq!(routing.state_now().as_deref(), Some("Todo"));
+
+        let reloaded = store
+            .get_publication_intent(&intent.intent_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(reloaded.status, PublicationStatus::Applied);
+        assert_eq!(
+            reloaded.completed_steps,
+            vec![
+                COMMENT_PENDING_STEP.to_string(),
+                ROUTE_LABEL_STEP.to_string(),
+                PROJECT_STATE_STEP.to_string(),
+                CONFLICT_CLEANUP_STEP.to_string(),
+                COMMENT_ROUTE_EFFECTS_STEP.to_string(),
+                INTAKE_REMOVED_STEP.to_string(),
+                COMMENT_APPLIED_STEP.to_string(),
+            ]
+        );
+
+        assert_eq!(*comments.create_count.lock().unwrap(), 1);
+        let history = comments.history.lock().unwrap().clone();
+        assert!(history[0].contains("Publication: `pending`"));
+        assert!(history
+            .iter()
+            .any(|body| body.contains("Route effects: `applied`; publication: `pending`")));
+        assert!(history.last().unwrap().contains("Publication: `applied`"));
+        assert!(history.last().unwrap().contains("`ready-for-agent`"));
+        assert!(history.last().unwrap().contains("`Todo`"));
+    }
+
+    #[tokio::test]
+    async fn automatic_spec_route_skips_project_state_and_stays_ineligible_for_implement() {
+        let (_temp, mut store, intent) = store_with_automatic_intent(TriageRoute::Spec);
+        let comments = MockComments::new("symphony-bot");
+        let routing = MockRouting::new(&["needs-triage"], Some("Backlog"));
+        let publisher = AutomaticPublisher::new(comments.clone(), routing.clone());
+        let artifact = artifact_for(TriageRoute::Spec);
+
+        let status = publisher
+            .reconcile_automatic(
+                &mut store,
+                AutomaticPublishRequest {
+                    intent: &intent,
+                    issue_number: 12,
+                    run_id: "run",
+                    stage_run_id: "stage",
+                    attempt: 1,
+                    artifact: &artifact,
+                    managed_labels: &managed_labels(),
+                    max_pages: 10,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(status, PublicationStatus::Applied);
+        assert_eq!(
+            routing.calls(),
+            vec![
+                "add:ready-to-spec".to_string(),
+                "remove:needs-triage".to_string(),
+            ]
+        );
+        assert_eq!(routing.state_now().as_deref(), Some("Backlog"));
+        let reloaded = store
+            .get_publication_intent(&intent.intent_id)
+            .unwrap()
+            .unwrap();
+        assert!(reloaded
+            .completed_steps
+            .iter()
+            .any(|step| step == PROJECT_STATE_STEP));
+    }
+
+    #[tokio::test]
+    async fn automatic_conflict_cleanup_removes_other_managed_route_labels() {
+        let (_temp, mut store, intent) = store_with_automatic_intent(TriageRoute::Implement);
+        let comments = MockComments::new("symphony-bot");
+        let routing = MockRouting::new(
+            &["needs-triage", "ready-to-spec", "docs"],
+            Some("Backlog"),
+        );
+        let publisher = AutomaticPublisher::new(comments.clone(), routing.clone());
+
+        publisher
+            .reconcile_automatic(
+                &mut store,
+                AutomaticPublishRequest {
+                    intent: &intent,
+                    issue_number: 12,
+                    run_id: "run",
+                    stage_run_id: "stage",
+                    attempt: 1,
+                    artifact: &artifact_for(TriageRoute::Implement),
+                    managed_labels: &managed_labels(),
+                    max_pages: 10,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert!(routing.calls().contains(&"remove:ready-to-spec".to_string()));
+        assert_eq!(
+            routing.labels_now(),
+            vec!["docs".to_string(), "ready-for-agent".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn automatic_human_conflict_stops_without_intake_removal() {
+        let (_temp, mut store, intent) = store_with_automatic_intent(TriageRoute::Implement);
+        let comments = MockComments::new("symphony-bot");
+        let routing = MockRouting::new(&["needs-triage"], Some("Backlog"));
+        let publisher = AutomaticPublisher::new(comments.clone(), routing.clone());
+
+        publisher
+            .reconcile_automatic(
+                &mut store,
+                AutomaticPublishRequest {
+                    intent: &intent,
+                    issue_number: 12,
+                    run_id: "run",
+                    stage_run_id: "stage",
+                    attempt: 1,
+                    artifact: &artifact_for(TriageRoute::Implement),
+                    managed_labels: &managed_labels(),
+                    max_pages: 10,
+                },
+            )
+            .await
+            .unwrap();
+
+        let applied = store
+            .get_publication_intent(&intent.intent_id)
+            .unwrap()
+            .unwrap();
+        let baseline = applied.observed_baseline.clone();
+        store
+            .debug_rewind_publication(&intent.intent_id, &[COMMENT_PENDING_STEP], &baseline)
+            .unwrap();
+        // Human changed managed labels away from the recorded expected projection.
+        *routing.labels.lock().unwrap() =
+            vec!["needs-triage".to_string(), "ready-to-spec".to_string()];
+        *routing.calls.lock().unwrap() = Vec::new();
+
+        let pending = store
+            .get_publication_intent(&intent.intent_id)
+            .unwrap()
+            .unwrap();
+        let status = publisher
+            .reconcile_automatic(
+                &mut store,
+                AutomaticPublishRequest {
+                    intent: &pending,
+                    issue_number: 12,
+                    run_id: "run",
+                    stage_run_id: "stage",
+                    attempt: 1,
+                    artifact: &artifact_for(TriageRoute::Implement),
+                    managed_labels: &managed_labels(),
+                    max_pages: 10,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(status, PublicationStatus::Conflict);
+        assert!(routing.labels_now().contains(&"needs-triage".to_string()));
+        assert!(!routing.calls().iter().any(|call| call == "remove:needs-triage"));
+    }
+
+    #[tokio::test]
+    async fn automatic_crash_after_route_label_resumes_without_duplicate_add() {
+        let (_temp, mut store, intent) = store_with_automatic_intent(TriageRoute::Implement);
+        let comments = MockComments::new("symphony-bot");
+        let routing = MockRouting::new(&["needs-triage"], Some("Backlog"));
+        let publisher = AutomaticPublisher::new(comments.clone(), routing.clone());
+
+        publisher
+            .reconcile_automatic(
+                &mut store,
+                AutomaticPublishRequest {
+                    intent: &intent,
+                    issue_number: 12,
+                    run_id: "run",
+                    stage_run_id: "stage",
+                    attempt: 1,
+                    artifact: &artifact_for(TriageRoute::Implement),
+                    managed_labels: &managed_labels(),
+                    max_pages: 10,
+                },
+            )
+            .await
+            .unwrap();
+
+        let applied = store
+            .get_publication_intent(&intent.intent_id)
+            .unwrap()
+            .unwrap();
+        let baseline = applied.observed_baseline.clone();
+        store
+            .debug_rewind_publication(&intent.intent_id, &[COMMENT_PENDING_STEP], &baseline)
+            .unwrap();
+        // GitHub already has the route label from the "lost" successful mutation.
+        *routing.labels.lock().unwrap() =
+            vec!["needs-triage".to_string(), "ready-for-agent".to_string()];
+        *routing.calls.lock().unwrap() = vec!["add:ready-for-agent".to_string()];
+        *routing.project_state.lock().unwrap() = Some("Backlog".to_string());
+
+        let pending = store
+            .get_publication_intent(&intent.intent_id)
+            .unwrap()
+            .unwrap();
+        publisher
+            .reconcile_automatic(
+                &mut store,
+                AutomaticPublishRequest {
+                    intent: &pending,
+                    issue_number: 12,
+                    run_id: "run",
+                    stage_run_id: "stage",
+                    attempt: 1,
+                    artifact: &artifact_for(TriageRoute::Implement),
+                    managed_labels: &managed_labels(),
+                    max_pages: 10,
+                },
+            )
+            .await
+            .unwrap();
+
+        let add_calls = routing
+            .calls()
+            .into_iter()
+            .filter(|call| call == "add:ready-for-agent")
+            .count();
+        assert_eq!(add_calls, 1);
+        let reloaded = store
+            .get_publication_intent(&intent.intent_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(reloaded.status, PublicationStatus::Applied);
+    }
+
+    #[tokio::test]
+    async fn automatic_needs_information_comment_includes_clarification_question() {
+        let (_temp, mut store, intent) =
+            store_with_automatic_intent(TriageRoute::NeedsInformation);
+        let comments = MockComments::new("symphony-bot");
+        let routing = MockRouting::new(&["needs-triage"], None);
+        let publisher = AutomaticPublisher::new(comments.clone(), routing.clone());
+        let artifact = artifact_for(TriageRoute::NeedsInformation);
+
+        publisher
+            .reconcile_automatic(
+                &mut store,
+                AutomaticPublishRequest {
+                    intent: &intent,
+                    issue_number: 12,
+                    run_id: "run",
+                    stage_run_id: "stage",
+                    attempt: 1,
+                    artifact: &artifact,
+                    managed_labels: &managed_labels(),
+                    max_pages: 10,
+                },
+            )
+            .await
+            .unwrap();
+
+        let history = comments.history.lock().unwrap().clone();
+        assert!(history
+            .iter()
+            .any(|body| body.contains("Which fallback should Symphony use?")));
     }
 
     #[tokio::test]

--- a/apps/symphony/src/triage/publisher.rs
+++ b/apps/symphony/src/triage/publisher.rs
@@ -459,13 +459,19 @@ where
         vocabulary: &std::collections::BTreeSet<String>,
         step: &str,
     ) -> Result<PublicationStatus> {
-        let expected = ManagedProjection::from_json(&intent.expected_projection)
-            .unwrap_or_default();
+        let expected =
+            ManagedProjection::from_json(&intent.expected_projection).unwrap_or_default();
         match step {
             COMMENT_PENDING_STEP => {
                 let body = automatic_body(request, intent, AutomaticCommentPhase::Pending);
-                self.upsert_marked_comment(store, intent, request.issue_number, &body, request.max_pages)
-                    .await?;
+                self.upsert_marked_comment(
+                    store,
+                    intent,
+                    request.issue_number,
+                    &body,
+                    request.max_pages,
+                )
+                .await?;
                 store.record_publication_step(
                     &intent.intent_id,
                     COMMENT_PENDING_STEP,
@@ -522,7 +528,11 @@ where
                 }
             }
             CONFLICT_CLEANUP_STEP => {
-                let desired = conflict_cleanup_desired(&expected, request.managed_labels, &intent.route_label);
+                let desired = conflict_cleanup_desired(
+                    &expected,
+                    request.managed_labels,
+                    &intent.route_label,
+                );
                 let to_remove = conflicting_route_labels(
                     &expected,
                     request.managed_labels,
@@ -548,8 +558,14 @@ where
             COMMENT_ROUTE_EFFECTS_STEP => {
                 let body =
                     automatic_body(request, intent, AutomaticCommentPhase::RouteEffectsApplied);
-                self.upsert_marked_comment(store, intent, request.issue_number, &body, request.max_pages)
-                    .await?;
+                self.upsert_marked_comment(
+                    store,
+                    intent,
+                    request.issue_number,
+                    &body,
+                    request.max_pages,
+                )
+                .await?;
                 store.record_publication_step(
                     &intent.intent_id,
                     COMMENT_ROUTE_EFFECTS_STEP,
@@ -579,8 +595,14 @@ where
             }
             COMMENT_APPLIED_STEP => {
                 let body = automatic_body(request, intent, AutomaticCommentPhase::Applied);
-                self.upsert_marked_comment(store, intent, request.issue_number, &body, request.max_pages)
-                    .await?;
+                self.upsert_marked_comment(
+                    store,
+                    intent,
+                    request.issue_number,
+                    &body,
+                    request.max_pages,
+                )
+                .await?;
                 store.record_publication_step(
                     &intent.intent_id,
                     COMMENT_APPLIED_STEP,
@@ -1254,10 +1276,7 @@ mod tests {
     async fn automatic_conflict_cleanup_removes_other_managed_route_labels() {
         let (_temp, mut store, intent) = store_with_automatic_intent(TriageRoute::Implement);
         let comments = MockComments::new("symphony-bot");
-        let routing = MockRouting::new(
-            &["needs-triage", "ready-to-spec", "docs"],
-            Some("Backlog"),
-        );
+        let routing = MockRouting::new(&["needs-triage", "ready-to-spec", "docs"], Some("Backlog"));
         let publisher = AutomaticPublisher::new(comments.clone(), routing.clone());
 
         publisher
@@ -1277,7 +1296,9 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(routing.calls().contains(&"remove:ready-to-spec".to_string()));
+        assert!(routing
+            .calls()
+            .contains(&"remove:ready-to-spec".to_string()));
         assert_eq!(
             routing.labels_now(),
             vec!["docs".to_string(), "ready-for-agent".to_string()]
@@ -1344,7 +1365,10 @@ mod tests {
 
         assert_eq!(status, PublicationStatus::Conflict);
         assert!(routing.labels_now().contains(&"needs-triage".to_string()));
-        assert!(!routing.calls().iter().any(|call| call == "remove:needs-triage"));
+        assert!(!routing
+            .calls()
+            .iter()
+            .any(|call| call == "remove:needs-triage"));
     }
 
     #[tokio::test]
@@ -1421,8 +1445,7 @@ mod tests {
 
     #[tokio::test]
     async fn automatic_needs_information_comment_includes_clarification_question() {
-        let (_temp, mut store, intent) =
-            store_with_automatic_intent(TriageRoute::NeedsInformation);
+        let (_temp, mut store, intent) = store_with_automatic_intent(TriageRoute::NeedsInformation);
         let comments = MockComments::new("symphony-bot");
         let routing = MockRouting::new(&["needs-triage"], None);
         let publisher = AutomaticPublisher::new(comments.clone(), routing.clone());

--- a/apps/symphony/src/triage/publisher.rs
+++ b/apps/symphony/src/triage/publisher.rs
@@ -668,11 +668,22 @@ where
                     .await?;
             }
             MutationKind::RemoveLabels(labels) => {
+                // Persist each successful removal so a crash mid-cleanup leaves
+                // expected projection on a publisher-owned intermediate state
+                // instead of looking like a human conflict on retry.
+                let mut progressive = current.clone();
                 for label in labels {
-                    if current.contains_label(&label) {
+                    if progressive.contains_label(&label) {
                         self.routing
                             .remove_issue_label(issue_number, &label)
                             .await?;
+                        progressive = progressive.without_label(&label);
+                        store.record_publication_step(
+                            &intent.intent_id,
+                            "",
+                            PublicationStatus::Pending,
+                            &progressive.to_json(),
+                        )?;
                     }
                 }
             }
@@ -1303,6 +1314,82 @@ mod tests {
             routing.labels_now(),
             vec!["docs".to_string(), "ready-for-agent".to_string()]
         );
+    }
+
+    #[tokio::test]
+    async fn automatic_crash_mid_conflict_cleanup_resumes_without_false_conflict() {
+        let (_temp, mut store, intent) = store_with_automatic_intent(TriageRoute::Implement);
+        let comments = MockComments::new("symphony-bot");
+        let routing = MockRouting::new(
+            &["needs-triage", "ready-to-spec", "needs-info"],
+            Some("Backlog"),
+        );
+        let publisher = AutomaticPublisher::new(comments.clone(), routing.clone());
+
+        publisher
+            .reconcile_automatic(
+                &mut store,
+                AutomaticPublishRequest {
+                    intent: &intent,
+                    issue_number: 12,
+                    run_id: "run",
+                    stage_run_id: "stage",
+                    attempt: 1,
+                    artifact: &artifact_for(TriageRoute::Implement),
+                    managed_labels: &managed_labels(),
+                    max_pages: 10,
+                },
+            )
+            .await
+            .unwrap();
+
+        // Simulate crash after removing one conflicting label during cleanup:
+        // rewind before conflict_cleanup completes, keep GitHub intermediate state,
+        // and leave expected projection on that publisher-owned intermediate.
+        let intermediate = ManagedProjection::observe(
+            ["needs-triage", "ready-for-agent", "needs-info"],
+            &publication_vocabulary(&managed_labels(), "needs-triage"),
+            Some("Todo"),
+        );
+        store
+            .debug_rewind_publication(
+                &intent.intent_id,
+                &[COMMENT_PENDING_STEP, ROUTE_LABEL_STEP, PROJECT_STATE_STEP],
+                &intermediate.to_json(),
+            )
+            .unwrap();
+        *routing.labels.lock().unwrap() = vec![
+            "needs-triage".to_string(),
+            "ready-for-agent".to_string(),
+            "needs-info".to_string(),
+        ];
+        *routing.project_state.lock().unwrap() = Some("Todo".to_string());
+        *routing.calls.lock().unwrap() = Vec::new();
+
+        let pending = store
+            .get_publication_intent(&intent.intent_id)
+            .unwrap()
+            .unwrap();
+        let status = publisher
+            .reconcile_automatic(
+                &mut store,
+                AutomaticPublishRequest {
+                    intent: &pending,
+                    issue_number: 12,
+                    run_id: "run",
+                    stage_run_id: "stage",
+                    attempt: 1,
+                    artifact: &artifact_for(TriageRoute::Implement),
+                    managed_labels: &managed_labels(),
+                    max_pages: 10,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(status, PublicationStatus::Applied);
+        assert!(!routing.labels_now().contains(&"needs-info".to_string()));
+        assert!(!routing.labels_now().contains(&"needs-triage".to_string()));
     }
 
     #[tokio::test]

--- a/apps/symphony/src/triage/routing.rs
+++ b/apps/symphony/src/triage/routing.rs
@@ -1,0 +1,109 @@
+//! GitHub label and Projects v2 state mutations for automatic triage publication.
+
+use async_trait::async_trait;
+
+use crate::error::{Result, SymphonyError};
+use crate::github::client::GithubClient;
+use crate::github::projects_v2::ProjectsV2Client;
+use crate::triage::publisher::TriageRoutingPort;
+
+/// GitHub-backed routing port used by [`crate::triage::publisher::AutomaticPublisher`].
+#[derive(Debug, Clone)]
+pub struct GithubTriageRouting {
+    client: GithubClient,
+    projects: ProjectsV2Client,
+    owner: String,
+    project_number: u64,
+    max_pages: u32,
+}
+
+impl GithubTriageRouting {
+    pub fn new(
+        client: GithubClient,
+        projects: ProjectsV2Client,
+        owner: impl Into<String>,
+        project_number: u64,
+        max_pages: u32,
+    ) -> Self {
+        Self {
+            client,
+            projects,
+            owner: owner.into(),
+            project_number,
+            max_pages: max_pages.max(1),
+        }
+    }
+}
+
+#[async_trait]
+impl TriageRoutingPort for GithubTriageRouting {
+    async fn list_issue_labels(&self, issue_number: u64) -> Result<Vec<String>> {
+        let issue = self.client.get_issue(issue_number).await?;
+        Ok(issue
+            .labels
+            .into_iter()
+            .map(|label| label.name)
+            .collect())
+    }
+
+    async fn issue_project_state(&self, issue_number: u64) -> Result<Option<String>> {
+        let status_field = self
+            .projects
+            .resolve_status_field(&self.owner, self.project_number)
+            .await?;
+        let items = self
+            .projects
+            .query_all_items(&status_field.project_id, self.max_pages)
+            .await?;
+        Ok(items
+            .into_iter()
+            .find(|item| item.issue_number == issue_number)
+            .and_then(|item| item.status))
+    }
+
+    async fn add_issue_label(&self, issue_number: u64, label: &str) -> Result<()> {
+        self.client.add_label(issue_number, label).await
+    }
+
+    async fn remove_issue_label(&self, issue_number: u64, label: &str) -> Result<()> {
+        self.client.remove_label(issue_number, label).await
+    }
+
+    async fn set_issue_project_state(&self, issue_number: u64, state: &str) -> Result<()> {
+        let status_field = self
+            .projects
+            .resolve_status_field(&self.owner, self.project_number)
+            .await?;
+        let target = status_field
+            .options
+            .iter()
+            .find(|option| option.name.eq_ignore_ascii_case(state))
+            .ok_or_else(|| {
+                SymphonyError::GithubProjectsV2Error(format!(
+                    "Projects v2 status option '{state}' not found on project #{}",
+                    self.project_number
+                ))
+            })?;
+        let items = self
+            .projects
+            .query_all_items(&status_field.project_id, self.max_pages)
+            .await?;
+        let item = items
+            .into_iter()
+            .find(|item| item.issue_number == issue_number)
+            .ok_or_else(|| {
+                SymphonyError::GithubProjectsV2Error(format!(
+                    "issue #{issue_number} is not on project board #{}",
+                    self.project_number
+                ))
+            })?;
+        self.projects
+            .update_item_status(
+                &status_field.project_id,
+                &item.item_id,
+                &status_field.field_id,
+                &target.id,
+            )
+            .await
+    }
+}

--- a/apps/symphony/src/triage/routing.rs
+++ b/apps/symphony/src/triage/routing.rs
@@ -39,11 +39,7 @@ impl GithubTriageRouting {
 impl TriageRoutingPort for GithubTriageRouting {
     async fn list_issue_labels(&self, issue_number: u64) -> Result<Vec<String>> {
         let issue = self.client.get_issue(issue_number).await?;
-        Ok(issue
-            .labels
-            .into_iter()
-            .map(|label| label.name)
-            .collect())
+        Ok(issue.labels.into_iter().map(|label| label.name).collect())
     }
 
     async fn issue_project_state(&self, issue_number: u64) -> Result<Option<String>> {

--- a/apps/symphony/src/triage/routing.rs
+++ b/apps/symphony/src/triage/routing.rs
@@ -13,6 +13,8 @@ pub struct GithubTriageRouting {
     client: GithubClient,
     projects: ProjectsV2Client,
     owner: String,
+    /// `owner/repo` for the configured tracker repository.
+    repository: String,
     project_number: u64,
     max_pages: u32,
 }
@@ -22,15 +24,33 @@ impl GithubTriageRouting {
         client: GithubClient,
         projects: ProjectsV2Client,
         owner: impl Into<String>,
+        repo: impl Into<String>,
         project_number: u64,
         max_pages: u32,
     ) -> Self {
+        let owner = owner.into();
+        let repo = repo.into();
+        let repository = format!("{owner}/{repo}");
         Self {
             client,
             projects,
-            owner: owner.into(),
+            owner,
+            repository,
             project_number,
             max_pages: max_pages.max(1),
+        }
+    }
+
+    fn matches_configured_repository(&self, item_repository: Option<&str>) -> bool {
+        let configured = self.repository.to_ascii_lowercase();
+        match item_repository
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            Some(repository) => repository.eq_ignore_ascii_case(&configured),
+            // Older payloads without repository metadata are treated as the
+            // configured tracker repo, matching intake membership heuristics.
+            None => true,
         }
     }
 }
@@ -53,7 +73,10 @@ impl TriageRoutingPort for GithubTriageRouting {
             .await?;
         Ok(items
             .into_iter()
-            .find(|item| item.issue_number == issue_number)
+            .find(|item| {
+                item.issue_number == issue_number
+                    && self.matches_configured_repository(item.repository.as_deref())
+            })
             .and_then(|item| item.status))
     }
 
@@ -84,13 +107,18 @@ impl TriageRoutingPort for GithubTriageRouting {
             .projects
             .query_all_items(&status_field.project_id, self.max_pages)
             .await?;
+        // Issue numbers are only unique within a repository. Qualify by
+        // owner/repo so multi-repo boards cannot mutate the wrong item.
         let item = items
             .into_iter()
-            .find(|item| item.issue_number == issue_number)
+            .find(|item| {
+                item.issue_number == issue_number
+                    && self.matches_configured_repository(item.repository.as_deref())
+            })
             .ok_or_else(|| {
                 SymphonyError::GithubProjectsV2Error(format!(
-                    "issue #{issue_number} is not on project board #{}",
-                    self.project_number
+                    "issue {}#{} is not on project board #{}",
+                    self.repository, issue_number, self.project_number
                 ))
             })?;
         self.projects

--- a/apps/symphony/src/triage/runtime.rs
+++ b/apps/symphony/src/triage/runtime.rs
@@ -20,10 +20,12 @@ use crate::triage::domain::{
     PublicationIntentRecord, PublicationStatus, StageRunRecord,
 };
 use crate::triage::intake::GithubTriageIntake;
+use crate::triage::routing::GithubTriageRouting;
 use crate::triage::storage_path::{resolve_storage_path, storage_path_for_log};
 use crate::triage::store::{
-    ClaimAttemptRequest, CreatePublicationIntentRequest, FactoryRunStore, SqliteFactoryStore,
-    StoreArtifactRequest, StoredCommentIdentity, UpsertFactoryRunRequest,
+    ClaimAttemptRequest, CreatePublicationIntentRequest, FactoryRunStore,
+    PendingAutomaticDispatchGuard, SqliteFactoryStore, StoreArtifactRequest, StoredCommentIdentity,
+    UpsertFactoryRunRequest,
 };
 
 /// Shared SQLite factory store for coordinator + HTTP reads.
@@ -165,6 +167,12 @@ impl FactoryRunStore for SharedFactoryStore {
         self.with_store(|store| store.list_pending_intents(limit))
     }
 
+    fn list_pending_automatic_dispatch_guards(
+        &self,
+    ) -> Result<Vec<PendingAutomaticDispatchGuard>> {
+        self.with_store(|store| store.list_pending_automatic_dispatch_guards())
+    }
+
     fn list_intents_for_run(&self, run_id: &str) -> Result<Vec<PublicationIntentRecord>> {
         self.with_store(|store| store.list_intents_for_run(run_id))
     }
@@ -193,6 +201,29 @@ impl FactoryRunStore for SharedFactoryStore {
     ) -> Result<()> {
         self.with_store_mut(|store| {
             store.update_publication_step(intent_id, completed_step, status, error)
+        })
+    }
+
+    fn record_publication_step(
+        &mut self,
+        intent_id: &str,
+        completed_step: &str,
+        status: PublicationStatus,
+        expected_projection: &serde_json::Value,
+    ) -> Result<()> {
+        self.with_store_mut(|store| {
+            store.record_publication_step(intent_id, completed_step, status, expected_projection)
+        })
+    }
+
+    fn set_publication_baseline(
+        &mut self,
+        intent_id: &str,
+        observed_baseline: &serde_json::Value,
+        expected_projection: &serde_json::Value,
+    ) -> Result<()> {
+        self.with_store_mut(|store| {
+            store.set_publication_baseline(intent_id, observed_baseline, expected_projection)
         })
     }
 
@@ -358,12 +389,19 @@ impl TriageRuntime {
         let managed_labels = config.triage.routes.managed_labels();
         let intake = GithubTriageIntake::new(
             client.clone(),
-            projects,
+            projects.clone(),
             owner,
             repo,
             project_number,
             forge_host.clone(),
             managed_labels,
+        );
+        let routing = GithubTriageRouting::new(
+            client.clone(),
+            projects,
+            owner,
+            project_number,
+            config.triage.max_intake_pages,
         );
 
         let workflow_dir = workflow_path
@@ -384,7 +422,8 @@ impl TriageRuntime {
                 workflow_dir,
                 project_display_name,
             },
-        );
+        )
+        .with_routing(routing);
         let sessions = Arc::new(Mutex::new(crate::domain::TriageSessionRegistry::default()));
         coordinator = coordinator.with_session_registry(sessions.clone());
         if let Some(hub) = event_hub {
@@ -404,6 +443,14 @@ impl TriageRuntime {
 
     pub fn sessions(&self) -> Arc<Mutex<crate::domain::TriageSessionRegistry>> {
         self.sessions.clone()
+    }
+
+    /// Issue IDs / intake labels that must not enter implementation dispatch
+    /// while automatic publication is still pending.
+    pub fn pending_automatic_dispatch_guards(
+        &self,
+    ) -> Result<Vec<PendingAutomaticDispatchGuard>> {
+        self.store.list_pending_automatic_dispatch_guards()
     }
 
     pub async fn poll(&mut self, config: &ServiceConfig) -> Result<TriagePollSummary> {

--- a/apps/symphony/src/triage/runtime.rs
+++ b/apps/symphony/src/triage/runtime.rs
@@ -21,7 +21,9 @@ use crate::triage::domain::{
 };
 use crate::triage::intake::GithubTriageIntake;
 use crate::triage::routing::GithubTriageRouting;
-use crate::triage::storage_path::{resolve_storage_path, storage_path_for_log};
+use crate::triage::storage_path::{
+    forge_host_from_endpoint, resolve_storage_path, storage_path_for_log,
+};
 use crate::triage::store::{
     ClaimAttemptRequest, CreatePublicationIntentRequest, FactoryRunStore,
     PendingAutomaticDispatchGuard, SqliteFactoryStore, StoreArtifactRequest, StoredCommentIdentity,
@@ -40,6 +42,11 @@ impl SharedFactoryStore {
         Ok(Self {
             inner: Arc::new(Mutex::new(store)),
         })
+    }
+
+    /// Read durable nonterminal automatic publication guards for dispatch.
+    pub fn pending_automatic_dispatch_guards(&self) -> Result<Vec<PendingAutomaticDispatchGuard>> {
+        self.with_store(|store| store.list_pending_automatic_dispatch_guards())
     }
 
     fn with_store<T>(&self, f: impl FnOnce(&SqliteFactoryStore) -> Result<T>) -> Result<T> {
@@ -310,6 +317,52 @@ pub struct TriageRuntime {
 }
 
 impl TriageRuntime {
+    /// Open the durable factory store for dispatch-guard reads when triage intake
+    /// is disabled. Returns `Ok(None)` when triage is enabled (the full runtime
+    /// owns the store), the tracker is not GitHub, or no existing DB is present.
+    pub fn try_open_dispatch_guard_store(
+        config: &ServiceConfig,
+    ) -> Result<Option<SharedFactoryStore>> {
+        if config.triage.enabled {
+            return Ok(None);
+        }
+        if !matches!(config.tracker.kind.as_deref(), Some("github")) {
+            return Ok(None);
+        }
+        let Some(owner) = config
+            .tracker
+            .repo_owner
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        else {
+            return Ok(None);
+        };
+        let Some(repo) = config
+            .tracker
+            .repo_name
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        else {
+            return Ok(None);
+        };
+        let forge_host = forge_host_from_endpoint(&config.tracker.endpoint);
+        let storage_path = resolve_storage_path(&config.storage, &forge_host, owner, repo);
+        if !storage_path.exists() {
+            return Ok(None);
+        }
+        tracing::info!(
+            event = "triage_dispatch_guard_store_opened",
+            path = %storage_path_for_log(&storage_path),
+            "opened durable triage store for dispatch guards while triage.enabled=false"
+        );
+        Ok(Some(SharedFactoryStore::open(
+            &storage_path,
+            config.storage.busy_timeout_ms,
+        )?))
+    }
+
     /// Start triage when `triage.enabled` is true. Returns `Ok(None)` when disabled.
     pub fn try_start(
         config: &ServiceConfig,
@@ -358,8 +411,7 @@ impl TriageRuntime {
             .ok_or(SymphonyError::MissingGithubApiToken)?;
         let token = resolved.token;
 
-        let forge_host =
-            crate::triage::storage_path::forge_host_from_endpoint(&config.tracker.endpoint);
+        let forge_host = forge_host_from_endpoint(&config.tracker.endpoint);
         let repository = format!("{owner}/{repo}");
         let storage_path = resolve_storage_path(&config.storage, &forge_host, owner, repo);
         tracing::info!(
@@ -398,6 +450,7 @@ impl TriageRuntime {
             client.clone(),
             projects,
             owner,
+            repo,
             project_number,
             config.triage.max_intake_pages,
         );
@@ -444,9 +497,9 @@ impl TriageRuntime {
     }
 
     /// Issue IDs / intake labels that must not enter implementation dispatch
-    /// while automatic publication is still pending.
+    /// while automatic publication is still nonterminal.
     pub fn pending_automatic_dispatch_guards(&self) -> Result<Vec<PendingAutomaticDispatchGuard>> {
-        self.store.list_pending_automatic_dispatch_guards()
+        self.store.pending_automatic_dispatch_guards()
     }
 
     pub async fn poll(&mut self, config: &ServiceConfig) -> Result<TriagePollSummary> {

--- a/apps/symphony/src/triage/runtime.rs
+++ b/apps/symphony/src/triage/runtime.rs
@@ -167,9 +167,7 @@ impl FactoryRunStore for SharedFactoryStore {
         self.with_store(|store| store.list_pending_intents(limit))
     }
 
-    fn list_pending_automatic_dispatch_guards(
-        &self,
-    ) -> Result<Vec<PendingAutomaticDispatchGuard>> {
+    fn list_pending_automatic_dispatch_guards(&self) -> Result<Vec<PendingAutomaticDispatchGuard>> {
         self.with_store(|store| store.list_pending_automatic_dispatch_guards())
     }
 
@@ -447,9 +445,7 @@ impl TriageRuntime {
 
     /// Issue IDs / intake labels that must not enter implementation dispatch
     /// while automatic publication is still pending.
-    pub fn pending_automatic_dispatch_guards(
-        &self,
-    ) -> Result<Vec<PendingAutomaticDispatchGuard>> {
+    pub fn pending_automatic_dispatch_guards(&self) -> Result<Vec<PendingAutomaticDispatchGuard>> {
         self.store.list_pending_automatic_dispatch_guards()
     }
 

--- a/apps/symphony/src/triage/store.rs
+++ b/apps/symphony/src/triage/store.rs
@@ -80,7 +80,7 @@ pub struct StoredCommentIdentity {
 }
 
 /// Durable guard used by the implementation scheduler while automatic
-/// publication is still nonterminal.
+/// publication is still nonterminal (`pending`, `conflict`, or `blocked`).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PendingAutomaticDispatchGuard {
     pub forge_host: String,
@@ -788,7 +788,7 @@ impl FactoryRunStore for SqliteFactoryStore {
                 "SELECT r.forge_host, r.repository, r.issue_id, i.intake_label
                  FROM publication_intents i
                  INNER JOIN factory_runs r ON r.run_id = i.run_id
-                 WHERE i.mode = ?1 AND i.status = ?2
+                 WHERE i.mode = ?1 AND i.status IN (?2, ?3, ?4)
                  ORDER BY i.updated_at ASC",
             )
             .map_err(storage_error)?;
@@ -796,7 +796,9 @@ impl FactoryRunStore for SqliteFactoryStore {
             .query_map(
                 params![
                     PublicationMode::Automatic.as_str(),
-                    PublicationStatus::Pending.as_str()
+                    PublicationStatus::Pending.as_str(),
+                    PublicationStatus::Conflict.as_str(),
+                    PublicationStatus::Blocked.as_str(),
                 ],
                 |row| {
                     Ok(PendingAutomaticDispatchGuard {
@@ -1636,6 +1638,13 @@ mod tests {
         assert_eq!(guards.len(), 1);
         assert_eq!(guards[0].issue_id, "123");
         assert_eq!(guards[0].intake_label, "needs-triage");
+
+        store
+            .update_publication_step(&automatic.intent_id, "", PublicationStatus::Conflict, None)
+            .unwrap();
+        let conflict_guards = store.list_pending_automatic_dispatch_guards().unwrap();
+        assert_eq!(conflict_guards.len(), 1);
+        assert_eq!(conflict_guards[0].issue_id, "123");
 
         store
             .update_publication_step(

--- a/apps/symphony/src/triage/store.rs
+++ b/apps/symphony/src/triage/store.rs
@@ -79,6 +79,16 @@ pub struct StoredCommentIdentity {
     pub publisher_login: String,
 }
 
+/// Durable guard used by the implementation scheduler while automatic
+/// publication is still nonterminal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingAutomaticDispatchGuard {
+    pub forge_host: String,
+    pub repository: String,
+    pub issue_id: String,
+    pub intake_label: String,
+}
+
 pub trait FactoryRunStore {
     fn claim_attempt(&mut self, request: ClaimAttemptRequest) -> Result<StageRunRecord>;
     fn store_artifact(&mut self, request: StoreArtifactRequest) -> Result<ArtifactRecord>;
@@ -113,6 +123,9 @@ pub trait FactoryRunStore {
     fn get_publication_intent(&self, intent_id: &str) -> Result<Option<PublicationIntentRecord>>;
     fn get_latest_publication(&self, run_id: &str) -> Result<Option<PublicationIntentRecord>>;
     fn list_pending_intents(&self, limit: usize) -> Result<Vec<PublicationIntentRecord>>;
+    fn list_pending_automatic_dispatch_guards(
+        &self,
+    ) -> Result<Vec<PendingAutomaticDispatchGuard>>;
     fn list_intents_for_run(&self, run_id: &str) -> Result<Vec<PublicationIntentRecord>>;
     fn list_verified_comment_identities(&self, run_id: &str) -> Result<Vec<StoredCommentIdentity>>;
     fn list_stage_attempts_for_revision(
@@ -127,6 +140,23 @@ pub trait FactoryRunStore {
         completed_step: &str,
         status: PublicationStatus,
         error: Option<FactoryError>,
+    ) -> Result<()>;
+    /// Record a completed publication step and the expected managed projection
+    /// it produced in one write, so a crash can never leave the two disagreeing.
+    fn record_publication_step(
+        &mut self,
+        intent_id: &str,
+        completed_step: &str,
+        status: PublicationStatus,
+        expected_projection: &serde_json::Value,
+    ) -> Result<()>;
+    /// Persist the managed baseline observed before any GitHub effect together
+    /// with the initial expected projection.
+    fn set_publication_baseline(
+        &mut self,
+        intent_id: &str,
+        observed_baseline: &serde_json::Value,
+        expected_projection: &serde_json::Value,
     ) -> Result<()>;
     fn set_publication_comment(
         &mut self,
@@ -181,6 +211,40 @@ impl SqliteFactoryStore {
 
     fn now() -> DateTime<Utc> {
         Utc::now()
+    }
+
+    /// Test-only helper to simulate crash windows by rewinding completed steps
+    /// and expected projection while leaving GitHub side effects intact.
+    #[cfg(test)]
+    pub fn debug_rewind_publication(
+        &mut self,
+        intent_id: &str,
+        completed_steps: &[&str],
+        expected_projection: &serde_json::Value,
+    ) -> Result<()> {
+        let now_s = ts(Self::now());
+        let changed = self
+            .conn
+            .execute(
+                "UPDATE publication_intents
+                 SET completed_steps_json = ?1, status = ?2, expected_projection_json = ?3,
+                     updated_at = ?4
+                 WHERE intent_id = ?5",
+                params![
+                    serde_json::to_string(&completed_steps).map_err(storage_error)?,
+                    PublicationStatus::Pending.as_str(),
+                    bounded_json(expected_projection)?,
+                    now_s,
+                    intent_id,
+                ],
+            )
+            .map_err(storage_error)?;
+        if changed == 0 {
+            return Err(SymphonyError::StorageError(format!(
+                "publication intent {intent_id} not found"
+            )));
+        }
+        Ok(())
     }
 }
 
@@ -719,6 +783,39 @@ impl FactoryRunStore for SqliteFactoryStore {
             .map_err(storage_error)
     }
 
+    fn list_pending_automatic_dispatch_guards(
+        &self,
+    ) -> Result<Vec<PendingAutomaticDispatchGuard>> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT r.forge_host, r.repository, r.issue_id, i.intake_label
+                 FROM publication_intents i
+                 INNER JOIN factory_runs r ON r.run_id = i.run_id
+                 WHERE i.mode = ?1 AND i.status = ?2
+                 ORDER BY i.updated_at ASC",
+            )
+            .map_err(storage_error)?;
+        let rows = stmt
+            .query_map(
+                params![
+                    PublicationMode::Automatic.as_str(),
+                    PublicationStatus::Pending.as_str()
+                ],
+                |row| {
+                    Ok(PendingAutomaticDispatchGuard {
+                        forge_host: row.get(0)?,
+                        repository: row.get(1)?,
+                        issue_id: row.get(2)?,
+                        intake_label: row.get(3)?,
+                    })
+                },
+            )
+            .map_err(storage_error)?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(storage_error)
+    }
+
     fn update_publication_step(
         &mut self,
         intent_id: &str,
@@ -754,6 +851,72 @@ impl FactoryRunStore for SqliteFactoryStore {
                 ],
             )
             .map_err(storage_error)?;
+        Ok(())
+    }
+
+    fn record_publication_step(
+        &mut self,
+        intent_id: &str,
+        completed_step: &str,
+        status: PublicationStatus,
+        expected_projection: &serde_json::Value,
+    ) -> Result<()> {
+        let mut intent = select_publication_intent(&self.conn, intent_id)?;
+        if !completed_step.trim().is_empty()
+            && !intent
+                .completed_steps
+                .iter()
+                .any(|step| step == completed_step.trim())
+        {
+            intent
+                .completed_steps
+                .push(completed_step.trim().to_string());
+        }
+        let now_s = ts(Self::now());
+        self.conn
+            .execute(
+                "UPDATE publication_intents
+                 SET completed_steps_json = ?1, status = ?2, last_error_json = NULL,
+                     expected_projection_json = ?3, updated_at = ?4
+                 WHERE intent_id = ?5",
+                params![
+                    serde_json::to_string(&intent.completed_steps).map_err(storage_error)?,
+                    status.as_str(),
+                    bounded_json(expected_projection)?,
+                    now_s,
+                    intent_id,
+                ],
+            )
+            .map_err(storage_error)?;
+        Ok(())
+    }
+
+    fn set_publication_baseline(
+        &mut self,
+        intent_id: &str,
+        observed_baseline: &serde_json::Value,
+        expected_projection: &serde_json::Value,
+    ) -> Result<()> {
+        let now_s = ts(Self::now());
+        let changed = self
+            .conn
+            .execute(
+                "UPDATE publication_intents
+                 SET observed_baseline_json = ?1, expected_projection_json = ?2, updated_at = ?3
+                 WHERE intent_id = ?4",
+                params![
+                    bounded_json(observed_baseline)?,
+                    bounded_json(expected_projection)?,
+                    now_s,
+                    intent_id,
+                ],
+            )
+            .map_err(storage_error)?;
+        if changed == 0 {
+            return Err(SymphonyError::StorageError(format!(
+                "publication intent {intent_id} not found"
+            )));
+        }
         Ok(())
     }
 
@@ -1418,6 +1581,78 @@ mod tests {
             )
             .unwrap();
         assert!(store.list_pending_intents(10).unwrap().is_empty());
+    }
+
+    #[test]
+    fn lists_pending_automatic_dispatch_guards_only() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("state.db");
+        let mut store = store(&path);
+        let attempt = store
+            .claim_attempt(claim_request("issue-rev", "config-rev"))
+            .unwrap();
+        let artifact = store
+            .store_artifact(StoreArtifactRequest {
+                stage_run_id: attempt.stage_run_id,
+                issue_revision: "issue-rev".to_string(),
+                configuration_revision: "config-rev".to_string(),
+                route_mapping_hash: "routes".to_string(),
+                artifact: artifact(TriageRoute::Implement),
+                bytes_len: 200,
+                usage: StageUsage::default(),
+            })
+            .unwrap();
+
+        store
+            .create_publication_intent(CreatePublicationIntentRequest {
+                run_id: artifact.run_id.clone(),
+                artifact_id: Some(artifact.artifact_id.clone()),
+                mode: PublicationMode::Preview,
+                intake_label: "needs-triage".to_string(),
+                route_label: "ready-for-agent".to_string(),
+                project_state: Some("Todo".to_string()),
+                route_mapping_hash: "routes".to_string(),
+                desired_effects: serde_json::json!({"kind": "preview_comment"}),
+                observed_baseline: serde_json::json!({}),
+                expected_projection: serde_json::json!({}),
+            })
+            .unwrap();
+        assert!(store
+            .list_pending_automatic_dispatch_guards()
+            .unwrap()
+            .is_empty());
+
+        let automatic = store
+            .create_publication_intent(CreatePublicationIntentRequest {
+                run_id: artifact.run_id,
+                artifact_id: Some(artifact.artifact_id),
+                mode: PublicationMode::Automatic,
+                intake_label: "needs-triage".to_string(),
+                route_label: "ready-for-agent".to_string(),
+                project_state: Some("Todo".to_string()),
+                route_mapping_hash: "routes".to_string(),
+                desired_effects: serde_json::json!({"kind": "automatic_route"}),
+                observed_baseline: serde_json::json!({}),
+                expected_projection: serde_json::json!({}),
+            })
+            .unwrap();
+        let guards = store.list_pending_automatic_dispatch_guards().unwrap();
+        assert_eq!(guards.len(), 1);
+        assert_eq!(guards[0].issue_id, "123");
+        assert_eq!(guards[0].intake_label, "needs-triage");
+
+        store
+            .update_publication_step(
+                &automatic.intent_id,
+                "comment_applied",
+                PublicationStatus::Applied,
+                None,
+            )
+            .unwrap();
+        assert!(store
+            .list_pending_automatic_dispatch_guards()
+            .unwrap()
+            .is_empty());
     }
 
     #[test]

--- a/apps/symphony/src/triage/store.rs
+++ b/apps/symphony/src/triage/store.rs
@@ -123,9 +123,7 @@ pub trait FactoryRunStore {
     fn get_publication_intent(&self, intent_id: &str) -> Result<Option<PublicationIntentRecord>>;
     fn get_latest_publication(&self, run_id: &str) -> Result<Option<PublicationIntentRecord>>;
     fn list_pending_intents(&self, limit: usize) -> Result<Vec<PublicationIntentRecord>>;
-    fn list_pending_automatic_dispatch_guards(
-        &self,
-    ) -> Result<Vec<PendingAutomaticDispatchGuard>>;
+    fn list_pending_automatic_dispatch_guards(&self) -> Result<Vec<PendingAutomaticDispatchGuard>>;
     fn list_intents_for_run(&self, run_id: &str) -> Result<Vec<PublicationIntentRecord>>;
     fn list_verified_comment_identities(&self, run_id: &str) -> Result<Vec<StoredCommentIdentity>>;
     fn list_stage_attempts_for_revision(
@@ -783,9 +781,7 @@ impl FactoryRunStore for SqliteFactoryStore {
             .map_err(storage_error)
     }
 
-    fn list_pending_automatic_dispatch_guards(
-        &self,
-    ) -> Result<Vec<PendingAutomaticDispatchGuard>> {
+    fn list_pending_automatic_dispatch_guards(&self) -> Result<Vec<PendingAutomaticDispatchGuard>> {
         let mut stmt = self
             .conn
             .prepare(

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ Open Knowledge Format (OKF) bundle for the Kata monorepo: Kata CLI (`apps/cli`) 
 
 * [Symphony Software Factory Platform PRD](specs/symphony-software-factory-platform-prd.md) - product direction and vertical-slice roadmap (Active; A1 PR1 shipped)
 * [Specs roadmap](specs/) - active, planned, and completed work (links into historical Superpowers plans/specs)
-* [A1 GitHub Issue Triage](specs/2026-07-16-a1-github-issue-triage-design.md) - PR1 shipped; PR2 automatic routing implemented pending Verify
+* [A1 GitHub Issue Triage](specs/2026-07-16-a1-github-issue-triage-design.md) - PR1 shipped; PR2 automatic routing Verify accepted (merge pending)
 * [ADRs](adrs/) - architecture decision records ([ADR-0001](adrs/0001-a1-triage-durability-and-isolation.md))
 
 # Guides

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ Open Knowledge Format (OKF) bundle for the Kata monorepo: Kata CLI (`apps/cli`) 
 
 * [Symphony Software Factory Platform PRD](specs/symphony-software-factory-platform-prd.md) - product direction and vertical-slice roadmap (Active; A1 PR1 shipped)
 * [Specs roadmap](specs/) - active, planned, and completed work (links into historical Superpowers plans/specs)
-* [A1 GitHub Issue Triage](specs/2026-07-16-a1-github-issue-triage-design.md) - PR1 preview shipped; PR2 automatic routing next
+* [A1 GitHub Issue Triage](specs/2026-07-16-a1-github-issue-triage-design.md) - PR1 shipped; PR2 automatic routing implemented pending Verify
 * [ADRs](adrs/) - architecture decision records ([ADR-0001](adrs/0001-a1-triage-durability-and-isolation.md))
 
 # Guides

--- a/docs/log.md
+++ b/docs/log.md
@@ -1,7 +1,8 @@
 # Docs Update Log
 
 ## 2026-07-24
-* **A1 PR2 build**: Automatic route publication implemented pending Verify; added [build report](/specs/2026-07-24-a1-pr2-build-report.md) and updated [specs roadmap](/specs/index.md), [A1 design](/specs/2026-07-16-a1-github-issue-triage-design.md), and [factory PRD](/specs/symphony-software-factory-platform-prd.md).
+* **A1 PR2 Verify accepted**: Live UAT on `gannonh/uat-symphony` Project #16 + automated suite; [verify report](/specs/2026-07-24-a1-pr2-verify-report.md). Roadmap/PRD/A1 design mark PR2 verified (merge pending).
+* **A1 PR2 build**: Automatic route publication implemented; added [build report](/specs/2026-07-24-a1-pr2-build-report.md) and updated [specs roadmap](/specs/index.md), [A1 design](/specs/2026-07-16-a1-github-issue-triage-design.md), and [factory PRD](/specs/symphony-software-factory-platform-prd.md).
 
 ## 2026-07-18
 * **Release model**: Switched to dispatch-driven releases (kata-code style). Symphony binary + Pi extension ship together at one version via `symphony-release.yml` (manual stable/nightly + 3h scheduled nightly). CLI stays independent via manual `cli-release.yml`. Removed push-to-main path-filter releases and standalone `pi-symphony-extension-release.yml`.

--- a/docs/log.md
+++ b/docs/log.md
@@ -1,5 +1,8 @@
 # Docs Update Log
 
+## 2026-07-24
+* **A1 PR2 build**: Automatic route publication implemented pending Verify; added [build report](/specs/2026-07-24-a1-pr2-build-report.md) and updated [specs roadmap](/specs/index.md), [A1 design](/specs/2026-07-16-a1-github-issue-triage-design.md), and [factory PRD](/specs/symphony-software-factory-platform-prd.md).
+
 ## 2026-07-18
 * **Release model**: Switched to dispatch-driven releases (kata-code style). Symphony binary + Pi extension ship together at one version via `symphony-release.yml` (manual stable/nightly + 3h scheduled nightly). CLI stays independent via manual `cli-release.yml`. Removed push-to-main path-filter releases and standalone `pi-symphony-extension-release.yml`.
 * **A1 PR1 shipped**: Updated [A1 design](/specs/2026-07-16-a1-github-issue-triage-design.md), [factory PRD](/specs/symphony-software-factory-platform-prd.md), and [specs roadmap](/specs/index.md) after [#587](https://github.com/gannonh/kata-symphony/pull/587); added [ADR-0001](/adrs/0001-a1-triage-durability-and-isolation.md) for triage durability and isolation decisions.

--- a/docs/specs/2026-07-16-a1-github-issue-triage-design.md
+++ b/docs/specs/2026-07-16-a1-github-issue-triage-design.md
@@ -11,7 +11,7 @@ timestamp: 2026-07-18T16:45:00Z
 
 ## Status
 
-Active — **PR1 (triage preview) shipped** in [#587](https://github.com/gannonh/kata-symphony/pull/587) (`80b3c215`). PR2 (automatic route publication) and PR3 (recovery and agreement measurement) remain open.
+Active — **PR1 (triage preview) shipped** in [#587](https://github.com/gannonh/kata-symphony/pull/587) (`80b3c215`). **PR2 (automatic route publication) implemented pending Verify** ([build report](/specs/2026-07-24-a1-pr2-build-report.md)). PR3 (recovery and agreement measurement) remains open.
 
 Related decisions: [ADR-0001 A1 triage durability and isolation](/adrs/0001-a1-triage-durability-and-isolation.md).
 

--- a/docs/specs/2026-07-16-a1-github-issue-triage-design.md
+++ b/docs/specs/2026-07-16-a1-github-issue-triage-design.md
@@ -11,7 +11,7 @@ timestamp: 2026-07-18T16:45:00Z
 
 ## Status
 
-Active — **PR1 (triage preview) shipped** in [#587](https://github.com/gannonh/kata-symphony/pull/587) (`80b3c215`). **PR2 (automatic route publication) implemented pending Verify** ([build report](/specs/2026-07-24-a1-pr2-build-report.md)). PR3 (recovery and agreement measurement) remains open.
+Active — **PR1 (triage preview) shipped** in [#587](https://github.com/gannonh/kata-symphony/pull/587) (`80b3c215`). **PR2 (automatic route publication) Verify accepted** ([build](/specs/2026-07-24-a1-pr2-build-report.md), [verify](/specs/2026-07-24-a1-pr2-verify-report.md)); merge/PR pending. PR3 (recovery and agreement measurement) remains open.
 
 Related decisions: [ADR-0001 A1 triage durability and isolation](/adrs/0001-a1-triage-durability-and-isolation.md).
 

--- a/docs/specs/2026-07-24-a1-pr2-build-report.md
+++ b/docs/specs/2026-07-24-a1-pr2-build-report.md
@@ -1,24 +1,24 @@
 ---
 type: Build Report
 title: A1 PR2 Automatic Route Publication Build Report
-status: Implemented
+status: Verified
 description: Build completion report for A1 PR2 automatic route publication and implementation handoff.
 tags: [symphony, triage, a1, pr2]
-timestamp: 2026-07-24T16:30:00-07:00
+timestamp: 2026-07-24T17:16:00-07:00
 ---
 
 # A1 PR2 Automatic Route Publication — Build Report
 
 ## Status
 
-Implemented (pending Verify / UAT)
+Implemented — **Verify accepted** ([verify report](2026-07-24-a1-pr2-verify-report.md)); merge/PR pending
 
 ## Spec
 
 - Spec path: [`2026-07-16-a1-github-issue-triage-design.md`](2026-07-16-a1-github-issue-triage-design.md)
 - Scope: A1 PR2 delivery slice only (acceptance criteria 9–13 + automatic-publication portions of 14, 15, 17)
 - User approval: explicit Build go-ahead for existing Active A1 design PR2 slice
-- Non-goals: A1 PR3 correction reconciler / agreement metrics; live GitHub UAT evidence (Verify)
+- Non-goals: A1 PR3 correction reconciler / agreement metrics
 
 ## Git range
 
@@ -60,7 +60,7 @@ Results: **61** triage tests passed; **206** lib tests passed.
 
 - Bundled TDD workflow used for publisher vertical slices
 - Independent subagent review: **unavailable** (Task dispatch failed earlier); single-agent path used
-- Spec compliance (self-check): AC 9–13 covered in code/tests for publisher, promotion path, and dispatch guard; AC 18 UAT not run
+- Spec compliance (self-check): AC 9–13 covered in code/tests; live UAT completed on uat-symphony Project #16
 - Code quality (self-check): no Critical issues found; follow-ups below
 
 ## Approved deviations
@@ -69,11 +69,11 @@ Results: **61** triage tests passed; **206** lib tests passed.
 
 ## Known follow-ups
 
-- Manual GitHub UAT for promotion + implement handoff (AC 18 portion for PR2)
 - Broader orchestrator integration test that attaches a real/fake triage store and proves dispatch exclusion across config reload
+- Dedicated automated test for promotion hash matching (covered live)
 - A1 PR3: interrupted-process recovery hardening and agreement/correction measurement
 - Commit + PR when maintainer requests
 
 ## Build handoff to Verify
 
-Ready for Verify against PR2 acceptance criteria once the working tree is committed or explicitly accepted as the verification target.
+Verify report: [`2026-07-24-a1-pr2-verify-report.md`](2026-07-24-a1-pr2-verify-report.md).

--- a/docs/specs/2026-07-24-a1-pr2-build-report.md
+++ b/docs/specs/2026-07-24-a1-pr2-build-report.md
@@ -1,0 +1,79 @@
+---
+type: Build Report
+title: A1 PR2 Automatic Route Publication Build Report
+status: Implemented
+description: Build completion report for A1 PR2 automatic route publication and implementation handoff.
+tags: [symphony, triage, a1, pr2]
+timestamp: 2026-07-24T16:30:00-07:00
+---
+
+# A1 PR2 Automatic Route Publication — Build Report
+
+## Status
+
+Implemented (pending Verify / UAT)
+
+## Spec
+
+- Spec path: [`2026-07-16-a1-github-issue-triage-design.md`](2026-07-16-a1-github-issue-triage-design.md)
+- Scope: A1 PR2 delivery slice only (acceptance criteria 9–13 + automatic-publication portions of 14, 15, 17)
+- User approval: explicit Build go-ahead for existing Active A1 design PR2 slice
+- Non-goals: A1 PR3 correction reconciler / agreement metrics; live GitHub UAT evidence (Verify)
+
+## Git range
+
+- Base SHA: `bb43c63e24ae6b97e739893a486fb3869e47f80e`
+- Head SHA: working tree (uncommitted at report time)
+
+## Tasks completed
+
+1. Automatic publisher step machine with expected-projection crash recovery and human-conflict stop
+2. Automatic comment rendering (pending / route-effects / applied)
+3. Store APIs: `record_publication_step`, `set_publication_baseline`, `list_pending_automatic_dispatch_guards`
+4. Coordinator automatic mode + preview→automatic promotion when revision/mapping still match
+5. `GithubTriageRouting` for label and Projects v2 state mutations
+6. Implementation scheduler dispatch guard for nonterminal automatic publication intents
+
+## Files changed
+
+- `apps/symphony/src/triage/publisher.rs`
+- `apps/symphony/src/triage/comment.rs`
+- `apps/symphony/src/triage/coordinator.rs`
+- `apps/symphony/src/triage/domain.rs`
+- `apps/symphony/src/triage/store.rs`
+- `apps/symphony/src/triage/runtime.rs`
+- `apps/symphony/src/triage/routing.rs` (new)
+- `apps/symphony/src/triage/mod.rs`
+- `apps/symphony/src/orchestrator.rs`
+- `apps/symphony/Cargo.lock`
+
+## Tests and verification
+
+```bash
+cd apps/symphony && cargo test --lib triage::
+cd apps/symphony && cargo test --lib
+```
+
+Results: **61** triage tests passed; **206** lib tests passed.
+
+## Review gates
+
+- Bundled TDD workflow used for publisher vertical slices
+- Independent subagent review: **unavailable** (Task dispatch failed earlier); single-agent path used
+- Spec compliance (self-check): AC 9–13 covered in code/tests for publisher, promotion path, and dispatch guard; AC 18 UAT not run
+- Code quality (self-check): no Critical issues found; follow-ups below
+
+## Approved deviations
+
+- None
+
+## Known follow-ups
+
+- Manual GitHub UAT for promotion + implement handoff (AC 18 portion for PR2)
+- Broader orchestrator integration test that attaches a real/fake triage store and proves dispatch exclusion across config reload
+- A1 PR3: interrupted-process recovery hardening and agreement/correction measurement
+- Commit + PR when maintainer requests
+
+## Build handoff to Verify
+
+Ready for Verify against PR2 acceptance criteria once the working tree is committed or explicitly accepted as the verification target.

--- a/docs/specs/2026-07-24-a1-pr2-verify-report.md
+++ b/docs/specs/2026-07-24-a1-pr2-verify-report.md
@@ -1,0 +1,59 @@
+---
+type: Verify Report
+title: A1 PR2 Automatic Route Publication Verify Report
+status: Accepted
+description: Verify results for A1 PR2 automatic route publication against acceptance criteria 9–13 and related auto/handoff criteria.
+tags: [symphony, triage, a1, pr2, verify, uat]
+timestamp: 2026-07-24T17:16:00-07:00
+---
+
+# A1 PR2 Automatic Route Publication — Verify Report
+
+## Status
+
+**Accepted** (maintainer sign-off 2026-07-24) — automated suite + live GitHub UAT on the dedicated UAT project both Pass. Merge/PR still pending.
+
+## Spec / Build
+
+- Spec: [`2026-07-16-a1-github-issue-triage-design.md`](2026-07-16-a1-github-issue-triage-design.md) (PR2 slice)
+- Build: [`2026-07-24-a1-pr2-build-report.md`](2026-07-24-a1-pr2-build-report.md)
+
+## Environments
+
+| Layer | Target |
+| --- | --- |
+| Automated | `cargo test --lib` / `triage::` in this worktree |
+| Live UAT | `/Volumes/EVO/dev/uat-runs/kata-symphony` → `gannonh/uat-symphony` Project [#16](https://github.com/users/gannonh/projects/16) |
+
+## Results
+
+| AC | Result | Notes |
+| --- | --- | --- |
+| 9 | Pass | Preview→automatic promotion on #8/#9/#10 with **no second stage attempt** |
+| 10 | Pass | Live `completed_steps_json` shows full 7-step chain |
+| 11 | Pass | Automated publisher crash/conflict tests |
+| 12 | Pass | Guard tests + #10 only dispatched after publication applied |
+| 13 | Pass | Live needs-info comments include clarification questions |
+| 14 (auto) | Pass | Automated human-conflict test |
+| 15 (auto) | Pass | Live `triage_route_applied` events |
+| 17 (auto) | Pass | 61 triage / 206 lib tests |
+| 18 (promo/handoff) | Pass | #10 implement handoff completed by coding worker; #12 cold automatic |
+
+## Live fixtures
+
+- [#7](https://github.com/gannonh/uat-symphony/issues/7) — off-project diagnostic
+- [#8](https://github.com/gannonh/uat-symphony/issues/8), [#9](https://github.com/gannonh/uat-symphony/issues/9) — preview→auto `needs_information`
+- [#10](https://github.com/gannonh/uat-symphony/issues/10) — preview→auto `implement` + handoff
+- [#12](https://github.com/gannonh/uat-symphony/issues/12) — cold automatic publication
+
+Evidence bundle (gitignored): `uat-evidence/cli-a1-pr2-20260724/`.
+
+## Caveats
+
+- UAT workflow temporarily used `openrouter/anthropic/claude-sonnet-4` because `openai-codex` OAuth refresh failed and Anthropic OAuth reported out of extra usage.
+- Working tree still uncommitted at Verify time.
+- No dedicated automated unit test solely for promotion hash matching (covered live + coordinator code path).
+
+## Recommendation
+
+**Accepted.** Next: commit the working tree and open the PR2 merge PR when ready.

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -5,14 +5,13 @@ Roadmap for planned and completed work. Historical Superpowers designs and plans
 # Active
 
 * [Symphony Software Factory Platform PRD](symphony-software-factory-platform-prd.md) - product requirements and vertical-slice roadmap for the full software factory platform
-* [A1 GitHub Issue Triage](2026-07-16-a1-github-issue-triage-design.md) - Active design; **PR1 preview shipped** ([#587](https://github.com/gannonh/kata-symphony/pull/587)); next is PR2 automatic route publication, then PR3 recovery/agreement
+* [A1 GitHub Issue Triage](2026-07-16-a1-github-issue-triage-design.md) - Active design; **PR1 shipped**; **PR2 implemented pending Verify** ([build report](2026-07-24-a1-pr2-build-report.md)); PR3 recovery/agreement remains open
 * [A2 Spec Stage](2026-07-18-a2-spec-stage-design.md) - Draft design; spec-routed issues → draft/review/revise pipeline → published versioned spec → label-driven approval → implementation-ready run
 * [Pi Symphony Extension Design](../superpowers/specs/2026-05-14-pi-symphony-extension-design.md) - Pi extension to init, launch, monitor, and steer Symphony
 * [Wave 4 Shared Context and Diagnostics Plan](../superpowers/plans/2026-05-17-wave-4-symphony-shared-context-diagnostics.md) - dashboard parity for shared context + diagnostics
 
 # Planned
 
-* A1 PR2: automatic route publication and implement handoff (see [A1 design delivery slices](2026-07-16-a1-github-issue-triage-design.md#delivery-slices))
 * A1 PR3: recovery and agreement measurement
 
 # Blocked

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -5,7 +5,7 @@ Roadmap for planned and completed work. Historical Superpowers designs and plans
 # Active
 
 * [Symphony Software Factory Platform PRD](symphony-software-factory-platform-prd.md) - product requirements and vertical-slice roadmap for the full software factory platform
-* [A1 GitHub Issue Triage](2026-07-16-a1-github-issue-triage-design.md) - Active design; **PR1 shipped**; **PR2 implemented pending Verify** ([build report](2026-07-24-a1-pr2-build-report.md)); PR3 recovery/agreement remains open
+* [A1 GitHub Issue Triage](2026-07-16-a1-github-issue-triage-design.md) - Active design; **PR1 shipped**; **PR2 Verify accepted** (merge pending) ([build](2026-07-24-a1-pr2-build-report.md), [verify](2026-07-24-a1-pr2-verify-report.md)); PR3 recovery/agreement remains open
 * [A2 Spec Stage](2026-07-18-a2-spec-stage-design.md) - Draft design; spec-routed issues → draft/review/revise pipeline → published versioned spec → label-driven approval → implementation-ready run
 * [Pi Symphony Extension Design](../superpowers/specs/2026-05-14-pi-symphony-extension-design.md) - Pi extension to init, launch, monitor, and steer Symphony
 * [Wave 4 Shared Context and Diagnostics Plan](../superpowers/plans/2026-05-17-wave-4-symphony-shared-context-diagnostics.md) - dashboard parity for shared context + diagnostics
@@ -20,6 +20,7 @@ _None recorded._
 
 # Completed (recent)
 
+* A1 PR2 automatic route publication — Verify accepted on `uat-symphony` Project #16 ([verify](2026-07-24-a1-pr2-verify-report.md)); merge/PR pending
 * A1 PR1 triage preview — durable factory runs, intake, runner, preview comments, HTTP read API ([#587](https://github.com/gannonh/kata-symphony/pull/587); [ADR-0001](../adrs/0001-a1-triage-durability-and-isolation.md))
 
 # Completed (archived)

--- a/docs/specs/log.md
+++ b/docs/specs/log.md
@@ -1,5 +1,8 @@
 # Specs Update Log
 
+## 2026-07-24
+* **A1 PR2 build**: Automatic route publication + implement handoff implemented in Symphony triage/orchestrator; see [A1 PR2 build report](/specs/2026-07-24-a1-pr2-build-report.md). Roadmap marks PR2 pending Verify; PR3 remains planned.
+
 ## 2026-07-18
 * **A1 PR1 shipped**: Marked [A1 GitHub Issue Triage](/specs/2026-07-16-a1-github-issue-triage-design.md) Active with PR1 preview complete ([#587](https://github.com/gannonh/kata-symphony/pull/587)); roadmap lists PR2/PR3 as planned and PR1 under completed.
 * **PRD**: Updated [Symphony Software Factory Platform PRD](/specs/symphony-software-factory-platform-prd.md) to Active; A1 progress table and narrowed platform gaps for durable GitHub triage preview.

--- a/docs/specs/log.md
+++ b/docs/specs/log.md
@@ -1,7 +1,8 @@
 # Specs Update Log
 
 ## 2026-07-24
-* **A1 PR2 build**: Automatic route publication + implement handoff implemented in Symphony triage/orchestrator; see [A1 PR2 build report](/specs/2026-07-24-a1-pr2-build-report.md). Roadmap marks PR2 pending Verify; PR3 remains planned.
+* **A1 PR2 Verify accepted**: [Verify report](/specs/2026-07-24-a1-pr2-verify-report.md) signed off after live UAT on Project #16; PR2 merge still pending. PR3 remains planned.
+* **A1 PR2 build**: Automatic route publication + implement handoff implemented in Symphony triage/orchestrator; see [A1 PR2 build report](/specs/2026-07-24-a1-pr2-build-report.md).
 
 ## 2026-07-18
 * **A1 PR1 shipped**: Marked [A1 GitHub Issue Triage](/specs/2026-07-16-a1-github-issue-triage-design.md) Active with PR1 preview complete ([#587](https://github.com/gannonh/kata-symphony/pull/587)); roadmap lists PR2/PR3 as planned and PR1 under completed.

--- a/docs/specs/symphony-software-factory-platform-prd.md
+++ b/docs/specs/symphony-software-factory-platform-prd.md
@@ -215,7 +215,7 @@ A new GitHub or Linear issue triggers a triage stage. Symphony creates the minim
 | Slice | Status | Notes |
 | --- | --- | --- |
 | PR1 preview | **Shipped** | Intake label + Projects v2 membership, local Pi/Codex triage, immutable artifact, durable preview comment, factory-run HTTP read API, doctor/starter assets |
-| PR2 automatic route publication | **Implemented (pending Verify)** | Apply route labels/states, remove intake label, implement handoff ([build report](/specs/2026-07-24-a1-pr2-build-report.md)) |
+| PR2 automatic route publication | **Verify accepted** (merge pending) | Apply route labels/states, remove intake label, implement handoff ([build](/specs/2026-07-24-a1-pr2-build-report.md), [verify](/specs/2026-07-24-a1-pr2-verify-report.md)) |
 | PR3 recovery and agreement | Planned | Interrupted-process recovery, correction events, agreement metrics |
 | Linear triage | Deferred | Separate vertical slice after GitHub path is complete |
 

--- a/docs/specs/symphony-software-factory-platform-prd.md
+++ b/docs/specs/symphony-software-factory-platform-prd.md
@@ -215,7 +215,7 @@ A new GitHub or Linear issue triggers a triage stage. Symphony creates the minim
 | Slice | Status | Notes |
 | --- | --- | --- |
 | PR1 preview | **Shipped** | Intake label + Projects v2 membership, local Pi/Codex triage, immutable artifact, durable preview comment, factory-run HTTP read API, doctor/starter assets |
-| PR2 automatic route publication | Planned | Apply route labels/states, remove intake label, implement handoff |
+| PR2 automatic route publication | **Implemented (pending Verify)** | Apply route labels/states, remove intake label, implement handoff ([build report](/specs/2026-07-24-a1-pr2-build-report.md)) |
 | PR3 recovery and agreement | Planned | Interrupted-process recovery, correction events, agreement metrics |
 | Linear triage | Deferred | Separate vertical slice after GitHub path is complete |
 


### PR DESCRIPTION
## Summary
- Implement A1 PR2 automatic route publication: 7-step publisher, preview→automatic promotion, GitHub label/Projects v2 routing, and implementation dispatch guards until publication is applied.
- Add coordinator/runtime wiring plus triage store helpers for publication steps, baselines, and pending automatic guards.
- Record Build + Verify docs after live UAT on `gannonh/uat-symphony` Project #16 (Verify accepted; fixtures #7/#8/#9/#10/#12).

## Test plan
- [x] `cargo test --lib triage::` (61 passed)
- [x] `cargo test --lib` (206 passed earlier in session)
- [x] Live UAT: preview→automatic promotion without re-triage; cold automatic publication; implement handoff on Project #16
- [ ] CI `turbo run lint typecheck test --affected` on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic triage publishing with progress tracking and crash recovery.
  * Automatically applies configured issue labels and project states.
  * Added detailed triage comments showing routing, status, evidence, rationale, and next steps.
  * Added conflict detection and cleanup when issue state changes unexpectedly.

* **Bug Fixes**
  * Prevented issues with pending automatic triage updates from being dispatched.
  * Dispatch now fails closed when triage guard information cannot be read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds automatic triage route publication for Symphony. The main changes are:

- Seven-step automatic publishing for triage comments, route labels, project state, conflict cleanup, and intake-label removal.
- Preview-to-automatic promotion and crash recovery for stored triage artifacts.
- Durable dispatch guards for pending, conflicted, and blocked automatic publication intents.
- GitHub label and Projects v2 routing support for automatic publication.
- OKF/spec documentation and build/verify reports for the A1 PR2 workflow.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

This PR appears safe to merge based on the reviewed changes.

No blocking correctness or security issues were found in the changed automatic publication, routing, store, runtime, or dispatch-guard paths. The previously reported guard gaps are addressed by including conflict/blocked statuses and opening a guard-only store while triage is disabled.

**Files Needing Attention:** No files require special attention.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the narrow triage command for the locked cargo test lib and recorded the working directory, command output, exact totals, and exit code.
- Ran the broader library command (Symphony) to validate the locked library, and captured the working directory, command output, exact totals, and exit code.

<a href="https://app.greptile.com/trex/runs/15829436/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/symphony/src/main.rs | Attaches the durable triage dispatch guard store when triage runtime is disabled so pending automatic publications can still block dispatch. |
| apps/symphony/src/orchestrator.rs | Adds dispatch filtering for nonterminal automatic triage publications, including fail-closed store read handling and repository-qualified guard matching. |
| apps/symphony/src/triage/coordinator.rs | Wires automatic-mode intent creation, preview promotion, publication reconciliation, and applied/conflict/blocked event emission. |
| apps/symphony/src/triage/domain.rs | Introduces normalized managed-state projections for route labels and project status with tests for blank state handling. |
| apps/symphony/src/triage/publisher.rs | Implements the seven-step automatic publisher with idempotent comment updates, label/state mutations, conflict detection, crash recovery tests, and intake-label removal last. |
| apps/symphony/src/triage/routing.rs | Adds GitHub-backed routing operations for labels and Projects v2 status updates with repository-qualified project item selection. |
| apps/symphony/src/triage/runtime.rs | Adds routing-port construction and store-opening support for dispatch guards when triage is disabled. |
| apps/symphony/src/triage/store.rs | Extends publication store helpers for baselines, expected projections, comments, and automatic dispatch guards including conflict/blocked states. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
participant Coord as TriageCoordinator
participant Store as Factory Store
participant Pub as AutomaticPublisher
participant GH as GitHub Labels
participant PV2 as Projects v2
participant Orch as Orchestrator

Coord->>Store: create/resume automatic publication intent
Coord->>Pub: reconcile_automatic(intent, artifact)
Pub->>Store: record pending comment step
Pub->>GH: add route label
Pub->>PV2: set project state (if configured)
Pub->>GH: remove conflicting managed route labels
Pub->>Store: update expected projection after each step
Pub->>GH: remove intake label last
Pub->>Store: mark publication applied
Orch->>Store: read nonterminal automatic dispatch guards
Store-->>Orch: pending/conflict/blocked issue guards
Orch->>Orch: filter guarded issues before implementation dispatch
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(symphony): address PR #598 automatic..."](https://github.com/gannonh/kata-symphony/commit/b069344ca22572c72dc6f48f7479dd60627f8ef7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47162542)</sub>

<!-- /greptile_comment -->