### PR TITLE
feat(symphony): complete A1 PR3 recovery remediation

### DIFF
--- a/.agents/skills/uat-evidence/references/backend-config.md
+++ b/.agents/skills/uat-evidence/references/backend-config.md
@@ -104,6 +104,11 @@ node <skill-directory>/scripts/uat-evidence.mjs test --runtime symphony-runtime 
   --github-project-number 17
 ```
 
+Symphony evidence stores these effective coordinates in sanitized form. Later
+cleanup normally needs only `--evidence`; explicit repository overrides are
+required only for ambiguous legacy evidence and must agree with every created
+issue URL.
+
 ### Linear
 
 The runner needs:

--- a/.agents/skills/uat-evidence/references/evidence.md
+++ b/.agents/skills/uat-evidence/references/evidence.md
@@ -11,6 +11,7 @@ Evidence should include:
 
 - runtime identity
 - backend identity
+- sanitized effective backend configuration (coordinates and token environment-variable name, never a token value)
 - workspace
 - runtime root or binary path
 - git commit
@@ -22,6 +23,13 @@ Evidence should include:
 - provider read-back results
 - retry, warning, and skip records
 - cleanup status
+
+For Symphony GitHub evidence, cleanup resolves the repository from explicit
+cleanup overrides, then stored evidence configuration, then a unanimous
+repository parsed from legacy created-issue URLs. Every created issue URL is
+validated against that repository before the first provider read or mutation.
+Ambiguous or conflicting evidence fails closed instead of inheriting the
+current workspace's `WORKFLOW.md`.
 
 ## Kata CLI Pass Criteria
 

--- a/.agents/skills/uat-evidence/scripts/symphony-runtime-config.mjs
+++ b/.agents/skills/uat-evidence/scripts/symphony-runtime-config.mjs
@@ -1,0 +1,148 @@
+function nonEmpty(value) {
+  const text = String(value ?? "").trim();
+  return text || null;
+}
+
+function githubCreatedIssues(evidence) {
+  return [
+    evidence.created?.followupIssue,
+    evidence.created?.childIssue,
+    evidence.created?.issue,
+  ].filter(Boolean);
+}
+
+export function sanitizeRuntimeConfig(backend, config) {
+  if (backend === "github") {
+    const projectNumber = nonEmpty(config.projectNumber);
+    return {
+      repoOwner: nonEmpty(config.repoOwner),
+      repoName: nonEmpty(config.repoName),
+      projectOwner: nonEmpty(config.projectOwner),
+      projectOwnerType: nonEmpty(config.projectOwnerType),
+      projectNumber: projectNumber && Number.isFinite(Number(projectNumber))
+        ? Number(projectNumber)
+        : null,
+      tokenEnv: nonEmpty(config.tokenEnv),
+    };
+  }
+  if (backend === "linear") {
+    return {
+      projectSlug: nonEmpty(config.projectSlug),
+      workspaceSlug: nonEmpty(config.workspaceSlug),
+      tokenEnv: nonEmpty(config.tokenEnv),
+    };
+  }
+  throw new Error(`Unsupported evidence backend: ${backend}`);
+}
+
+export function parseGithubIssueRepository(url) {
+  const value = nonEmpty(url);
+  if (!value) return null;
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return null;
+  }
+  if (parsed.hostname.toLowerCase() !== "github.com") return null;
+  const match = parsed.pathname.match(/^\/([^/]+)\/([^/]+)\/issues\/(\d+)\/?$/);
+  if (!match) return null;
+  return {
+    repoOwner: decodeURIComponent(match[1]),
+    repoName: decodeURIComponent(match[2]),
+    number: Number(match[3]),
+  };
+}
+
+function explicitGithubRepository(args) {
+  const owner = nonEmpty(args.github_owner);
+  const name = nonEmpty(args.github_repo);
+  if (Boolean(owner) !== Boolean(name)) {
+    throw new Error("GitHub cleanup overrides require both --github-owner and --github-repo");
+  }
+  return owner && name ? { repoOwner: owner, repoName: name } : null;
+}
+
+function evidenceGithubRepository(evidence) {
+  const owner = nonEmpty(evidence.config?.repoOwner);
+  const name = nonEmpty(evidence.config?.repoName);
+  if (Boolean(owner) !== Boolean(name)) {
+    throw new Error("Evidence config must contain both repoOwner and repoName");
+  }
+  return owner && name ? { repoOwner: owner, repoName: name } : null;
+}
+
+function createdGithubRepositories(evidence) {
+  const issues = githubCreatedIssues(evidence);
+  const repositories = new Map();
+  for (const issue of issues) {
+    const url = issue.url ?? issue.html_url;
+    const parsed = parseGithubIssueRepository(url);
+    if (!parsed) {
+      throw new Error("Every created GitHub issue must have a canonical github.com issue URL");
+    }
+    const key = `${parsed.repoOwner.toLowerCase()}/${parsed.repoName.toLowerCase()}`;
+    repositories.set(key, {
+      repoOwner: parsed.repoOwner,
+      repoName: parsed.repoName,
+    });
+  }
+  if (repositories.size > 1) {
+    throw new Error(
+      `Created GitHub issues span conflicting repositories: ${[...repositories.keys()].join(", ")}`,
+    );
+  }
+  return repositories.values().next().value ?? null;
+}
+
+function sameRepository(left, right) {
+  return left.repoOwner.toLowerCase() === right.repoOwner.toLowerCase()
+    && left.repoName.toLowerCase() === right.repoName.toLowerCase();
+}
+
+export function resolveGithubCleanupConfig({ args = {}, evidence }) {
+  const explicit = explicitGithubRepository(args);
+  const stored = evidenceGithubRepository(evidence);
+  const created = createdGithubRepositories(evidence);
+  const resolved = explicit ?? stored ?? created;
+  if (!resolved) {
+    throw new Error(
+      "Unable to resolve GitHub cleanup repository; provide overrides or evidence config",
+    );
+  }
+
+  for (const [label, candidate] of [["evidence config", stored], ["created issue URLs", created]]) {
+    if (candidate && !sameRepository(resolved, candidate)) {
+      throw new Error(
+        `GitHub cleanup repository ${resolved.repoOwner}/${resolved.repoName} conflicts with ${label} ${candidate.repoOwner}/${candidate.repoName}`,
+      );
+    }
+  }
+
+  return {
+    ...sanitizeRuntimeConfig("github", evidence.config ?? {}),
+    repoOwner: resolved.repoOwner,
+    repoName: resolved.repoName,
+  };
+}
+
+export function validateGithubCleanupTargets({ evidence, config }) {
+  return githubCreatedIssues(evidence).map((issue) => {
+    const parsed = parseGithubIssueRepository(issue.url ?? issue.html_url);
+    if (!parsed) {
+      throw new Error("Every created GitHub issue must have a canonical github.com issue URL");
+    }
+    if (!sameRepository(config, parsed)) {
+      throw new Error(
+        `Created issue ${parsed.repoOwner}/${parsed.repoName}#${parsed.number} does not match cleanup repository ${config.repoOwner}/${config.repoName}`,
+      );
+    }
+    const recordedNumber = Number(issue.number ?? issue.id);
+    if (Number.isFinite(recordedNumber) && recordedNumber !== parsed.number) {
+      throw new Error(
+        `Created issue number ${recordedNumber} does not match its URL number ${parsed.number}`,
+      );
+    }
+    return { issue, number: parsed.number };
+  });
+}

--- a/.agents/skills/uat-evidence/scripts/symphony-runtime-config.test.mjs
+++ b/.agents/skills/uat-evidence/scripts/symphony-runtime-config.test.mjs
@@ -1,0 +1,180 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  resolveGithubCleanupConfig,
+  sanitizeRuntimeConfig,
+  validateGithubCleanupTargets,
+} from "./symphony-runtime-config.mjs";
+
+const githubIssue = (owner, repo, number) => ({
+  number,
+  title: `Symphony Backend UAT 20260725190000 #${number}`,
+  url: `https://github.com/${owner}/${repo}/issues/${number}`,
+});
+
+test("sanitized GitHub evidence records coordinates and token env name only", () => {
+  const config = sanitizeRuntimeConfig("github", {
+    repoOwner: "gannonh",
+    repoName: "uat-symphony",
+    projectOwner: "gannonh",
+    projectOwnerType: "user",
+    projectNumber: 16,
+    tokenEnv: "GH_TOKEN",
+    token: "must-not-serialize",
+  });
+
+  assert.deepEqual(config, {
+    repoOwner: "gannonh",
+    repoName: "uat-symphony",
+    projectOwner: "gannonh",
+    projectOwnerType: "user",
+    projectNumber: 16,
+    tokenEnv: "GH_TOKEN",
+  });
+  assert.equal(JSON.stringify(config).includes("must-not-serialize"), false);
+});
+
+test("sanitized Linear evidence records slugs and token env name only", () => {
+  assert.deepEqual(
+    sanitizeRuntimeConfig("linear", {
+      projectSlug: "kata",
+      workspaceSlug: "kata-sh",
+      tokenEnv: "LINEAR_API_KEY",
+      token: "must-not-serialize",
+    }),
+    {
+      projectSlug: "kata",
+      workspaceSlug: "kata-sh",
+      tokenEnv: "LINEAR_API_KEY",
+    },
+  );
+});
+
+test("cleanup resolves the repository from stored evidence config", () => {
+  const evidence = {
+    config: { repoOwner: "gannonh", repoName: "uat-symphony", projectNumber: 16 },
+    created: { issue: githubIssue("gannonh", "uat-symphony", 21) },
+  };
+
+  const config = resolveGithubCleanupConfig({ evidence });
+  assert.equal(config.repoOwner, "gannonh");
+  assert.equal(config.repoName, "uat-symphony");
+  assert.equal(config.projectNumber, 16);
+});
+
+test("legacy cleanup derives a unanimous repository from created issue URLs", () => {
+  const evidence = {
+    created: {
+      issue: githubIssue("gannonh", "uat-symphony", 21),
+      childIssue: githubIssue("gannonh", "uat-symphony", 22),
+    },
+  };
+
+  assert.deepEqual(resolveGithubCleanupConfig({ evidence }), {
+    repoOwner: "gannonh",
+    repoName: "uat-symphony",
+    projectOwner: null,
+    projectOwnerType: null,
+    projectNumber: null,
+    tokenEnv: null,
+  });
+});
+
+test("cleanup rejects created issues from conflicting repositories", () => {
+  const evidence = {
+    created: {
+      issue: githubIssue("gannonh", "uat-symphony", 21),
+      childIssue: githubIssue("gannonh", "kata-symphony", 22),
+    },
+  };
+
+  assert.throws(
+    () => resolveGithubCleanupConfig({ evidence }),
+    /span conflicting repositories/,
+  );
+});
+
+test("cleanup rejects explicit overrides that conflict with evidence", () => {
+  const evidence = {
+    config: { repoOwner: "gannonh", repoName: "uat-symphony" },
+    created: { issue: githubIssue("gannonh", "uat-symphony", 21) },
+  };
+
+  assert.throws(
+    () => resolveGithubCleanupConfig({
+      args: { github_owner: "gannonh", github_repo: "kata-symphony" },
+      evidence,
+    }),
+    /conflicts with evidence config/,
+  );
+});
+
+test("all cleanup targets are validated before provider work can begin", () => {
+  const evidence = {
+    config: { repoOwner: "gannonh", repoName: "uat-symphony" },
+    created: {
+      issue: githubIssue("gannonh", "uat-symphony", 21),
+      childIssue: githubIssue("someone", "elsewhere", 22),
+    },
+  };
+  let providerCalls = 0;
+
+  assert.throws(() => {
+    const config = {
+      repoOwner: evidence.config.repoOwner,
+      repoName: evidence.config.repoName,
+    };
+    validateGithubCleanupTargets({ evidence, config });
+    providerCalls += 1;
+  }, /does not match cleanup repository/);
+  assert.equal(providerCalls, 0);
+});
+
+test("cleanup rejects issue numbers that disagree with canonical URLs", () => {
+  const evidence = {
+    created: {
+      issue: {
+        ...githubIssue("gannonh", "uat-symphony", 21),
+        number: 99,
+      },
+    },
+  };
+  const config = resolveGithubCleanupConfig({ evidence });
+
+  assert.throws(
+    () => validateGithubCleanupTargets({ evidence, config }),
+    /does not match its URL number/,
+  );
+});
+
+test("ambiguous evidence without config or created records fails clearly", () => {
+  assert.throws(
+    () => resolveGithubCleanupConfig({ evidence: { created: {} } }),
+    /Unable to resolve GitHub cleanup repository/,
+  );
+});
+
+test("dry-run evidence uses the same sanitized config shape", () => {
+  const evidence = {
+    mode: "dry-run",
+    config: sanitizeRuntimeConfig("github", {
+      repoOwner: "gannonh",
+      repoName: "uat-symphony",
+      projectOwner: "gannonh",
+      projectOwnerType: "user",
+      projectNumber: 16,
+      tokenEnv: "GH_TOKEN",
+    }),
+  };
+
+  assert.equal(evidence.mode, "dry-run");
+  assert.equal(evidence.config.repoName, "uat-symphony");
+  assert.deepEqual(Object.keys(evidence.config).sort(), [
+    "projectNumber",
+    "projectOwner",
+    "projectOwnerType",
+    "repoName",
+    "repoOwner",
+    "tokenEnv",
+  ]);
+});

--- a/.agents/skills/uat-evidence/scripts/symphony-runtime.mjs
+++ b/.agents/skills/uat-evidence/scripts/symphony-runtime.mjs
@@ -8,6 +8,11 @@ import {
 } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  resolveGithubCleanupConfig,
+  sanitizeRuntimeConfig,
+  validateGithubCleanupTargets,
+} from "./symphony-runtime-config.mjs";
 
 const SKILL_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const PROMPT_FILES = [
@@ -111,6 +116,7 @@ async function testBackend(args) {
     runtime: "symphony-runtime",
     backend,
     mode: args.dry_run ? "dry-run" : "real",
+    config: sanitizeRuntimeConfig(backend, config),
     stamp,
     workspace,
     symphonyRoot,
@@ -574,9 +580,26 @@ async function cleanupRun(args) {
   }
 
   if (evidence.backend === "github") {
-    const config = githubConfig(args, workspace, env, evidence);
-    for (const issue of createdIssues) {
-      const number = issue.number ?? issue.id;
+    // Resolve and validate the complete target set before the first provider
+    // read or mutation. Cleanup must never inherit an ambient workflow repo.
+    const config = resolveGithubCleanupConfig({ args, evidence });
+    const targets = validateGithubCleanupTargets({ evidence, config });
+    cleanup.config = sanitizeRuntimeConfig("github", config);
+    if (args.dry_run) {
+      cleanup.actions = targets.map(({ number }) => ({
+        provider: "github",
+        issue: number,
+        action: "would-close",
+      }));
+      cleanup.completed = true;
+      evidence.cleanup = cleanup;
+      writeFileSync(evidencePath, `${JSON.stringify(evidence, null, 2)}\n`, "utf8");
+      const reportPath = path.join(path.dirname(evidencePath), "evidence.md");
+      writeFileSync(reportPath, evidenceMarkdown(evidence, evidencePath), "utf8");
+      console.log(JSON.stringify({ ok: true, dryRun: true, evidence: evidencePath, cleanup }, null, 2));
+      return;
+    }
+    for (const { issue, number } of targets) {
       const verified = verifyGithubCleanupIssue({ env, config, evidence, issue });
       if (!verified.ok) {
         cleanup.skipped.push({ provider: "github", issue: number, reason: verified.reason });
@@ -815,14 +838,14 @@ polling:
 `, "utf8");
 }
 
-function githubConfig(args, workspace, env, evidence = {}) {
+function githubConfig(args, workspace, env) {
   const workflow = readWorkflowConfig(path.join(workspace, ".symphony", "WORKFLOW.md"));
   return {
-    repoOwner: String(args.github_owner ?? evidence.config?.repoOwner ?? workflow.repo_owner ?? "gannonh"),
-    repoName: String(args.github_repo ?? evidence.config?.repoName ?? workflow.repo_name ?? "kata"),
-    projectOwner: String(args.github_project_owner ?? evidence.config?.projectOwner ?? workflow.github_project_owner ?? workflow.repo_owner ?? "gannonh"),
-    projectOwnerType: String(args.github_project_owner_type ?? evidence.config?.projectOwnerType ?? workflow.github_project_owner_type ?? "user"),
-    projectNumber: Number(args.github_project_number ?? evidence.config?.projectNumber ?? workflow.github_project_number ?? 17),
+    repoOwner: String(args.github_owner ?? workflow.repo_owner ?? "gannonh"),
+    repoName: String(args.github_repo ?? workflow.repo_name ?? "kata"),
+    projectOwner: String(args.github_project_owner ?? workflow.github_project_owner ?? workflow.repo_owner ?? "gannonh"),
+    projectOwnerType: String(args.github_project_owner_type ?? workflow.github_project_owner_type ?? "user"),
+    projectNumber: Number(args.github_project_number ?? workflow.github_project_number ?? 17),
     tokenEnv: env.GH_TOKEN ? "GH_TOKEN" : env.GITHUB_TOKEN ? "GITHUB_TOKEN" : null,
   };
 }

--- a/apps/symphony/docs/WORKFLOW-REFERENCE.md
+++ b/apps/symphony/docs/WORKFLOW-REFERENCE.md
@@ -508,10 +508,26 @@ server:
 # be distinct and must not equal `intake_label`. Optional `state` values must exist
 # on the Projects v2 Status field.
 #
+# Restart recovery: each poll interrupts attempts whose lease went stale, then
+# reclaims them. A recorded triage child is terminated only when its pid,
+# process group, OS start token and executable all still match, so a reused PID
+# is never signalled; otherwise Symphony skips the signal. The attempt's
+# disposable directory is removed before retry, and the attempt stays
+# interrupted so it still counts against `max_attempts`. Late output from an
+# interrupted attempt is rejected rather than recorded as success.
+#
+# Agreement measurement: after a route is published, Symphony re-reads the issue
+# from its durable record and compares current labels against the five route
+# labels stored on that publication, so reloading this file with a different
+# mapping cannot reinterpret an older publication. Replacing the route label
+# emits `triage_route_corrected` once per artifact and observed route. Zero or
+# several route labels is recorded as a durable `triage_route_consistency`
+# diagnostic instead, and is not counted as disagreement.
+#
 # HTTP (when the observability server is enabled):
 #   GET /api/v1/factory-runs/{run_id}
 #   GET /api/v1/factory-runs?issue={issue_identifier}
-#   GET /api/v1/factory-runs/metrics?stage=triage
+#   GET /api/v1/factory-runs/metrics?stage=triage   # includes correction_count / correction_rate
 #
 # triage:
 #   enabled: false

--- a/apps/symphony/docs/WORKFLOW-REFERENCE.md
+++ b/apps/symphony/docs/WORKFLOW-REFERENCE.md
@@ -510,9 +510,10 @@ server:
 #
 # Restart recovery: each poll interrupts attempts whose lease went stale, then
 # reclaims them. A recorded triage child is terminated only when its pid,
-# process group, OS start token and executable all still match, so a reused PID
-# is never signalled; otherwise Symphony skips the signal. The attempt's
-# disposable directory is removed before retry, and the attempt stays
+# process group, and OS start token still match, so a reused PID is never
+# signalled. The recorded executable is diagnostic because a launcher may
+# legitimately replace itself through `exec`; otherwise Symphony skips the
+# signal. The attempt's disposable directory is removed before retry, and the attempt stays
 # interrupted so it still counts against `max_attempts`. Late output from an
 # interrupted attempt is rejected rather than recorded as success.
 #

--- a/apps/symphony/src/triage/coordinator.rs
+++ b/apps/symphony/src/triage/coordinator.rs
@@ -25,11 +25,11 @@ use crate::triage::publisher::{
 use crate::triage::runner::{
     effective_pi_model, TriageHarness, TriageIssueIdentity, TriageProgress, TriageProgressSink,
     TriageRunner, TriageRunnerFailureKind, TriageRunnerOutcome, TriageRunnerRequest,
-    TriageRunnerSuccess,
+    TriageRunnerSuccess, TriageSpawnInfo,
 };
 use crate::triage::store::{
-    ClaimAttemptRequest, CreatePublicationIntentRequest, FactoryRunStore, StoreArtifactRequest,
-    UpsertFactoryRunRequest,
+    ClaimAttemptRequest, CreatePublicationIntentRequest, FactoryRunStore,
+    RecordAttemptProcessRequest, StoreArtifactRequest, UpsertFactoryRunRequest,
 };
 
 const PENDING_INTENT_BATCH: usize = 256;
@@ -602,9 +602,14 @@ where
             current_tool_args_preview: None,
             total_tokens: 0,
         });
+        // The spawn notification arrives on a channel because the runner holds
+        // no store handle; the lease-renewal loop drains it and persists the
+        // identity while the turn is still in flight.
+        let (spawn_tx, spawn_rx) = tokio::sync::mpsc::channel::<TriageSpawnInfo>(1);
         let outcome = self
             .execute_with_lease_renewal(
                 &stage.stage_run_id,
+                spawn_rx,
                 TriageRunnerRequest {
                     attempt_id: stage.stage_run_id.clone(),
                     workspace_root: workspace_root.to_path_buf(),
@@ -621,6 +626,9 @@ where
                     },
                     codex: (harness == TriageHarness::Codex).then(|| service.codex.clone()),
                     progress: self.progress_sink(&stage.stage_run_id),
+                    spawned: Some(Arc::new(move |info: TriageSpawnInfo| {
+                        let _ = spawn_tx.try_send(info);
+                    })),
                 },
             )
             .await;
@@ -677,6 +685,7 @@ where
     async fn execute_with_lease_renewal(
         &mut self,
         stage_run_id: &str,
+        mut spawned: tokio::sync::mpsc::Receiver<TriageSpawnInfo>,
         request: TriageRunnerRequest,
     ) -> Result<TriageRunnerOutcome> {
         let owner_instance = self.config.owner_instance.clone();
@@ -691,6 +700,23 @@ where
             tokio::select! {
                 biased;
                 outcome = &mut execute => return outcome,
+                Some(info) = spawned.recv() => {
+                    if let Err(err) = self.store.record_attempt_process(RecordAttemptProcessRequest {
+                        stage_run_id: stage_run_id.to_string(),
+                        owner_instance: owner_instance.clone(),
+                        identity: info.identity,
+                        workspace_path: Some(info.workspace_path.display().to_string()),
+                        output_path: Some(info.output_path.display().to_string()),
+                    }) {
+                        // Losing this record only costs a restart the ability to
+                        // reclaim the child, so warn instead of failing the turn.
+                        tracing::warn!(
+                            stage_run_id,
+                            error = %err,
+                            "failed to record triage attempt process identity"
+                        );
+                    }
+                }
                 _ = ticker.tick() => {
                     match self.store.renew_lease(stage_run_id, &owner_instance) {
                         Ok(true) => {}

--- a/apps/symphony/src/triage/coordinator.rs
+++ b/apps/symphony/src/triage/coordinator.rs
@@ -311,9 +311,10 @@ where
     /// Reclaim attempts a previous process abandoned.
     ///
     /// An interrupted attempt may still own a live child and a disposable
-    /// workspace. The child is signalled only when every recorded identity
-    /// field still matches the live process, so a reused PID is never killed;
-    /// the attempt directory is then removed so the retry starts clean. The
+    /// workspace. The child is signalled only when its PID, group, and OS start
+    /// token still match, so a reused PID is never killed. Its executable may
+    /// change legitimately through `exec` and is logged as diagnostic drift.
+    /// The attempt directory is then removed so the retry starts clean. The
     /// attempt itself stays interrupted and counts against `max_attempts`.
     async fn recover_interrupted_attempts(&mut self) -> Result<u32> {
         let attempts = self.store.list_recoverable_attempts()?;
@@ -321,19 +322,59 @@ where
 
         for attempt in attempts {
             if let Some(identity) = attempt.identity.as_ref() {
-                if process_identity::is_signalable(identity) {
-                    tracing::info!(
-                        stage_run_id = attempt.stage_run_id,
-                        process_group_id = identity.process_group_id,
-                        "terminating orphaned triage process group"
-                    );
-                    process_identity::terminate_process_group(identity.process_group_id).await;
-                } else {
-                    tracing::debug!(
+                match process_identity::assess_signalability(identity) {
+                    process_identity::Signalability::Authorized { executable } => {
+                        if let process_identity::ExecutableComparison::Changed { recorded, live } =
+                            &executable
+                        {
+                            tracing::info!(
+                                stage_run_id = attempt.stage_run_id,
+                                pid = identity.pid,
+                                recorded_executable =
+                                    recorded.as_deref().unwrap_or("<unavailable>"),
+                                live_executable = live.as_deref().unwrap_or("<unavailable>"),
+                                "triage child executable changed after spawn"
+                            );
+                        }
+                        tracing::info!(
+                            stage_run_id = attempt.stage_run_id,
+                            process_group_id = identity.process_group_id,
+                            "terminating orphaned triage process group"
+                        );
+                        match process_identity::terminate_process_group(identity).await {
+                            process_identity::TerminationOutcome::Terminated => {
+                                tracing::info!(
+                                    stage_run_id = attempt.stage_run_id,
+                                    process_group_id = identity.process_group_id,
+                                    "orphaned triage process group terminated"
+                                );
+                            }
+                            process_identity::TerminationOutcome::NoLongerSignalable(reason) => {
+                                tracing::warn!(
+                                    stage_run_id = attempt.stage_run_id,
+                                    pid = identity.pid,
+                                    process_group_id = identity.process_group_id,
+                                    reason = %reason,
+                                    "triage process identity changed before termination; signal skipped"
+                                );
+                            }
+                            process_identity::TerminationOutcome::StillRunning => {
+                                tracing::warn!(
+                                    stage_run_id = attempt.stage_run_id,
+                                    pid = identity.pid,
+                                    process_group_id = identity.process_group_id,
+                                    "orphaned triage process group remains live after bounded termination"
+                                );
+                            }
+                        }
+                    }
+                    process_identity::Signalability::Denied(reason) => tracing::warn!(
                         stage_run_id = attempt.stage_run_id,
                         pid = identity.pid,
-                        "skipping signal; recorded triage process identity no longer matches"
-                    );
+                        process_group_id = identity.process_group_id,
+                        reason = %reason,
+                        "skipping orphan signal; recorded triage process identity is not signalable"
+                    ),
                 }
             }
 
@@ -2112,25 +2153,18 @@ mod tests {
         let workflow_dir = prep_workflow(&temp);
         let mut store = open_store(&temp);
 
-        // Stand in for the orphaned triage child left behind by a prior process.
-        // Spawned and reaped through std so the assertion does not depend on
-        // which tokio runtime happens to receive SIGCHLD.
-        let mut orphan = {
-            use std::os::unix::process::CommandExt;
-            let mut command = std::process::Command::new("sleep");
-            command.arg("60").process_group(0);
-            command.spawn().unwrap()
-        };
-        let identity = crate::triage::process_identity::capture_child(orphan.id(), true);
-        // A real orphan predates this process by a restart. Wait for the child
-        // to finish entering its own group so the test observes that settled
-        // state rather than the instant after fork.
-        for _ in 0..100 {
-            if crate::triage::process_identity::matches(&identity) {
-                break;
+        // Capture a shell launcher, then let it replace itself with the worker.
+        // This is the live failure shape that previously made executable
+        // equality reject a legitimate orphan.
+        let mut orphan = crate::triage::process_identity::ExecTransitionChild::spawn();
+        let identity = orphan.identity().clone();
+        orphan.release_and_wait_for_exec();
+        assert!(matches!(
+            crate::triage::process_identity::assess_signalability(&identity),
+            crate::triage::process_identity::Signalability::Authorized {
+                executable: crate::triage::process_identity::ExecutableComparison::Changed { .. }
             }
-            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
-        }
+        ));
 
         let attempt_root = temp.path().join("workspaces").join("triage-stale-attempt");
         let workspace_path = attempt_root.join("workspace");
@@ -2203,24 +2237,15 @@ mod tests {
             "precondition: the interrupted attempt must be recoverable work"
         );
 
-        // Reap concurrently: a real orphan is reparented to init and reaped
-        // there, so recovery sees it disappear. Left unreaped here it would
-        // linger as a zombie and only die at the force-kill deadline.
-        let (reaped_tx, reaped_rx) = std::sync::mpsc::channel();
-        std::thread::spawn(move || {
-            let status = orphan.wait();
-            let _ = reaped_tx.send(status.is_ok());
-        });
-
         coordinator
             .poll_once(&service_config(true, &workflow_dir))
             .await
             .unwrap();
 
-        let reaped = reaped_rx
-            .recv_timeout(std::time::Duration::from_secs(30))
-            .expect("orphaned child must be terminated by recovery");
-        assert!(reaped);
+        assert!(
+            orphan.wait_for_exit(),
+            "orphaned child must be terminated and reaped by recovery"
+        );
         assert!(
             !attempt_root.exists(),
             "attempt directory must be reclaimed before retry"
@@ -2237,6 +2262,12 @@ mod tests {
             crate::triage::domain::StageStatus::Interrupted,
             "recovery must not resurrect the attempt"
         );
+        assert_eq!(stage.pid, None);
+        assert_eq!(stage.process_group_id, None);
+        assert_eq!(stage.process_start_token, None);
+        assert_eq!(stage.executable_identity, None);
+        assert_eq!(stage.workspace_path, None);
+        assert_eq!(stage.output_path, None);
         assert!(coordinator
             .store_mut()
             .list_recoverable_attempts()

--- a/apps/symphony/src/triage/coordinator.rs
+++ b/apps/symphony/src/triage/coordinator.rs
@@ -9,6 +9,7 @@ use crate::domain::{AgentBackend, Issue, ServiceConfig, TriageSessionInfo, Triag
 use crate::error::{Result, SymphonyError};
 use crate::path_safety;
 use crate::repo_url::repo_is_remote;
+use crate::triage::correction::{compare_route_labels, RouteAgreement, ROUTE_KEYS};
 use crate::triage::domain::{
     FactoryError, FactoryEventRecord, FactoryRunStatus, PublicationMode, PublicationStatus,
     TriageMode, TRIAGE_LEASE_RENEW_INTERVAL_MS, TRIAGE_STAGE_NAME,
@@ -30,10 +31,15 @@ use crate::triage::runner::{
 };
 use crate::triage::store::{
     ClaimAttemptRequest, CreatePublicationIntentRequest, FactoryRunStore,
-    RecordAttemptProcessRequest, StoreArtifactRequest, UpsertFactoryRunRequest,
+    RecordAttemptProcessRequest, RouteObservationKind, StoreArtifactRequest,
+    UpsertFactoryRunRequest,
 };
 
 const PENDING_INTENT_BATCH: usize = 256;
+const CORRECTION_BATCH: usize = 256;
+/// Durable-only diagnostic. Deliberately outside the live triage event
+/// vocabulary, which the spec fixes to nine names.
+const TRIAGE_ROUTE_CONSISTENCY_EVENT: &str = "triage_route_consistency";
 const INELIGIBLE_REMEDIATION: &str =
     "Add the issue to the configured GitHub Project, then leave the intake label in place.";
 const DESIRED_KIND_PREVIEW: &str = "preview_comment";
@@ -81,6 +87,7 @@ pub struct TriagePollSummary {
     pub skipped: u32,
     pub reconciled_intents: u32,
     pub recovered_attempts: u32,
+    pub route_corrections: u32,
 }
 
 pub struct TriageCoordinator<S, I, C, X = DefaultTriageExecutor> {
@@ -226,6 +233,9 @@ where
         summary.reconciled_intents = self
             .reconcile_pending_intents(service, self.max_pages)
             .await?;
+        // Runs whether or not intake is enabled: published routes stay under
+        // measurement even after triage is switched off.
+        summary.route_corrections = self.reconcile_route_corrections().await?;
 
         if !service.triage.enabled {
             return Ok(summary);
@@ -356,6 +366,128 @@ where
         }
 
         Ok(recovered)
+    }
+
+    /// Measure whether humans kept or changed the routes Symphony published.
+    ///
+    /// Published issues are re-read from durable records, independently of the
+    /// intake and implementation-candidate queries, and compared against the
+    /// five route labels recorded on their publication intent. A correction is
+    /// recorded at most once per artifact and observed route.
+    async fn reconcile_route_corrections(&mut self) -> Result<u32> {
+        let Some(routing) = self.routing.clone() else {
+            return Ok(0);
+        };
+        let candidates = self.store.list_correction_candidates(CORRECTION_BATCH)?;
+        let mut corrections = 0;
+
+        for candidate in candidates {
+            let Some(recorded_labels) =
+                route_labels_from_desired_effects(&candidate.desired_effects)
+            else {
+                continue;
+            };
+            let issue_number = match parse_issue_number(&candidate.issue_id) {
+                Ok(number) => number,
+                Err(err) => {
+                    tracing::warn!(
+                        issue = candidate.issue_identifier,
+                        error = %err,
+                        "skipping correction check for unparsable durable issue id"
+                    );
+                    continue;
+                }
+            };
+
+            let current_labels = match routing.list_issue_labels(issue_number).await {
+                Ok(labels) => labels,
+                Err(err) => {
+                    // A transient read failure must not look like agreement;
+                    // the next poll retries this candidate.
+                    tracing::warn!(
+                        issue = candidate.issue_identifier,
+                        error = %err,
+                        "failed to read issue labels for correction measurement"
+                    );
+                    continue;
+                }
+            };
+
+            // Re-applied intake means a fresh triage attempt is coming, so the
+            // published route is no longer the decision under measurement.
+            if current_labels.iter().any(|label| {
+                label
+                    .trim()
+                    .eq_ignore_ascii_case(candidate.intake_label.trim())
+            }) {
+                continue;
+            }
+
+            match compare_route_labels(
+                &candidate.published_route,
+                &recorded_labels,
+                &current_labels,
+            ) {
+                RouteAgreement::Agreed => {}
+                RouteAgreement::Corrected { route, label } => {
+                    if self.store.record_route_observation(
+                        &candidate.artifact_id,
+                        RouteObservationKind::Corrected,
+                        &route,
+                    )? {
+                        self.emit_event(
+                            "triage_route_corrected",
+                            Some(&candidate.issue_identifier),
+                            Some(&candidate.run_id),
+                            candidate.stage_run_id.as_deref(),
+                            serde_json::json!({
+                                "run_id": candidate.run_id,
+                                "stage_run_id": candidate.stage_run_id,
+                                "artifact_id": candidate.artifact_id,
+                                "publication_intent_id": candidate.intent_id,
+                                "route": candidate.published_route,
+                                "corrected_route": route,
+                                "corrected_label": label,
+                                "status": "corrected",
+                                "error_code": serde_json::Value::Null,
+                            }),
+                        )?;
+                        corrections += 1;
+                    }
+                }
+                RouteAgreement::Inconsistent { observed } => {
+                    // Durable diagnostic only: an ambiguous label set is not an
+                    // agreement result and must not reach the live event
+                    // vocabulary or the correction count.
+                    let value = observed.join(",");
+                    if self.store.record_route_observation(
+                        &candidate.artifact_id,
+                        RouteObservationKind::Inconsistent,
+                        &value,
+                    )? {
+                        self.store.record_event(FactoryEventRecord {
+                            event_id: Uuid::now_v7().to_string(),
+                            run_id: Some(candidate.run_id.clone()),
+                            stage_run_id: candidate.stage_run_id.clone(),
+                            event_type: TRIAGE_ROUTE_CONSISTENCY_EVENT.to_string(),
+                            timestamp: Utc::now(),
+                            payload: serde_json::json!({
+                                "run_id": candidate.run_id,
+                                "stage_run_id": candidate.stage_run_id,
+                                "artifact_id": candidate.artifact_id,
+                                "publication_intent_id": candidate.intent_id,
+                                "route": candidate.published_route,
+                                "observed_route_labels": observed,
+                                "status": "inconsistent",
+                                "error_code": "route_label_inconsistent",
+                            }),
+                        })?;
+                    }
+                }
+            }
+        }
+
+        Ok(corrections)
     }
 
     async fn reconcile_pending_intents(
@@ -1441,16 +1573,17 @@ fn desired_kind(value: &serde_json::Value) -> Option<&str> {
 fn managed_labels_from_automatic_intent(
     intent: &crate::triage::domain::PublicationIntentRecord,
 ) -> Option<Vec<String>> {
-    let labels = intent.desired_effects.get("route_labels")?.as_object()?;
-    let keys = [
-        "implement",
-        "spec",
-        "needs_information",
-        "park",
-        "human_owned",
-    ];
-    let mut out = Vec::with_capacity(keys.len());
-    for key in keys {
+    route_labels_from_desired_effects(&intent.desired_effects)
+}
+
+/// The five route labels an automatic intent recorded, in [`ROUTE_KEYS`] order.
+///
+/// Publication and correction measurement both read the mapping from here so a
+/// live `WORKFLOW.md` reload cannot reinterpret an existing publication.
+fn route_labels_from_desired_effects(desired_effects: &serde_json::Value) -> Option<Vec<String>> {
+    let labels = desired_effects.get("route_labels")?.as_object()?;
+    let mut out = Vec::with_capacity(ROUTE_KEYS.len());
+    for key in ROUTE_KEYS {
         let label = labels.get(key)?.as_str()?.trim();
         if label.is_empty() {
             return None;
@@ -1980,12 +2113,24 @@ mod tests {
         let mut store = open_store(&temp);
 
         // Stand in for the orphaned triage child left behind by a prior process.
-        let mut orphan = tokio::process::Command::new("sleep")
-            .arg("60")
-            .process_group(0)
-            .spawn()
-            .unwrap();
-        let identity = crate::triage::process_identity::capture(orphan.id().expect("orphan pid"));
+        // Spawned and reaped through std so the assertion does not depend on
+        // which tokio runtime happens to receive SIGCHLD.
+        let mut orphan = {
+            use std::os::unix::process::CommandExt;
+            let mut command = std::process::Command::new("sleep");
+            command.arg("60").process_group(0);
+            command.spawn().unwrap()
+        };
+        let identity = crate::triage::process_identity::capture_child(orphan.id(), true);
+        // A real orphan predates this process by a restart. Wait for the child
+        // to finish entering its own group so the test observes that settled
+        // state rather than the instant after fork.
+        for _ in 0..100 {
+            if crate::triage::process_identity::matches(&identity) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
 
         let attempt_root = temp.path().join("workspaces").join("triage-stale-attempt");
         let workspace_path = attempt_root.join("workspace");
@@ -2015,7 +2160,7 @@ mod tests {
             .record_attempt_process(RecordAttemptProcessRequest {
                 stage_run_id: stage.stage_run_id.clone(),
                 owner_instance: "prior-owner".to_string(),
-                identity,
+                identity: identity.clone(),
                 workspace_path: Some(workspace_path.display().to_string()),
                 output_path: Some(
                     attempt_root
@@ -2044,15 +2189,38 @@ mod tests {
             FakeExecutor::success(sample_artifact()),
         );
 
+        assert!(
+            crate::triage::process_identity::is_signalable(&identity),
+            "precondition: the orphan must be identifiable and signalable"
+        );
+        assert_eq!(
+            coordinator
+                .store_mut()
+                .list_recoverable_attempts()
+                .unwrap()
+                .len(),
+            1,
+            "precondition: the interrupted attempt must be recoverable work"
+        );
+
+        // Reap concurrently: a real orphan is reparented to init and reaped
+        // there, so recovery sees it disappear. Left unreaped here it would
+        // linger as a zombie and only die at the force-kill deadline.
+        let (reaped_tx, reaped_rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let status = orphan.wait();
+            let _ = reaped_tx.send(status.is_ok());
+        });
+
         coordinator
             .poll_once(&service_config(true, &workflow_dir))
             .await
             .unwrap();
 
-        let status = tokio::time::timeout(std::time::Duration::from_secs(10), orphan.wait())
-            .await
+        let reaped = reaped_rx
+            .recv_timeout(std::time::Duration::from_secs(30))
             .expect("orphaned child must be terminated by recovery");
-        assert!(status.is_ok());
+        assert!(reaped);
         assert!(
             !attempt_root.exists(),
             "attempt directory must be reclaimed before retry"
@@ -2074,6 +2242,296 @@ mod tests {
             .list_recoverable_attempts()
             .unwrap()
             .is_empty());
+    }
+
+    #[derive(Default)]
+    struct FakeRouting {
+        labels: Mutex<Vec<String>>,
+    }
+
+    #[async_trait]
+    impl TriageRoutingPort for Arc<FakeRouting> {
+        async fn list_issue_labels(&self, _issue_number: u64) -> Result<Vec<String>> {
+            Ok(self.labels.lock().unwrap().clone())
+        }
+
+        async fn issue_project_state(&self, _issue_number: u64) -> Result<Option<String>> {
+            Ok(None)
+        }
+
+        async fn add_issue_label(&self, _issue_number: u64, _label: &str) -> Result<()> {
+            Ok(())
+        }
+
+        async fn remove_issue_label(&self, _issue_number: u64, _label: &str) -> Result<()> {
+            Ok(())
+        }
+
+        async fn set_issue_project_state(&self, _issue_number: u64, _state: &str) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    /// Build an applied automatic publication so correction measurement has a
+    /// published route to compare against.
+    fn seed_applied_automatic_publication(
+        store: &mut SqliteFactoryStore,
+        service: &ServiceConfig,
+        issue_number: u64,
+    ) -> String {
+        let stage = store
+            .claim_attempt(ClaimAttemptRequest {
+                forge_host: "github.com".to_string(),
+                repository: "owner/repo".to_string(),
+                issue_id: issue_number.to_string(),
+                issue_identifier: format!("#{issue_number}"),
+                issue_revision: "rev".to_string(),
+                configuration_revision: "config".to_string(),
+                owner_instance: "test-owner".to_string(),
+                harness: "pi".to_string(),
+                model: None,
+                workspace_path: None,
+                output_path: None,
+                pid: None,
+                process_group_id: None,
+                process_start_token: None,
+                executable_identity: None,
+            })
+            .unwrap();
+        let artifact = store
+            .store_artifact(StoreArtifactRequest {
+                stage_run_id: stage.stage_run_id.clone(),
+                issue_revision: "rev".to_string(),
+                configuration_revision: "config".to_string(),
+                route_mapping_hash: "routes".to_string(),
+                artifact: sample_artifact(),
+                bytes_len: 200,
+                usage: crate::triage::domain::StageUsage::default(),
+            })
+            .unwrap();
+        let routes = &service.triage.routes;
+        let intent = store
+            .create_publication_intent(CreatePublicationIntentRequest {
+                run_id: artifact.run_id.clone(),
+                artifact_id: Some(artifact.artifact_id.clone()),
+                mode: PublicationMode::Automatic,
+                intake_label: service.triage.intake_label.clone(),
+                route_label: routes.implement.label.clone(),
+                project_state: routes.implement.state.clone(),
+                route_mapping_hash: "routes".to_string(),
+                desired_effects: serde_json::json!({
+                    "kind": DESIRED_KIND_AUTOMATIC,
+                    "route": "implement",
+                    "route_labels": {
+                        "implement": routes.implement.label.clone(),
+                        "spec": routes.spec.label.clone(),
+                        "needs_information": routes.needs_information.label.clone(),
+                        "park": routes.park.label.clone(),
+                        "human_owned": routes.human_owned.label.clone(),
+                    },
+                }),
+                observed_baseline: serde_json::json!({}),
+                expected_projection: serde_json::json!({}),
+            })
+            .unwrap();
+        store
+            .update_publication_step(
+                &intent.intent_id,
+                "comment_applied",
+                PublicationStatus::Applied,
+                None,
+            )
+            .unwrap();
+        artifact.artifact_id
+    }
+
+    /// A maintainer replacing Symphony's route label is the disagreement signal
+    /// A1 measures. It must be recorded exactly once no matter how often the
+    /// reconciler re-reads the issue, otherwise the correction rate inflates on
+    /// every poll.
+    #[tokio::test]
+    async fn human_route_swap_records_one_correction_across_repeated_polls() {
+        let temp = tempfile::tempdir().unwrap();
+        let workflow_dir = prep_workflow(&temp);
+        let service = service_config(true, &workflow_dir);
+        let mut store = open_store(&temp);
+        seed_applied_automatic_publication(&mut store, &service, 42);
+
+        // Maintainer swapped ready-for-agent for needs-info.
+        let routing = Arc::new(FakeRouting {
+            labels: Mutex::new(vec!["needs-info".to_string(), "bug".to_string()]),
+        });
+        let emitter = Arc::new(RecordingEmitter::default());
+        let mut coordinator = TriageCoordinator::with_executor(
+            store,
+            Arc::new(FakeIntake::default()),
+            FakeComments::new("symphony-bot"),
+            TriageCoordinatorConfig {
+                forge_host: "github.com".to_string(),
+                repository: "owner/repo".to_string(),
+                owner_instance: "test-owner".to_string(),
+                workflow_dir: workflow_dir.clone(),
+                project_display_name: "Factory".to_string(),
+            },
+            FakeExecutor::success(sample_artifact()),
+        )
+        .with_routing(routing.clone())
+        .with_events(emitter.clone());
+
+        let first = coordinator.poll_once(&service).await.unwrap();
+        let second = coordinator.poll_once(&service).await.unwrap();
+
+        assert_eq!(first.route_corrections, 1);
+        assert_eq!(second.route_corrections, 0, "correction must not repeat");
+        let corrected: Vec<_> = emitter
+            .events
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|(name, _)| name == "triage_route_corrected")
+            .cloned()
+            .collect();
+        assert_eq!(corrected.len(), 1);
+        assert_eq!(corrected[0].1.as_deref(), Some("#42"));
+    }
+
+    /// Leaving Symphony's label in place is agreement, so nothing is recorded.
+    #[tokio::test]
+    async fn unchanged_route_label_records_no_correction() {
+        let temp = tempfile::tempdir().unwrap();
+        let workflow_dir = prep_workflow(&temp);
+        let service = service_config(true, &workflow_dir);
+        let mut store = open_store(&temp);
+        seed_applied_automatic_publication(&mut store, &service, 43);
+
+        let routing = Arc::new(FakeRouting {
+            labels: Mutex::new(vec!["ready-for-agent".to_string()]),
+        });
+        let emitter = Arc::new(RecordingEmitter::default());
+        let mut coordinator = TriageCoordinator::with_executor(
+            store,
+            Arc::new(FakeIntake::default()),
+            FakeComments::new("symphony-bot"),
+            TriageCoordinatorConfig {
+                forge_host: "github.com".to_string(),
+                repository: "owner/repo".to_string(),
+                owner_instance: "test-owner".to_string(),
+                workflow_dir: workflow_dir.clone(),
+                project_display_name: "Factory".to_string(),
+            },
+            FakeExecutor::success(sample_artifact()),
+        )
+        .with_routing(routing.clone())
+        .with_events(emitter.clone());
+
+        let summary = coordinator.poll_once(&service).await.unwrap();
+
+        assert_eq!(summary.route_corrections, 0);
+        assert!(!emitter
+            .events
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|(name, _)| name == "triage_route_corrected"));
+    }
+
+    /// Two route labels at once is a diagnostic, not disagreement. It must stay
+    /// out of the live event vocabulary and out of the correction count, while
+    /// still being durable for operators.
+    #[tokio::test]
+    async fn ambiguous_route_labels_record_durable_diagnostic_only() {
+        let temp = tempfile::tempdir().unwrap();
+        let workflow_dir = prep_workflow(&temp);
+        let service = service_config(true, &workflow_dir);
+        let mut store = open_store(&temp);
+        seed_applied_automatic_publication(&mut store, &service, 44);
+
+        let routing = Arc::new(FakeRouting {
+            labels: Mutex::new(vec![
+                "ready-for-agent".to_string(),
+                "needs-info".to_string(),
+            ]),
+        });
+        let emitter = Arc::new(RecordingEmitter::default());
+        let mut coordinator = TriageCoordinator::with_executor(
+            store,
+            Arc::new(FakeIntake::default()),
+            FakeComments::new("symphony-bot"),
+            TriageCoordinatorConfig {
+                forge_host: "github.com".to_string(),
+                repository: "owner/repo".to_string(),
+                owner_instance: "test-owner".to_string(),
+                workflow_dir: workflow_dir.clone(),
+                project_display_name: "Factory".to_string(),
+            },
+            FakeExecutor::success(sample_artifact()),
+        )
+        .with_routing(routing.clone())
+        .with_events(emitter.clone());
+
+        let summary = coordinator.poll_once(&service).await.unwrap();
+
+        assert_eq!(
+            summary.route_corrections, 0,
+            "ambiguity is not a correction"
+        );
+        let live = emitter.events.lock().unwrap();
+        assert!(
+            !live
+                .iter()
+                .any(|(name, _)| name == "triage_route_corrected"),
+            "ambiguity must not be counted as disagreement"
+        );
+        assert!(
+            !live
+                .iter()
+                .any(|(name, _)| name == TRIAGE_ROUTE_CONSISTENCY_EVENT),
+            "consistency diagnostics stay out of the live event vocabulary"
+        );
+        assert_eq!(
+            coordinator
+                .store_mut()
+                .triage_metrics()
+                .unwrap()
+                .correction_count,
+            0
+        );
+    }
+
+    /// Re-applying the intake label means a new triage attempt is coming, so the
+    /// old published route is no longer the decision under measurement.
+    #[tokio::test]
+    async fn reapplied_intake_label_suspends_correction_measurement() {
+        let temp = tempfile::tempdir().unwrap();
+        let workflow_dir = prep_workflow(&temp);
+        let service = service_config(true, &workflow_dir);
+        let mut store = open_store(&temp);
+        seed_applied_automatic_publication(&mut store, &service, 45);
+
+        let routing = Arc::new(FakeRouting {
+            labels: Mutex::new(vec![
+                "needs-info".to_string(),
+                service.triage.intake_label.clone(),
+            ]),
+        });
+        let mut coordinator = TriageCoordinator::with_executor(
+            store,
+            Arc::new(FakeIntake::default()),
+            FakeComments::new("symphony-bot"),
+            TriageCoordinatorConfig {
+                forge_host: "github.com".to_string(),
+                repository: "owner/repo".to_string(),
+                owner_instance: "test-owner".to_string(),
+                workflow_dir: workflow_dir.clone(),
+                project_display_name: "Factory".to_string(),
+            },
+            FakeExecutor::success(sample_artifact()),
+        )
+        .with_routing(routing.clone());
+
+        let summary = coordinator.poll_once(&service).await.unwrap();
+
+        assert_eq!(summary.route_corrections, 0);
     }
 
     #[tokio::test]

--- a/apps/symphony/src/triage/coordinator.rs
+++ b/apps/symphony/src/triage/coordinator.rs
@@ -18,6 +18,7 @@ use crate::triage::fingerprint::{
     IssueCommentFingerprint, IssueMilestoneFingerprint, IssueRevisionInput, VerifiedTriageComment,
 };
 use crate::triage::intake::{TriageIntakeIssue, TriageIntakePort};
+use crate::triage::process_identity;
 use crate::triage::publisher::{
     AutomaticPublishRequest, AutomaticPublisher, IneligiblePublishRequest, PreviewPublishRequest,
     PreviewPublisher, TriageCommentPort, TriageRoutingPort,
@@ -79,6 +80,7 @@ pub struct TriagePollSummary {
     pub ineligible: u32,
     pub skipped: u32,
     pub reconciled_intents: u32,
+    pub recovered_attempts: u32,
 }
 
 pub struct TriageCoordinator<S, I, C, X = DefaultTriageExecutor> {
@@ -220,6 +222,7 @@ where
         };
 
         self.store.interrupt_stale_attempts()?;
+        summary.recovered_attempts = self.recover_interrupted_attempts().await?;
         summary.reconciled_intents = self
             .reconcile_pending_intents(service, self.max_pages)
             .await?;
@@ -293,6 +296,66 @@ where
         }
 
         Ok(summary)
+    }
+
+    /// Reclaim attempts a previous process abandoned.
+    ///
+    /// An interrupted attempt may still own a live child and a disposable
+    /// workspace. The child is signalled only when every recorded identity
+    /// field still matches the live process, so a reused PID is never killed;
+    /// the attempt directory is then removed so the retry starts clean. The
+    /// attempt itself stays interrupted and counts against `max_attempts`.
+    async fn recover_interrupted_attempts(&mut self) -> Result<u32> {
+        let attempts = self.store.list_recoverable_attempts()?;
+        let mut recovered = 0;
+
+        for attempt in attempts {
+            if let Some(identity) = attempt.identity.as_ref() {
+                if process_identity::is_signalable(identity) {
+                    tracing::info!(
+                        stage_run_id = attempt.stage_run_id,
+                        process_group_id = identity.process_group_id,
+                        "terminating orphaned triage process group"
+                    );
+                    process_identity::terminate_process_group(identity.process_group_id).await;
+                } else {
+                    tracing::debug!(
+                        stage_run_id = attempt.stage_run_id,
+                        pid = identity.pid,
+                        "skipping signal; recorded triage process identity no longer matches"
+                    );
+                }
+            }
+
+            if let Some(workspace) = attempt.workspace_path.as_deref() {
+                match process_identity::attempt_root_for_cleanup(Path::new(workspace)) {
+                    Some(root) => {
+                        if let Err(err) = std::fs::remove_dir_all(&root) {
+                            if err.kind() != std::io::ErrorKind::NotFound {
+                                // Report rather than swallow: a workspace we
+                                // cannot reclaim is operator-visible disk leak.
+                                tracing::warn!(
+                                    stage_run_id = attempt.stage_run_id,
+                                    path = %root.display(),
+                                    error = %err,
+                                    "failed to remove interrupted triage attempt directory"
+                                );
+                            }
+                        }
+                    }
+                    None => tracing::warn!(
+                        stage_run_id = attempt.stage_run_id,
+                        path = workspace,
+                        "recorded triage workspace is not an attempt directory; not removing"
+                    ),
+                }
+            }
+
+            self.store.clear_attempt_process(&attempt.stage_run_id)?;
+            recovered += 1;
+        }
+
+        Ok(recovered)
     }
 
     async fn reconcile_pending_intents(
@@ -1904,6 +1967,113 @@ mod tests {
             stages[0].status,
             crate::triage::domain::StageStatus::Interrupted
         );
+    }
+
+    /// After a crash the previous process's triage child can still be running
+    /// against a workspace this process is about to reclaim. A poll must kill
+    /// the recorded process group and delete the attempt directory, so the
+    /// retry starts from a clean workspace instead of racing a live agent.
+    #[tokio::test]
+    async fn recovery_terminates_orphaned_child_and_removes_attempt_directory() {
+        let temp = tempfile::tempdir().unwrap();
+        let workflow_dir = prep_workflow(&temp);
+        let mut store = open_store(&temp);
+
+        // Stand in for the orphaned triage child left behind by a prior process.
+        let mut orphan = tokio::process::Command::new("sleep")
+            .arg("60")
+            .process_group(0)
+            .spawn()
+            .unwrap();
+        let identity = crate::triage::process_identity::capture(orphan.id().expect("orphan pid"));
+
+        let attempt_root = temp.path().join("workspaces").join("triage-stale-attempt");
+        let workspace_path = attempt_root.join("workspace");
+        std::fs::create_dir_all(&workspace_path).unwrap();
+        std::fs::write(workspace_path.join("README.md"), "clone\n").unwrap();
+
+        let stage = store
+            .claim_attempt(ClaimAttemptRequest {
+                forge_host: "github.com".to_string(),
+                repository: "owner/repo".to_string(),
+                issue_id: "77".to_string(),
+                issue_identifier: "#77".to_string(),
+                issue_revision: "rev".to_string(),
+                configuration_revision: "config".to_string(),
+                owner_instance: "prior-owner".to_string(),
+                harness: "pi".to_string(),
+                model: None,
+                workspace_path: None,
+                output_path: None,
+                pid: None,
+                process_group_id: None,
+                process_start_token: None,
+                executable_identity: None,
+            })
+            .unwrap();
+        store
+            .record_attempt_process(RecordAttemptProcessRequest {
+                stage_run_id: stage.stage_run_id.clone(),
+                owner_instance: "prior-owner".to_string(),
+                identity,
+                workspace_path: Some(workspace_path.display().to_string()),
+                output_path: Some(
+                    attempt_root
+                        .join("stage-output")
+                        .join("result.json")
+                        .display()
+                        .to_string(),
+                ),
+            })
+            .unwrap();
+        store
+            .interrupt_attempt(&stage.stage_run_id, "prior-owner")
+            .unwrap();
+
+        let mut coordinator = TriageCoordinator::with_executor(
+            store,
+            Arc::new(FakeIntake::default()),
+            FakeComments::new("symphony-bot"),
+            TriageCoordinatorConfig {
+                forge_host: "github.com".to_string(),
+                repository: "owner/repo".to_string(),
+                owner_instance: "new-owner".to_string(),
+                workflow_dir: workflow_dir.clone(),
+                project_display_name: "Factory".to_string(),
+            },
+            FakeExecutor::success(sample_artifact()),
+        );
+
+        coordinator
+            .poll_once(&service_config(true, &workflow_dir))
+            .await
+            .unwrap();
+
+        let status = tokio::time::timeout(std::time::Duration::from_secs(10), orphan.wait())
+            .await
+            .expect("orphaned child must be terminated by recovery");
+        assert!(status.is_ok());
+        assert!(
+            !attempt_root.exists(),
+            "attempt directory must be reclaimed before retry"
+        );
+
+        // Cleared so a later poll does not try to reclaim the same attempt.
+        let stage = coordinator
+            .store_mut()
+            .get_stage_run(&stage.stage_run_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            stage.status,
+            crate::triage::domain::StageStatus::Interrupted,
+            "recovery must not resurrect the attempt"
+        );
+        assert!(coordinator
+            .store_mut()
+            .list_recoverable_attempts()
+            .unwrap()
+            .is_empty());
     }
 
     #[tokio::test]

--- a/apps/symphony/src/triage/coordinator.rs
+++ b/apps/symphony/src/triage/coordinator.rs
@@ -2393,6 +2393,12 @@ mod tests {
             .collect();
         assert_eq!(corrected.len(), 1);
         assert_eq!(corrected[0].1.as_deref(), Some("#42"));
+
+        // The agreement metrics on the read surface come from the same durable
+        // events, so repeated polling must not inflate them either.
+        let metrics = coordinator.store_mut().triage_metrics().unwrap();
+        assert_eq!(metrics.correction_count, 1);
+        assert_eq!(metrics.correction_rate, 1.0);
     }
 
     /// Leaving Symphony's label in place is agreement, so nothing is recorded.

--- a/apps/symphony/src/triage/coordinator.rs
+++ b/apps/symphony/src/triage/coordinator.rs
@@ -390,10 +390,8 @@ where
                         }
                     }
                     process_identity::Signalability::Denied(reason) => {
-                        let gone = matches!(
-                            reason,
-                            process_identity::SignalBlockReason::ProcessNotFound
-                        );
+                        let gone =
+                            matches!(reason, process_identity::SignalBlockReason::ProcessNotFound);
                         if gone {
                             tracing::info!(
                                 stage_run_id = attempt.stage_run_id,

--- a/apps/symphony/src/triage/coordinator.rs
+++ b/apps/symphony/src/triage/coordinator.rs
@@ -229,7 +229,7 @@ where
         };
 
         self.store.interrupt_stale_attempts()?;
-        summary.recovered_attempts = self.recover_interrupted_attempts().await?;
+        summary.recovered_attempts = self.recover_interrupted_attempts(service).await?;
         summary.reconciled_intents = self
             .reconcile_pending_intents(service, self.max_pages)
             .await?;
@@ -314,15 +314,29 @@ where
     /// workspace. The child is signalled only when its PID, group, and OS start
     /// token still match, so a reused PID is never killed. Its executable may
     /// change legitimately through `exec` and is logged as diagnostic drift.
-    /// The attempt directory is then removed so the retry starts clean. The
-    /// attempt itself stays interrupted and counts against `max_attempts`.
-    async fn recover_interrupted_attempts(&mut self) -> Result<u32> {
+    /// Workspace cleanup and clearing the durable process record happen only
+    /// after the orphan is confirmed gone (terminated or no longer present),
+    /// so a still-live child keeps its identity for a later poll. The attempt
+    /// itself stays interrupted and counts against `max_attempts`.
+    async fn recover_interrupted_attempts(&mut self, service: &ServiceConfig) -> Result<u32> {
         let attempts = self.store.list_recoverable_attempts()?;
+        let workspace_root = match resolve_workspace_path(&service.workspace.root, "workspace.root")
+        {
+            Ok(root) => root,
+            Err(err) => {
+                tracing::warn!(
+                    error = %err,
+                    "skipping interrupted-attempt recovery; workspace.root is not usable"
+                );
+                return Ok(0);
+            }
+        };
         let mut recovered = 0;
 
         for attempt in attempts {
+            let mut reclaim = true;
             if let Some(identity) = attempt.identity.as_ref() {
-                match process_identity::assess_signalability(identity) {
+                reclaim = match process_identity::assess_signalability(identity) {
                     process_identity::Signalability::Authorized { executable } => {
                         if let process_identity::ExecutableComparison::Changed { recorded, live } =
                             &executable
@@ -348,8 +362,13 @@ where
                                     process_group_id = identity.process_group_id,
                                     "orphaned triage process group terminated"
                                 );
+                                true
                             }
                             process_identity::TerminationOutcome::NoLongerSignalable(reason) => {
+                                let gone = matches!(
+                                    reason,
+                                    process_identity::SignalBlockReason::ProcessNotFound
+                                );
                                 tracing::warn!(
                                     stage_run_id = attempt.stage_run_id,
                                     pid = identity.pid,
@@ -357,29 +376,55 @@ where
                                     reason = %reason,
                                     "triage process identity changed before termination; signal skipped"
                                 );
+                                gone
                             }
                             process_identity::TerminationOutcome::StillRunning => {
                                 tracing::warn!(
                                     stage_run_id = attempt.stage_run_id,
                                     pid = identity.pid,
                                     process_group_id = identity.process_group_id,
-                                    "orphaned triage process group remains live after bounded termination"
+                                    "orphaned triage process group remains live after bounded termination; retaining process record"
                                 );
+                                false
                             }
                         }
                     }
-                    process_identity::Signalability::Denied(reason) => tracing::warn!(
-                        stage_run_id = attempt.stage_run_id,
-                        pid = identity.pid,
-                        process_group_id = identity.process_group_id,
-                        reason = %reason,
-                        "skipping orphan signal; recorded triage process identity is not signalable"
-                    ),
-                }
+                    process_identity::Signalability::Denied(reason) => {
+                        let gone = matches!(
+                            reason,
+                            process_identity::SignalBlockReason::ProcessNotFound
+                        );
+                        if gone {
+                            tracing::info!(
+                                stage_run_id = attempt.stage_run_id,
+                                pid = identity.pid,
+                                process_group_id = identity.process_group_id,
+                                "recorded triage process is already gone; reclaiming attempt directory"
+                            );
+                        } else {
+                            tracing::warn!(
+                                stage_run_id = attempt.stage_run_id,
+                                pid = identity.pid,
+                                process_group_id = identity.process_group_id,
+                                reason = %reason,
+                                "skipping orphan reclaim; recorded triage process identity is not signalable"
+                            );
+                        }
+                        gone
+                    }
+                };
+            }
+
+            if !reclaim {
+                continue;
             }
 
             if let Some(workspace) = attempt.workspace_path.as_deref() {
-                match process_identity::attempt_root_for_cleanup(Path::new(workspace)) {
+                match process_identity::attempt_root_for_cleanup(
+                    Path::new(workspace),
+                    &workspace_root,
+                    &attempt.stage_run_id,
+                ) {
                     Some(root) => {
                         if let Err(err) = std::fs::remove_dir_all(&root) {
                             if err.kind() != std::io::ErrorKind::NotFound {
@@ -397,7 +442,8 @@ where
                     None => tracing::warn!(
                         stage_run_id = attempt.stage_run_id,
                         path = workspace,
-                        "recorded triage workspace is not an attempt directory; not removing"
+                        workspace_root = %workspace_root.display(),
+                        "recorded triage workspace is not an attempt directory under workspace.root; not removing"
                     ),
                 }
             }
@@ -2166,11 +2212,6 @@ mod tests {
             }
         ));
 
-        let attempt_root = temp.path().join("workspaces").join("triage-stale-attempt");
-        let workspace_path = attempt_root.join("workspace");
-        std::fs::create_dir_all(&workspace_path).unwrap();
-        std::fs::write(workspace_path.join("README.md"), "clone\n").unwrap();
-
         let stage = store
             .claim_attempt(ClaimAttemptRequest {
                 forge_host: "github.com".to_string(),
@@ -2190,6 +2231,14 @@ mod tests {
                 executable_identity: None,
             })
             .unwrap();
+        // Mirror the runner layout: triage-<stage_run_id> under workspace.root.
+        let attempt_root = workflow_dir
+            .join("workspaces")
+            .join(format!("triage-{}", stage.stage_run_id));
+        let workspace_path = attempt_root.join("workspace");
+        std::fs::create_dir_all(&workspace_path).unwrap();
+        std::fs::write(workspace_path.join("README.md"), "clone\n").unwrap();
+
         store
             .record_attempt_process(RecordAttemptProcessRequest {
                 stage_run_id: stage.stage_run_id.clone(),

--- a/apps/symphony/src/triage/correction.rs
+++ b/apps/symphony/src/triage/correction.rs
@@ -12,8 +12,8 @@
 //! Correction is a proxy for disagreement. Absence of a correction does not
 //! prove the route was right.
 
-/// Canonical routes in the order [`route_labels_in_canonical_order`] records
-/// them on a publication intent.
+/// Canonical routes in the order an automatic publication intent records its
+/// route labels.
 pub const ROUTE_KEYS: [&str; 5] = [
     "implement",
     "spec",

--- a/apps/symphony/src/triage/correction.rs
+++ b/apps/symphony/src/triage/correction.rs
@@ -1,0 +1,183 @@
+//! Human route correction measurement.
+//!
+//! After Symphony publishes a route, a maintainer may disagree and swap the
+//! route label by hand. Comparing the labels currently on the issue against the
+//! five labels recorded on that publication turns the disagreement into a
+//! measurable signal.
+//!
+//! The comparison always uses the mapping recorded on the publication intent,
+//! never the live configuration, so reloading `WORKFLOW.md` with a different
+//! route mapping cannot retroactively reinterpret an older publication.
+//!
+//! Correction is a proxy for disagreement. Absence of a correction does not
+//! prove the route was right.
+
+/// Canonical routes in the order [`route_labels_in_canonical_order`] records
+/// them on a publication intent.
+pub const ROUTE_KEYS: [&str; 5] = [
+    "implement",
+    "spec",
+    "needs_information",
+    "park",
+    "human_owned",
+];
+
+/// Outcome of comparing an issue's current labels with a published route.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RouteAgreement {
+    /// The published route label is still the only managed route label present.
+    Agreed,
+    /// Exactly one managed route label is present and it is a different route.
+    Corrected { route: String, label: String },
+    /// Zero or several managed route labels are present, so the issue's route
+    /// is ambiguous. This is a diagnostic, not an agreement observation.
+    Inconsistent { observed: Vec<String> },
+}
+
+/// Compare an issue's current labels against a recorded publication.
+///
+/// `recorded_labels` holds the five route labels in [`ROUTE_KEYS`] order as
+/// captured when the route was published.
+pub fn compare_route_labels(
+    published_route: &str,
+    recorded_labels: &[String],
+    current_labels: &[String],
+) -> RouteAgreement {
+    if recorded_labels.len() != ROUTE_KEYS.len() {
+        return RouteAgreement::Inconsistent {
+            observed: Vec::new(),
+        };
+    }
+
+    let current: Vec<String> = current_labels
+        .iter()
+        .map(|label| normalize(label))
+        .collect();
+    let mut present: Vec<(usize, String)> = Vec::new();
+    for (index, recorded) in recorded_labels.iter().enumerate() {
+        let recorded = normalize(recorded);
+        if recorded.is_empty() {
+            continue;
+        }
+        // A route mapped to the same label twice must not count twice.
+        if present.iter().any(|(_, label)| *label == recorded) {
+            continue;
+        }
+        if current.contains(&recorded) {
+            present.push((index, recorded));
+        }
+    }
+
+    match present.as_slice() {
+        [(index, label)] => {
+            let route = ROUTE_KEYS[*index];
+            if route.eq_ignore_ascii_case(published_route.trim()) {
+                RouteAgreement::Agreed
+            } else {
+                RouteAgreement::Corrected {
+                    route: route.to_string(),
+                    label: label.clone(),
+                }
+            }
+        }
+        observed => RouteAgreement::Inconsistent {
+            observed: observed.iter().map(|(_, label)| label.clone()).collect(),
+        },
+    }
+}
+
+fn normalize(label: &str) -> String {
+    label.trim().to_ascii_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn recorded() -> Vec<String> {
+        vec![
+            "ready-for-agent".to_string(),
+            "ready-to-spec".to_string(),
+            "needs-info".to_string(),
+            "wait-to-implement".to_string(),
+            "ready-for-human".to_string(),
+        ]
+    }
+
+    /// The published label still standing alone means the maintainer left the
+    /// decision in place, which must not be counted as disagreement.
+    #[test]
+    fn published_label_left_in_place_is_agreement() {
+        let agreement = compare_route_labels(
+            "implement",
+            &recorded(),
+            &["ready-for-agent".to_string(), "bug".to_string()],
+        );
+
+        assert_eq!(agreement, RouteAgreement::Agreed);
+    }
+
+    /// A maintainer swapping the route label is the disagreement signal A1
+    /// exists to measure.
+    #[test]
+    fn swapped_route_label_is_a_correction() {
+        let agreement = compare_route_labels(
+            "implement",
+            &recorded(),
+            &["needs-info".to_string(), "bug".to_string()],
+        );
+
+        assert_eq!(
+            agreement,
+            RouteAgreement::Corrected {
+                route: "needs_information".to_string(),
+                label: "needs-info".to_string(),
+            }
+        );
+    }
+
+    /// Label comparison must survive GitHub casing and padding differences,
+    /// otherwise a cosmetic difference would read as a route change.
+    #[test]
+    fn label_comparison_ignores_case_and_padding() {
+        let agreement = compare_route_labels(
+            "implement",
+            &recorded(),
+            &["  Ready-For-Agent ".to_string()],
+        );
+
+        assert_eq!(agreement, RouteAgreement::Agreed);
+    }
+
+    /// Two route labels at once means the issue has no single route, so calling
+    /// either one a correction would invent a decision nobody made.
+    #[test]
+    fn multiple_route_labels_are_inconsistent_not_a_correction() {
+        let agreement = compare_route_labels(
+            "implement",
+            &recorded(),
+            &["ready-for-agent".to_string(), "needs-info".to_string()],
+        );
+
+        assert_eq!(
+            agreement,
+            RouteAgreement::Inconsistent {
+                observed: vec!["ready-for-agent".to_string(), "needs-info".to_string()],
+            }
+        );
+    }
+
+    /// Every route label removed is equally ambiguous: the route was erased,
+    /// not corrected to something else.
+    #[test]
+    fn no_route_label_is_inconsistent() {
+        let agreement = compare_route_labels("implement", &recorded(), &["bug".to_string()]);
+
+        assert_eq!(
+            agreement,
+            RouteAgreement::Inconsistent {
+                observed: Vec::new(),
+            }
+        );
+    }
+}

--- a/apps/symphony/src/triage/migrations/002_route_observations.sql
+++ b/apps/symphony/src/triage/migrations/002_route_observations.sql
@@ -1,0 +1,13 @@
+-- Post-publication route observations.
+--
+-- The primary key makes correction measurement idempotent: the reconciler runs
+-- on every poll, but a given artifact records a given corrected route (or a
+-- given inconsistent label set) exactly once, so repeated polling cannot
+-- inflate the correction count.
+CREATE TABLE IF NOT EXISTS route_observations (
+  artifact_id TEXT NOT NULL REFERENCES triage_artifacts(artifact_id) ON DELETE CASCADE,
+  kind TEXT NOT NULL,
+  value TEXT NOT NULL,
+  observed_at TEXT NOT NULL,
+  PRIMARY KEY (artifact_id, kind, value)
+);

--- a/apps/symphony/src/triage/mod.rs
+++ b/apps/symphony/src/triage/mod.rs
@@ -1,6 +1,7 @@
 pub mod artifact;
 pub mod comment;
 pub mod coordinator;
+pub mod correction;
 pub mod domain;
 pub mod fingerprint;
 pub mod intake;

--- a/apps/symphony/src/triage/mod.rs
+++ b/apps/symphony/src/triage/mod.rs
@@ -5,6 +5,7 @@ pub mod domain;
 pub mod fingerprint;
 pub mod intake;
 pub mod integrity;
+pub mod process_identity;
 pub mod publisher;
 pub mod routing;
 pub mod runner;

--- a/apps/symphony/src/triage/process_identity.rs
+++ b/apps/symphony/src/triage/process_identity.rs
@@ -7,7 +7,7 @@
 //! the child was running. Signalling only happens when every recorded field
 //! still matches the live process.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Identity of a spawned triage child, captured immediately after spawn.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -122,22 +122,51 @@ fn ps_field(pid: i64, format: &str) -> Option<String> {
     (!value.is_empty()).then_some(value)
 }
 
-/// Remove an abandoned attempt's disposable directories before it is retried.
+/// Directory name prefix the runner gives every attempt's disposable root.
+pub const ATTEMPT_DIR_PREFIX: &str = "triage-";
+
+/// The attempt root holding a recorded workspace, or `None` when the recorded
+/// path is not one the triage runner created.
 ///
-/// Errors are returned rather than swallowed so recovery can report a workspace
-/// it failed to reclaim instead of silently leaking it.
-pub fn remove_attempt_paths(paths: &[&Path]) -> std::io::Result<()> {
-    for path in paths {
-        if !path.exists() {
-            continue;
+/// Cleanup deletes recursively, so it only ever accepts a directory named
+/// `triage-<attempt id>`. A stale, hand-edited, or corrupted `workspace_path`
+/// therefore cannot make recovery delete a real repository or the workspace
+/// root itself.
+pub fn attempt_root_for_cleanup(workspace_path: &Path) -> Option<PathBuf> {
+    let root = workspace_path.parent()?;
+    let name = root.file_name()?.to_str()?;
+    name.starts_with(ATTEMPT_DIR_PREFIX)
+        .then(|| root.to_path_buf())
+}
+
+/// Send a bounded termination to `process_group_id`: `SIGTERM`, then `SIGKILL`
+/// if the group is still alive after [`FORCE_KILL_WAIT`].
+pub async fn terminate_process_group(process_group_id: i64) {
+    let group = match i32::try_from(process_group_id) {
+        Ok(group) if group > 0 => group,
+        _ => return,
+    };
+
+    // SAFETY: kill against a negative pid signals the process group; the call
+    // has no memory effects and a failure only means the group is already gone.
+    unsafe { kill(-group, SIGTERM) };
+
+    let deadline = std::time::Instant::now() + FORCE_KILL_WAIT;
+    while std::time::Instant::now() < deadline {
+        if unsafe { kill(-group, 0) } != 0 {
+            return;
         }
-        if path.is_dir() {
-            std::fs::remove_dir_all(path)?;
-        } else {
-            std::fs::remove_file(path)?;
-        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     }
-    Ok(())
+    unsafe { kill(-group, SIGKILL) };
+}
+
+const SIGTERM: i32 = 15;
+const SIGKILL: i32 = 9;
+const FORCE_KILL_WAIT: std::time::Duration = std::time::Duration::from_secs(5);
+
+unsafe extern "C" {
+    fn kill(pid: i32, sig: i32) -> i32;
 }
 
 #[cfg(test)]
@@ -199,6 +228,51 @@ mod tests {
             !is_signalable(&identity),
             "must never signal our own process group"
         );
+    }
+
+    /// Cleanup removes directories recursively, so it must only ever accept a
+    /// root the triage runner created. Anything else could be a real repository
+    /// or the shared workspace root.
+    #[test]
+    fn cleanup_root_accepts_only_runner_created_attempt_dirs() {
+        assert_eq!(
+            attempt_root_for_cleanup(Path::new("/srv/workspaces/triage-abc123/workspace")),
+            Some(PathBuf::from("/srv/workspaces/triage-abc123"))
+        );
+        assert_eq!(
+            attempt_root_for_cleanup(Path::new("/home/dev/my-project/workspace")),
+            None,
+            "a path outside a triage attempt dir must never be deleted"
+        );
+        assert_eq!(
+            attempt_root_for_cleanup(Path::new("/srv/workspaces")),
+            None,
+            "the workspace root itself must never be deleted"
+        );
+    }
+
+    /// An orphaned triage child must actually die, otherwise a restart leaves
+    /// an agent running against a workspace it is about to delete.
+    #[tokio::test]
+    async fn terminates_a_live_process_group() {
+        let mut child = tokio::process::Command::new("sleep")
+            .arg("60")
+            .process_group(0)
+            .spawn()
+            .expect("spawn sleep");
+        let pid = child.id().expect("child pid") as i64;
+        let identity = capture(pid as u32);
+        assert!(
+            is_signalable(&identity),
+            "a foreign group leader must be signalable"
+        );
+
+        terminate_process_group(identity.process_group_id).await;
+
+        let status = tokio::time::timeout(std::time::Duration::from_secs(10), child.wait())
+            .await
+            .expect("child must exit after termination");
+        assert!(status.is_ok());
     }
 
     /// An attempt recorded without a usable identity must never be signalled.

--- a/apps/symphony/src/triage/process_identity.rs
+++ b/apps/symphony/src/triage/process_identity.rs
@@ -1,0 +1,216 @@
+//! OS process identity for triage attempts.
+//!
+//! A restart has to decide whether the process group recorded against an
+//! abandoned attempt is still *that* process, or whether the PID has since been
+//! reused by something unrelated. Comparing the PID alone is not enough, so an
+//! attempt also records the OS-provided process start token and the executable
+//! the child was running. Signalling only happens when every recorded field
+//! still matches the live process.
+
+use std::path::Path;
+
+/// Identity of a spawned triage child, captured immediately after spawn.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProcessIdentity {
+    pub pid: i64,
+    pub process_group_id: i64,
+    /// OS-provided start marker. `None` when this platform exposes none, which
+    /// forces recovery to skip signalling rather than risk a reused PID.
+    pub start_token: Option<String>,
+    /// Executable backing the process, used to reject a reused PID that now
+    /// runs an unrelated program.
+    pub executable: Option<String>,
+}
+
+/// Capture identity for `pid`, reading the real process group rather than
+/// assuming the child leads its own.
+pub fn capture(pid: u32) -> ProcessIdentity {
+    let pid = i64::from(pid);
+    ProcessIdentity {
+        pid,
+        process_group_id: process_group_of(pid).unwrap_or(pid),
+        start_token: start_token(pid),
+        executable: executable(pid),
+    }
+}
+
+/// Whether the live process still matches every recorded identity field.
+///
+/// Missing recorded or live values are treated as a mismatch: an attempt whose
+/// identity cannot be proven must never be signalled.
+pub fn matches(recorded: &ProcessIdentity) -> bool {
+    let (Some(recorded_token), Some(recorded_exe)) = (&recorded.start_token, &recorded.executable)
+    else {
+        return false;
+    };
+    if recorded.pid <= 0 {
+        return false;
+    }
+
+    let live = capture(recorded.pid as u32);
+    live.process_group_id == recorded.process_group_id
+        && live.start_token.as_ref() == Some(recorded_token)
+        && live.executable.as_ref() == Some(recorded_exe)
+}
+
+/// Whether recovery may signal this attempt's recorded process group.
+///
+/// Beyond a full identity match the group must be a real, foreign group: a
+/// child that never got its own group would share Symphony's, and signalling
+/// that would take down the orchestrator itself.
+pub fn is_signalable(recorded: &ProcessIdentity) -> bool {
+    if recorded.process_group_id <= 0 || recorded.process_group_id == own_process_group() {
+        return false;
+    }
+    matches(recorded)
+}
+
+fn own_process_group() -> i64 {
+    process_group_of(std::process::id() as i64).unwrap_or(-1)
+}
+
+fn process_group_of(pid: i64) -> Option<i64> {
+    // SAFETY: getpgid is a plain POSIX query with no memory effects.
+    let pgid = unsafe { getpgid(pid as i32) };
+    (pgid >= 0).then_some(i64::from(pgid))
+}
+
+unsafe extern "C" {
+    fn getpgid(pid: i32) -> i32;
+}
+
+#[cfg(target_os = "linux")]
+fn start_token(pid: i64) -> Option<String> {
+    // Field 22 of /proc/<pid>/stat is starttime in clock ticks since boot.
+    // Field 2 (comm) may contain spaces inside parentheses, so split after it.
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    let after_comm = stat.rsplit_once(')')?.1;
+    after_comm.split_whitespace().nth(19).map(str::to_string)
+}
+
+#[cfg(target_os = "linux")]
+fn executable(pid: i64) -> Option<String> {
+    std::fs::read_link(format!("/proc/{pid}/exe"))
+        .ok()
+        .map(|path| path.display().to_string())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn start_token(pid: i64) -> Option<String> {
+    ps_field(pid, "lstart=")
+}
+
+#[cfg(not(target_os = "linux"))]
+fn executable(pid: i64) -> Option<String> {
+    ps_field(pid, "comm=")
+}
+
+/// `ps` is the portable source of process start time and command outside Linux.
+#[cfg(not(target_os = "linux"))]
+fn ps_field(pid: i64, format: &str) -> Option<String> {
+    let output = std::process::Command::new("ps")
+        .arg("-o")
+        .arg(format)
+        .arg("-p")
+        .arg(pid.to_string())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!value.is_empty()).then_some(value)
+}
+
+/// Remove an abandoned attempt's disposable directories before it is retried.
+///
+/// Errors are returned rather than swallowed so recovery can report a workspace
+/// it failed to reclaim instead of silently leaking it.
+pub fn remove_attempt_paths(paths: &[&Path]) -> std::io::Result<()> {
+    for path in paths {
+        if !path.exists() {
+            continue;
+        }
+        if path.is_dir() {
+            std::fs::remove_dir_all(path)?;
+        } else {
+            std::fs::remove_file(path)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A live child must be identifiable, otherwise recovery could never
+    /// terminate a real orphan.
+    #[test]
+    fn captures_identity_for_a_live_process() {
+        let child = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn sleep");
+        let identity = capture(child.id());
+
+        assert_eq!(identity.pid, i64::from(child.id()));
+        assert!(
+            identity.start_token.is_some(),
+            "start token must be captured"
+        );
+        assert!(identity.executable.is_some(), "executable must be captured");
+        assert!(
+            matches(&identity),
+            "live process must match its own identity"
+        );
+
+        let mut child = child;
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    /// A recorded token that no longer matches means the PID was reused, so
+    /// signalling it would kill an unrelated process.
+    #[test]
+    fn rejects_identity_whose_start_token_changed() {
+        let mut child = std::process::Command::new("sleep")
+            .arg("30")
+            .spawn()
+            .expect("spawn sleep");
+        let mut identity = capture(child.id());
+        identity.start_token = Some("not-the-recorded-token".to_string());
+
+        assert!(!matches(&identity));
+
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    /// A child that never got its own process group shares Symphony's, so
+    /// signalling that group would kill the orchestrator. Recovery must refuse
+    /// even though every identity field matches a live process.
+    #[test]
+    fn refuses_to_signal_symphonys_own_process_group() {
+        let identity = capture(std::process::id());
+
+        assert!(matches(&identity), "self identity matches by construction");
+        assert!(
+            !is_signalable(&identity),
+            "must never signal our own process group"
+        );
+    }
+
+    /// An attempt recorded without a usable identity must never be signalled.
+    #[test]
+    fn rejects_identity_missing_os_fields() {
+        let identity = ProcessIdentity {
+            pid: 1,
+            process_group_id: 1,
+            start_token: None,
+            executable: Some("/bin/sleep".to_string()),
+        };
+
+        assert!(!matches(&identity));
+    }
+}

--- a/apps/symphony/src/triage/process_identity.rs
+++ b/apps/symphony/src/triage/process_identity.rs
@@ -3,9 +3,10 @@
 //! A restart has to decide whether the process group recorded against an
 //! abandoned attempt is still *that* process, or whether the PID has since been
 //! reused by something unrelated. Comparing the PID alone is not enough, so an
-//! attempt also records the OS-provided process start token and the executable
-//! the child was running. Signalling only happens when every recorded field
-//! still matches the live process.
+//! attempt also records its process group and the OS-provided process start
+//! token. The executable is retained as diagnostic context, but is not stable
+//! identity: a launcher can legitimately replace itself with a worker through
+//! `exec` while keeping the same PID, process group, and start token.
 
 use std::path::{Path, PathBuf};
 
@@ -17,9 +18,68 @@ pub struct ProcessIdentity {
     /// OS-provided start marker. `None` when this platform exposes none, which
     /// forces recovery to skip signalling rather than risk a reused PID.
     pub start_token: Option<String>,
-    /// Executable backing the process, used to reject a reused PID that now
-    /// runs an unrelated program.
+    /// Executable observed when the process was captured. This is diagnostic
+    /// context only because a legitimate child may replace it through `exec`.
     pub executable: Option<String>,
+}
+
+/// Diagnostic comparison of the executable recorded at spawn with the live
+/// executable observed during recovery.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExecutableComparison {
+    Unchanged,
+    Changed {
+        recorded: Option<String>,
+        live: Option<String>,
+    },
+}
+
+/// Why recovery refused to signal a recorded process group.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SignalBlockReason {
+    InvalidPidOrGroup,
+    OwnProcessGroup,
+    MissingStartToken,
+    ProcessNotFound,
+    LiveIdentityUnavailable,
+    ProcessGroupMismatch { recorded: i64, live: i64 },
+    StartTokenMismatch { recorded: String, live: String },
+}
+
+impl std::fmt::Display for SignalBlockReason {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidPidOrGroup => formatter.write_str("invalid pid or process group"),
+            Self::OwnProcessGroup => formatter.write_str("recorded group is Symphony's group"),
+            Self::MissingStartToken => formatter.write_str("recorded start token is missing"),
+            Self::ProcessNotFound => formatter.write_str("recorded process is no longer present"),
+            Self::LiveIdentityUnavailable => {
+                formatter.write_str("live process start token is unavailable")
+            }
+            Self::ProcessGroupMismatch { recorded, live } => {
+                write!(
+                    formatter,
+                    "process group mismatch (recorded {recorded}, live {live})"
+                )
+            }
+            Self::StartTokenMismatch { .. } => formatter.write_str("process start token mismatch"),
+        }
+    }
+}
+
+/// Recovery's authorization decision for a recorded child.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Signalability {
+    Authorized { executable: ExecutableComparison },
+    Denied(SignalBlockReason),
+}
+
+/// Verified result of bounded process-group termination.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TerminationOutcome {
+    Terminated,
+    NoLongerSignalable(SignalBlockReason),
+    StillRunning,
 }
 
 /// Capture identity for a live `pid`, reading its current process group.
@@ -47,35 +107,69 @@ pub fn capture_child(pid: u32, group_leader: bool) -> ProcessIdentity {
     identity
 }
 
-/// Whether the live process still matches every recorded identity field.
+/// Whether the live process still matches the recorded stable identity.
 ///
-/// Missing recorded or live values are treated as a mismatch: an attempt whose
-/// identity cannot be proven must never be signalled.
+/// Executable equality is intentionally excluded because `exec` changes the
+/// executable without changing the process identity that authorizes recovery.
 pub fn matches(recorded: &ProcessIdentity) -> bool {
-    let (Some(recorded_token), Some(recorded_exe)) = (&recorded.start_token, &recorded.executable)
-    else {
+    let Some(recorded_token) = recorded.start_token.as_ref() else {
         return false;
     };
-    if recorded.pid <= 0 {
+    if recorded.pid <= 0 || recorded.process_group_id <= 0 {
         return false;
     }
-
-    let live = capture(recorded.pid as u32);
-    live.process_group_id == recorded.process_group_id
-        && live.start_token.as_ref() == Some(recorded_token)
-        && live.executable.as_ref() == Some(recorded_exe)
+    process_group_of(recorded.pid) == Some(recorded.process_group_id)
+        && start_token(recorded.pid).as_ref() == Some(recorded_token)
 }
 
-/// Whether recovery may signal this attempt's recorded process group.
-///
-/// Beyond a full identity match the group must be a real, foreign group: a
-/// child that never got its own group would share Symphony's, and signalling
-/// that would take down the orchestrator itself.
-pub fn is_signalable(recorded: &ProcessIdentity) -> bool {
-    if recorded.process_group_id <= 0 || recorded.process_group_id == own_process_group() {
-        return false;
+/// Assess whether recovery may signal this attempt's recorded process group.
+pub fn assess_signalability(recorded: &ProcessIdentity) -> Signalability {
+    if recorded.pid <= 0 || recorded.process_group_id <= 0 {
+        return Signalability::Denied(SignalBlockReason::InvalidPidOrGroup);
     }
-    matches(recorded)
+    if recorded.process_group_id == own_process_group() {
+        return Signalability::Denied(SignalBlockReason::OwnProcessGroup);
+    }
+    let Some(recorded_token) = recorded.start_token.as_ref() else {
+        return Signalability::Denied(SignalBlockReason::MissingStartToken);
+    };
+    let Some(live_group) = process_group_of(recorded.pid) else {
+        return Signalability::Denied(SignalBlockReason::ProcessNotFound);
+    };
+    if live_group != recorded.process_group_id {
+        return Signalability::Denied(SignalBlockReason::ProcessGroupMismatch {
+            recorded: recorded.process_group_id,
+            live: live_group,
+        });
+    }
+    let Some(live_token) = start_token(recorded.pid) else {
+        return Signalability::Denied(SignalBlockReason::LiveIdentityUnavailable);
+    };
+    if &live_token != recorded_token {
+        return Signalability::Denied(SignalBlockReason::StartTokenMismatch {
+            recorded: recorded_token.clone(),
+            live: live_token,
+        });
+    }
+
+    let live_executable = executable(recorded.pid);
+    let executable = if live_executable == recorded.executable {
+        ExecutableComparison::Unchanged
+    } else {
+        ExecutableComparison::Changed {
+            recorded: recorded.executable.clone(),
+            live: live_executable,
+        }
+    };
+    Signalability::Authorized { executable }
+}
+
+/// Boolean compatibility wrapper for callers that do not need diagnostics.
+pub fn is_signalable(recorded: &ProcessIdentity) -> bool {
+    matches!(
+        assess_signalability(recorded),
+        Signalability::Authorized { .. }
+    )
 }
 
 fn own_process_group() -> i64 {
@@ -152,12 +246,19 @@ pub fn attempt_root_for_cleanup(workspace_path: &Path) -> Option<PathBuf> {
         .then(|| root.to_path_buf())
 }
 
-/// Send a bounded termination to `process_group_id`: `SIGTERM`, then `SIGKILL`
-/// if the group is still alive after [`FORCE_KILL_WAIT`].
-pub async fn terminate_process_group(process_group_id: i64) {
-    let group = match i32::try_from(process_group_id) {
+/// Terminate the recorded process group after re-checking stable identity:
+/// `SIGTERM`, then `SIGKILL` if a running member remains after
+/// [`FORCE_KILL_WAIT`].
+pub async fn terminate_process_group(recorded: &ProcessIdentity) -> TerminationOutcome {
+    if let Signalability::Denied(reason) = assess_signalability(recorded) {
+        return TerminationOutcome::NoLongerSignalable(reason);
+    }
+
+    let group = match i32::try_from(recorded.process_group_id) {
         Ok(group) if group > 0 => group,
-        _ => return,
+        _ => {
+            return TerminationOutcome::NoLongerSignalable(SignalBlockReason::InvalidPidOrGroup);
+        }
     };
 
     // SAFETY: kill against a negative pid signals the process group; the call
@@ -166,20 +267,199 @@ pub async fn terminate_process_group(process_group_id: i64) {
 
     let deadline = std::time::Instant::now() + FORCE_KILL_WAIT;
     while std::time::Instant::now() < deadline {
-        if unsafe { kill(-group, 0) } != 0 {
-            return;
+        if !process_group_has_running_members(group) {
+            return TerminationOutcome::Terminated;
         }
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     }
     unsafe { kill(-group, SIGKILL) };
+
+    let deadline = std::time::Instant::now() + FORCE_KILL_CONFIRM_WAIT;
+    while std::time::Instant::now() < deadline {
+        if !process_group_has_running_members(group) {
+            return TerminationOutcome::Terminated;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+
+    if process_group_has_running_members(group) {
+        TerminationOutcome::StillRunning
+    } else {
+        TerminationOutcome::Terminated
+    }
 }
 
 const SIGTERM: i32 = 15;
 const SIGKILL: i32 = 9;
 const FORCE_KILL_WAIT: std::time::Duration = std::time::Duration::from_secs(5);
+const FORCE_KILL_CONFIRM_WAIT: std::time::Duration = std::time::Duration::from_secs(1);
 
 unsafe extern "C" {
     fn kill(pid: i32, sig: i32) -> i32;
+}
+
+#[cfg(target_os = "linux")]
+fn process_group_has_running_members(process_group_id: i32) -> bool {
+    let Ok(entries) = std::fs::read_dir("/proc") else {
+        // Fail closed when the process table cannot be inspected.
+        return true;
+    };
+    for entry in entries.flatten() {
+        let Some(pid) = entry
+            .file_name()
+            .to_str()
+            .and_then(|name| name.parse::<i64>().ok())
+        else {
+            continue;
+        };
+        let Ok(stat) = std::fs::read_to_string(format!("/proc/{pid}/stat")) else {
+            continue;
+        };
+        let Some((_, after_comm)) = stat.rsplit_once(')') else {
+            continue;
+        };
+        let mut fields = after_comm.split_whitespace();
+        let Some(state) = fields.next() else {
+            continue;
+        };
+        let _parent_pid = fields.next();
+        let Some(group) = fields.next().and_then(|value| value.parse::<i32>().ok()) else {
+            continue;
+        };
+        if group == process_group_id && state != "Z" && state != "X" {
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(not(target_os = "linux"))]
+fn process_group_has_running_members(process_group_id: i32) -> bool {
+    let output = std::process::Command::new("ps")
+        .args(["-o", "stat=", "-g", &process_group_id.to_string()])
+        .output();
+    let Ok(output) = output else {
+        return true;
+    };
+    if !output.status.success() {
+        return false;
+    }
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .any(|state| !state.is_empty() && !state.starts_with('Z') && !state.starts_with('X'))
+}
+
+/// Deterministic launcher-to-worker fixture shared by recovery tests.
+#[cfg(test)]
+pub(crate) struct ExecTransitionChild {
+    child: Option<std::process::Child>,
+    identity: ProcessIdentity,
+    release_path: PathBuf,
+    _temp: tempfile::TempDir,
+}
+
+#[cfg(test)]
+impl ExecTransitionChild {
+    pub(crate) fn spawn() -> Self {
+        use std::os::unix::process::CommandExt;
+
+        let temp = tempfile::tempdir().expect("create exec-transition fixture");
+        let release_path = temp.path().join("release.fifo");
+        let status = std::process::Command::new("mkfifo")
+            .arg(&release_path)
+            .status()
+            .expect("run mkfifo");
+        assert!(status.success(), "mkfifo must create the release barrier");
+
+        let mut command = std::process::Command::new("sh");
+        command
+            .args([
+                "-c",
+                "read -r _ < \"$1\"; exec sleep 60",
+                "symphony-test-launcher",
+            ])
+            .arg(&release_path)
+            .process_group(0);
+        let child = command.spawn().expect("spawn launcher");
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        let identity = loop {
+            let candidate = capture_child(child.id(), true);
+            let settled = process_group_of(candidate.pid) == Some(candidate.process_group_id)
+                && candidate.start_token.is_some()
+                && candidate
+                    .executable
+                    .as_deref()
+                    .is_some_and(|value| value.contains("sh") || value.contains("dash"));
+            if settled {
+                break candidate;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "launcher must settle before identity capture"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        };
+
+        Self {
+            child: Some(child),
+            identity,
+            release_path,
+            _temp: temp,
+        }
+    }
+
+    pub(crate) fn identity(&self) -> &ProcessIdentity {
+        &self.identity
+    }
+
+    pub(crate) fn release_and_wait_for_exec(&self) {
+        use std::io::Write;
+
+        let mut release = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&self.release_path)
+            .expect("open release barrier");
+        release.write_all(b"go\n").expect("release launcher");
+        drop(release);
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            if matches!(
+                assess_signalability(&self.identity),
+                Signalability::Authorized {
+                    executable: ExecutableComparison::Changed { .. }
+                }
+            ) {
+                return;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "launcher must replace itself while stable identity remains"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+    }
+
+    pub(crate) fn wait_for_exit(&mut self) -> bool {
+        let mut child = self.child.take().expect("child has not been reaped");
+        child.wait().is_ok()
+    }
+}
+
+#[cfg(test)]
+impl Drop for ExecTransitionChild {
+    fn drop(&mut self) {
+        let Some(child) = self.child.as_mut() else {
+            return;
+        };
+        if let Ok(group) = i32::try_from(self.identity.process_group_id) {
+            // SAFETY: this fixture owns the foreign process group.
+            unsafe { kill(-group, SIGKILL) };
+        }
+        let _ = child.wait();
+    }
 }
 
 #[cfg(test)]
@@ -227,6 +507,77 @@ mod tests {
 
         let _ = child.kill();
         let _ = child.wait();
+    }
+
+    #[test]
+    fn executable_drift_after_exec_remains_signalable() {
+        let fixture = ExecTransitionChild::spawn();
+        let recorded = fixture.identity().clone();
+
+        fixture.release_and_wait_for_exec();
+
+        assert_eq!(
+            assess_signalability(&recorded),
+            Signalability::Authorized {
+                executable: ExecutableComparison::Changed {
+                    recorded: recorded.executable.clone(),
+                    live: executable(recorded.pid),
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn missing_executable_is_diagnostic_not_authorization() {
+        use std::os::unix::process::CommandExt;
+        let mut command = std::process::Command::new("sleep");
+        command.arg("30").process_group(0);
+        let mut child = command.spawn().expect("spawn sleep");
+        let mut identity = capture_child(child.id(), true);
+        identity.executable = None;
+
+        assert!(is_signalable(&identity));
+        assert!(matches!(
+            assess_signalability(&identity),
+            Signalability::Authorized { .. }
+        ));
+
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    #[test]
+    fn rejects_identity_whose_process_group_changed() {
+        use std::os::unix::process::CommandExt;
+        let mut command = std::process::Command::new("sleep");
+        command.arg("30").process_group(0);
+        let mut child = command.spawn().expect("spawn sleep");
+        let mut identity = capture_child(child.id(), true);
+        identity.process_group_id += 1;
+
+        assert!(matches!(
+            assess_signalability(&identity),
+            Signalability::Denied(SignalBlockReason::ProcessGroupMismatch { .. })
+        ));
+
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
+    #[test]
+    fn rejects_identity_for_dead_process() {
+        use std::os::unix::process::CommandExt;
+        let mut command = std::process::Command::new("sleep");
+        command.arg("30").process_group(0);
+        let mut child = command.spawn().expect("spawn sleep");
+        let identity = capture_child(child.id(), true);
+        child.kill().expect("kill child");
+        child.wait().expect("reap child");
+
+        assert_eq!(
+            assess_signalability(&identity),
+            Signalability::Denied(SignalBlockReason::ProcessNotFound)
+        );
     }
 
     /// A child placed in its own group calls `setpgid` after `fork`, so reading
@@ -291,37 +642,20 @@ mod tests {
     /// an agent running against a workspace it is about to delete.
     #[tokio::test]
     async fn terminates_a_live_process_group() {
-        // Spawned and reaped through std: `tokio::process` relies on SIGCHLD
-        // reaching the runtime that owns the child, which is unreliable when
-        // many test runtimes share one process.
-        let mut child = {
-            use std::os::unix::process::CommandExt;
-            let mut command = std::process::Command::new("sleep");
-            command.arg("60").process_group(0);
-            command.spawn().expect("spawn sleep")
-        };
-        let identity = capture_child(child.id(), true);
-        assert!(
-            is_signalable(&identity),
-            "a foreign group leader must be signalable"
+        let mut fixture = ExecTransitionChild::spawn();
+        let identity = fixture.identity().clone();
+        fixture.release_and_wait_for_exec();
+
+        assert_eq!(
+            terminate_process_group(&identity).await,
+            TerminationOutcome::Terminated
         );
-
-        let (reaped_tx, reaped_rx) = std::sync::mpsc::channel();
-        std::thread::spawn(move || {
-            let _ = reaped_tx.send(child.wait().is_ok());
-        });
-
-        terminate_process_group(identity.process_group_id).await;
-
-        let reaped = reaped_rx
-            .recv_timeout(std::time::Duration::from_secs(30))
-            .expect("child must exit after termination");
-        assert!(reaped);
+        assert!(fixture.wait_for_exit(), "child must be reaped");
     }
 
     /// An attempt recorded without a usable identity must never be signalled.
     #[test]
-    fn rejects_identity_missing_os_fields() {
+    fn rejects_identity_missing_start_token() {
         let identity = ProcessIdentity {
             pid: 1,
             process_group_id: 1,
@@ -330,5 +664,9 @@ mod tests {
         };
 
         assert!(!matches(&identity));
+        assert_eq!(
+            assess_signalability(&identity),
+            Signalability::Denied(SignalBlockReason::MissingStartToken)
+        );
     }
 }

--- a/apps/symphony/src/triage/process_identity.rs
+++ b/apps/symphony/src/triage/process_identity.rs
@@ -291,24 +291,32 @@ mod tests {
     /// an agent running against a workspace it is about to delete.
     #[tokio::test]
     async fn terminates_a_live_process_group() {
-        let mut child = tokio::process::Command::new("sleep")
-            .arg("60")
-            .process_group(0)
-            .spawn()
-            .expect("spawn sleep");
-        let pid = child.id().expect("child pid") as i64;
-        let identity = capture_child(pid as u32, true);
+        // Spawned and reaped through std: `tokio::process` relies on SIGCHLD
+        // reaching the runtime that owns the child, which is unreliable when
+        // many test runtimes share one process.
+        let mut child = {
+            use std::os::unix::process::CommandExt;
+            let mut command = std::process::Command::new("sleep");
+            command.arg("60").process_group(0);
+            command.spawn().expect("spawn sleep")
+        };
+        let identity = capture_child(child.id(), true);
         assert!(
             is_signalable(&identity),
             "a foreign group leader must be signalable"
         );
 
+        let (reaped_tx, reaped_rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = reaped_tx.send(child.wait().is_ok());
+        });
+
         terminate_process_group(identity.process_group_id).await;
 
-        let status = tokio::time::timeout(std::time::Duration::from_secs(10), child.wait())
-            .await
+        let reaped = reaped_rx
+            .recv_timeout(std::time::Duration::from_secs(30))
             .expect("child must exit after termination");
-        assert!(status.is_ok());
+        assert!(reaped);
     }
 
     /// An attempt recorded without a usable identity must never be signalled.

--- a/apps/symphony/src/triage/process_identity.rs
+++ b/apps/symphony/src/triage/process_identity.rs
@@ -22,8 +22,7 @@ pub struct ProcessIdentity {
     pub executable: Option<String>,
 }
 
-/// Capture identity for `pid`, reading the real process group rather than
-/// assuming the child leads its own.
+/// Capture identity for a live `pid`, reading its current process group.
 pub fn capture(pid: u32) -> ProcessIdentity {
     let pid = i64::from(pid);
     ProcessIdentity {
@@ -32,6 +31,20 @@ pub fn capture(pid: u32) -> ProcessIdentity {
         start_token: start_token(pid),
         executable: executable(pid),
     }
+}
+
+/// Capture identity for a child we just spawned.
+///
+/// A child placed in its own group calls `setpgid` after `fork`, so reading the
+/// group here would race it and could return *Symphony's* group. When the
+/// caller asked for a new group the id is known to equal the child pid, so it
+/// is recorded directly rather than read back.
+pub fn capture_child(pid: u32, group_leader: bool) -> ProcessIdentity {
+    let mut identity = capture(pid);
+    if group_leader {
+        identity.process_group_id = identity.pid;
+    }
+    identity
 }
 
 /// Whether the live process still matches every recorded identity field.
@@ -216,6 +229,29 @@ mod tests {
         let _ = child.wait();
     }
 
+    /// A child placed in its own group calls `setpgid` after `fork`, so reading
+    /// the group back can still see Symphony's group and make recovery refuse
+    /// to terminate a real orphan. Recording the known group id avoids the race.
+    #[test]
+    fn child_group_is_recorded_without_racing_setpgid() {
+        use std::os::unix::process::CommandExt;
+        let mut command = std::process::Command::new("sleep");
+        command.arg("30").process_group(0);
+        let mut child = command.spawn().expect("spawn sleep");
+
+        let identity = capture_child(child.id(), true);
+
+        assert_eq!(identity.process_group_id, identity.pid);
+        assert_ne!(
+            identity.process_group_id,
+            own_process_group(),
+            "a group-leader child must never be recorded as Symphony's group"
+        );
+
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+
     /// A child that never got its own process group shares Symphony's, so
     /// signalling that group would kill the orchestrator. Recovery must refuse
     /// even though every identity field matches a live process.
@@ -261,7 +297,7 @@ mod tests {
             .spawn()
             .expect("spawn sleep");
         let pid = child.id().expect("child pid") as i64;
-        let identity = capture(pid as u32);
+        let identity = capture_child(pid as u32, true);
         assert!(
             is_signalable(&identity),
             "a foreign group leader must be signalable"

--- a/apps/symphony/src/triage/process_identity.rs
+++ b/apps/symphony/src/triage/process_identity.rs
@@ -233,17 +233,32 @@ fn ps_field(pid: i64, format: &str) -> Option<String> {
 pub const ATTEMPT_DIR_PREFIX: &str = "triage-";
 
 /// The attempt root holding a recorded workspace, or `None` when the recorded
-/// path is not one the triage runner created.
+/// path is not one the triage runner created under the configured workspace
+/// root.
 ///
 /// Cleanup deletes recursively, so it only ever accepts a directory named
-/// `triage-<attempt id>`. A stale, hand-edited, or corrupted `workspace_path`
-/// therefore cannot make recovery delete a real repository or the workspace
-/// root itself.
-pub fn attempt_root_for_cleanup(workspace_path: &Path) -> Option<PathBuf> {
+/// exactly `triage-<stage_run_id>` that is a direct child of `workspace_root`.
+/// A stale, hand-edited, or corrupted `workspace_path` therefore cannot make
+/// recovery delete a real repository or an unrelated `triage-*` tree.
+pub fn attempt_root_for_cleanup(
+    workspace_path: &Path,
+    workspace_root: &Path,
+    stage_run_id: &str,
+) -> Option<PathBuf> {
     let root = workspace_path.parent()?;
-    let name = root.file_name()?.to_str()?;
-    name.starts_with(ATTEMPT_DIR_PREFIX)
-        .then(|| root.to_path_buf())
+    let expected_name = format!("{ATTEMPT_DIR_PREFIX}{stage_run_id}");
+    if root.file_name()?.to_str()? != expected_name {
+        return None;
+    }
+    let parent = root.parent()?;
+    paths_equal(parent, workspace_root).then(|| root.to_path_buf())
+}
+
+fn paths_equal(left: &Path, right: &Path) -> bool {
+    match (left.canonicalize(), right.canonicalize()) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => left == right,
+    }
 }
 
 /// Terminate the recorded process group after re-checking stable identity:
@@ -618,21 +633,38 @@ mod tests {
     }
 
     /// Cleanup removes directories recursively, so it must only ever accept a
-    /// root the triage runner created. Anything else could be a real repository
-    /// or the shared workspace root.
+    /// root the triage runner created under the configured workspace root.
     #[test]
     fn cleanup_root_accepts_only_runner_created_attempt_dirs() {
+        let workspace_root = Path::new("/srv/workspaces");
         assert_eq!(
-            attempt_root_for_cleanup(Path::new("/srv/workspaces/triage-abc123/workspace")),
+            attempt_root_for_cleanup(
+                Path::new("/srv/workspaces/triage-abc123/workspace"),
+                workspace_root,
+                "abc123",
+            ),
             Some(PathBuf::from("/srv/workspaces/triage-abc123"))
         );
         assert_eq!(
-            attempt_root_for_cleanup(Path::new("/home/dev/my-project/workspace")),
+            attempt_root_for_cleanup(
+                Path::new("/home/user/triage-project/workspace"),
+                workspace_root,
+                "project",
+            ),
             None,
-            "a path outside a triage attempt dir must never be deleted"
+            "a triage-* path outside the configured workspace root must never be deleted"
         );
         assert_eq!(
-            attempt_root_for_cleanup(Path::new("/srv/workspaces")),
+            attempt_root_for_cleanup(
+                Path::new("/srv/workspaces/triage-other/workspace"),
+                workspace_root,
+                "abc123",
+            ),
+            None,
+            "attempt id in the directory name must match the recorded stage_run_id"
+        );
+        assert_eq!(
+            attempt_root_for_cleanup(Path::new("/srv/workspaces"), workspace_root, "abc123"),
             None,
             "the workspace root itself must never be deleted"
         );

--- a/apps/symphony/src/triage/runner.rs
+++ b/apps/symphony/src/triage/runner.rs
@@ -14,6 +14,7 @@ use crate::error::{Result, SymphonyError};
 use crate::triage::artifact::{self, ArtifactValidationError};
 use crate::triage::domain::{StageUsage, TriageArtifact};
 use crate::triage::integrity::{self, RepoBaseline};
+use crate::triage::process_identity::{self, ProcessIdentity};
 
 const FORCE_KILL_WAIT: Duration = Duration::from_secs(5);
 const OUTPUT_ENV: &str = "SYMPHONY_STAGE_OUTPUT";
@@ -60,10 +61,24 @@ pub struct TriageRunnerRequest {
     pub codex: Option<CodexConfig>,
     /// Live progress sink; events arrive as the turn executes.
     pub progress: Option<TriageProgressSink>,
+    /// Notified once the child is running, so the attempt's OS identity and
+    /// disposable paths are durable before the turn can be interrupted.
+    pub spawned: Option<TriageSpawnSink>,
 }
 
 /// Callback receiving structured progress during a triage turn.
 pub type TriageProgressSink = std::sync::Arc<dyn Fn(TriageProgress) + Send + Sync>;
+
+/// Callback receiving the spawned child's identity, fired once per turn.
+pub type TriageSpawnSink = std::sync::Arc<dyn Fn(TriageSpawnInfo) + Send + Sync>;
+
+/// What a restart needs to identify and clean up an abandoned attempt.
+#[derive(Debug, Clone)]
+pub struct TriageSpawnInfo {
+    pub identity: ProcessIdentity,
+    pub workspace_path: PathBuf,
+    pub output_path: PathBuf,
+}
 
 #[derive(Debug, Clone, Default)]
 pub struct TriageProgress {
@@ -293,6 +308,21 @@ fn finish_attempt(
 }
 
 /// Remove the isolated home (and any seeded credentials) after the child exits.
+/// Publish the running child's identity and disposable paths to the caller.
+///
+/// Recovery after a crash depends entirely on this record, so it is emitted as
+/// soon as the child exists rather than when the turn completes.
+fn report_spawn(request: &TriageRunnerRequest, layout: &AttemptLayout, child_id: Option<u32>) {
+    let (Some(sink), Some(pid)) = (request.spawned.as_ref(), child_id) else {
+        return;
+    };
+    sink(TriageSpawnInfo {
+        identity: process_identity::capture(pid),
+        workspace_path: layout.workspace_path.clone(),
+        output_path: layout.output_path.clone(),
+    });
+}
+
 fn scrub_isolated_home(home_dir: &Path) -> std::io::Result<()> {
     if home_dir.exists() {
         fs::remove_dir_all(home_dir)?;
@@ -348,6 +378,7 @@ async fn run_pi_turn(
     };
 
     let child_id = child.id();
+    report_spawn(request, layout, child_id);
     let stdout = child.stdout.take().expect("stdout piped");
     let stderr = child.stderr.take().expect("stderr piped");
     let turn_timeout = Duration::from_millis(request.turn_timeout_ms);
@@ -573,7 +604,7 @@ async fn run_codex_turn(
         parent_identifier: None,
     };
 
-    let handle = codex_session_start(&config, &issue, layout).await;
+    let handle = codex_session_start(request, &config, &issue, layout).await;
     let mut handle = match handle {
         Ok(handle) => handle,
         Err(outcome) => return Err(outcome),
@@ -666,6 +697,7 @@ fn codex_failure_kind(err: &SymphonyError) -> TriageRunnerFailureKind {
 /// Environment is cleared and rebuilt with an isolated `HOME` (same policy as
 /// the Pi path) so operator credentials such as `GH_TOKEN` are not inherited.
 async fn codex_session_start(
+    request: &TriageRunnerRequest,
     config: &CodexConfig,
     issue: &Issue,
     layout: &AttemptLayout,
@@ -691,6 +723,7 @@ async fn codex_session_start(
         )
     })?;
 
+    report_spawn(request, layout, child.id());
     let mut stdin = child.stdin.take().expect("stdin piped");
     let stdout = child.stdout.take().expect("stdout piped");
     if let Some(stderr) = child.stderr.take() {
@@ -1114,7 +1147,53 @@ mod tests {
             },
             codex: None,
             progress: None,
+            spawned: None,
         }
+    }
+
+    /// Restart recovery can only terminate an orphaned triage child if the
+    /// running attempt published the child's identity and disposable paths
+    /// while the turn was still in flight.
+    #[tokio::test]
+    async fn reports_spawned_child_identity_and_attempt_paths() {
+        let temp = tempfile::tempdir().unwrap();
+        let repo = temp.path().join("repo");
+        init_repo(&repo);
+        let workspace_root = temp.path().join("workspaces");
+
+        let script = temp.path().join("fake-pi.sh");
+        write_script(
+            &script,
+            &format!(
+                "#!/bin/sh\nprintf '%s' '{artifact}' > \"$SYMPHONY_STAGE_OUTPUT\"\n",
+                artifact = valid_artifact_json().replace('\'', "'\"'\"'")
+            ),
+        );
+
+        let seen: std::sync::Arc<std::sync::Mutex<Vec<TriageSpawnInfo>>> =
+            std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = seen.clone();
+        let mut request = pi_request(&repo, &workspace_root, vec![script.display().to_string()]);
+        request.spawned = Some(std::sync::Arc::new(move |info: TriageSpawnInfo| {
+            sink.lock().unwrap().push(info);
+        }));
+
+        let outcome = TriageRunner::run(request).await.unwrap();
+        assert!(matches!(outcome, TriageRunnerOutcome::Success(_)));
+
+        let seen = seen.lock().unwrap();
+        assert_eq!(seen.len(), 1, "exactly one spawn notification per turn");
+        let info = &seen[0];
+        assert!(info.identity.pid > 0);
+        assert_eq!(
+            info.identity.process_group_id, info.identity.pid,
+            "child runs in its own process group"
+        );
+        assert!(
+            info.workspace_path.starts_with(&workspace_root),
+            "workspace path must locate the disposable clone"
+        );
+        assert!(info.output_path.ends_with("result.json"));
     }
 
     #[test]

--- a/apps/symphony/src/triage/runner.rs
+++ b/apps/symphony/src/triage/runner.rs
@@ -314,12 +314,17 @@ fn finish_attempt(
 ///
 /// Recovery after a crash depends entirely on this record, so it is emitted as
 /// soon as the child exists rather than when the turn completes.
-fn report_spawn(request: &TriageRunnerRequest, layout: &AttemptLayout, child_id: Option<u32>) {
+fn report_spawn(
+    request: &TriageRunnerRequest,
+    layout: &AttemptLayout,
+    child_id: Option<u32>,
+    group_leader: bool,
+) {
     let (Some(sink), Some(pid)) = (request.spawned.as_ref(), child_id) else {
         return;
     };
     sink(TriageSpawnInfo {
-        identity: process_identity::capture(pid),
+        identity: process_identity::capture_child(pid, group_leader),
         workspace_path: layout.workspace_path.clone(),
         output_path: layout.output_path.clone(),
     });
@@ -380,7 +385,7 @@ async fn run_pi_turn(
     };
 
     let child_id = child.id();
-    report_spawn(request, layout, child_id);
+    report_spawn(request, layout, child_id, cfg!(unix));
     let stdout = child.stdout.take().expect("stdout piped");
     let stderr = child.stderr.take().expect("stderr piped");
     let turn_timeout = Duration::from_millis(request.turn_timeout_ms);
@@ -725,7 +730,7 @@ async fn codex_session_start(
         )
     })?;
 
-    report_spawn(request, layout, child.id());
+    report_spawn(request, layout, child.id(), false);
     let mut stdin = child.stdin.take().expect("stdin piped");
     let stdout = child.stdout.take().expect("stdout piped");
     if let Some(stderr) = child.stderr.take() {

--- a/apps/symphony/src/triage/runner.rs
+++ b/apps/symphony/src/triage/runner.rs
@@ -217,9 +217,11 @@ fn validate_request(request: &TriageRunnerRequest) -> std::result::Result<(), St
 fn prepare_attempt(
     request: &TriageRunnerRequest,
 ) -> std::result::Result<AttemptLayout, TriageRunnerOutcome> {
-    let attempt_root = request
-        .workspace_root
-        .join(format!("triage-{}", request.attempt_id));
+    let attempt_root = request.workspace_root.join(format!(
+        "{}{}",
+        process_identity::ATTEMPT_DIR_PREFIX,
+        request.attempt_id
+    ));
     let layout = AttemptLayout {
         workspace_path: attempt_root.join("workspace"),
         output_path: attempt_root.join("stage-output").join("result.json"),

--- a/apps/symphony/src/triage/runner.rs
+++ b/apps/symphony/src/triage/runner.rs
@@ -723,6 +723,13 @@ async fn codex_session_start(
         .env_clear()
         .envs(env);
 
+    // Own process group, same as the Pi path: recovery must be able to signal
+    // the Codex app-server without targeting Symphony's group.
+    #[cfg(unix)]
+    {
+        command.process_group(0);
+    }
+
     let mut child = command.spawn().map_err(|err| {
         failure(
             TriageRunnerFailureKind::Spawn,
@@ -730,7 +737,7 @@ async fn codex_session_start(
         )
     })?;
 
-    report_spawn(request, layout, child.id(), false);
+    report_spawn(request, layout, child.id(), cfg!(unix));
     let mut stdin = child.stdin.take().expect("stdin piped");
     let stdout = child.stdout.take().expect("stdout piped");
     if let Some(stderr) = child.stderr.take() {

--- a/apps/symphony/src/triage/runtime.rs
+++ b/apps/symphony/src/triage/runtime.rs
@@ -274,6 +274,22 @@ impl FactoryRunStore for SharedFactoryStore {
         self.with_store_mut(|store| store.clear_attempt_process(stage_run_id))
     }
 
+    fn list_correction_candidates(
+        &self,
+        limit: usize,
+    ) -> Result<Vec<crate::triage::store::CorrectionCandidate>> {
+        self.with_store(|store| store.list_correction_candidates(limit))
+    }
+
+    fn record_route_observation(
+        &mut self,
+        artifact_id: &str,
+        kind: crate::triage::store::RouteObservationKind,
+        value: &str,
+    ) -> Result<bool> {
+        self.with_store_mut(|store| store.record_route_observation(artifact_id, kind, value))
+    }
+
     fn triage_metrics(&self) -> Result<crate::triage::domain::TriageMetricsAggregate> {
         self.with_store(|store| store.triage_metrics())
     }

--- a/apps/symphony/src/triage/runtime.rs
+++ b/apps/symphony/src/triage/runtime.rs
@@ -255,6 +255,25 @@ impl FactoryRunStore for SharedFactoryStore {
         self.with_store_mut(|store| store.interrupt_stale_attempts())
     }
 
+    fn interrupt_attempt(&mut self, stage_run_id: &str, owner_instance: &str) -> Result<bool> {
+        self.with_store_mut(|store| store.interrupt_attempt(stage_run_id, owner_instance))
+    }
+
+    fn record_attempt_process(
+        &mut self,
+        request: crate::triage::store::RecordAttemptProcessRequest,
+    ) -> Result<()> {
+        self.with_store_mut(|store| store.record_attempt_process(request.clone()))
+    }
+
+    fn list_recoverable_attempts(&self) -> Result<Vec<crate::triage::store::RecoverableAttempt>> {
+        self.with_store(|store| store.list_recoverable_attempts())
+    }
+
+    fn clear_attempt_process(&mut self, stage_run_id: &str) -> Result<()> {
+        self.with_store_mut(|store| store.clear_attempt_process(stage_run_id))
+    }
+
     fn triage_metrics(&self) -> Result<crate::triage::domain::TriageMetricsAggregate> {
         self.with_store(|store| store.triage_metrics())
     }

--- a/apps/symphony/src/triage/store.rs
+++ b/apps/symphony/src/triage/store.rs
@@ -6,6 +6,7 @@ use crate::triage::domain::{
     FACTORY_ERROR_STRING_MAX_BYTES, FACTORY_EVENT_PAYLOAD_MAX_BYTES, TRIAGE_LEASE_STALE_AFTER_MS,
     TRIAGE_STAGE_NAME,
 };
+use crate::triage::process_identity::ProcessIdentity;
 use crate::triage::storage_path::lock_path_for_storage;
 use chrono::{DateTime, Duration, Utc};
 use fs2::FileExt;
@@ -77,6 +78,28 @@ pub struct StoredCommentIdentity {
     pub comment_id: String,
     pub intent_id: String,
     pub publisher_login: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct RecordAttemptProcessRequest {
+    pub stage_run_id: String,
+    pub owner_instance: String,
+    pub identity: ProcessIdentity,
+    pub workspace_path: Option<String>,
+    pub output_path: Option<String>,
+}
+
+/// An interrupted attempt whose child process and disposable directories may
+/// still be around after a crash or restart.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecoverableAttempt {
+    pub stage_run_id: String,
+    pub run_id: String,
+    pub owner_instance: Option<String>,
+    /// Present only when every OS identity field was recorded.
+    pub identity: Option<ProcessIdentity>,
+    pub workspace_path: Option<String>,
+    pub output_path: Option<String>,
 }
 
 /// Durable guard used by the implementation scheduler while automatic
@@ -165,6 +188,20 @@ pub trait FactoryRunStore {
     fn record_event(&mut self, event: FactoryEventRecord) -> Result<()>;
     fn renew_lease(&mut self, stage_run_id: &str, owner_instance: &str) -> Result<bool>;
     fn interrupt_stale_attempts(&mut self) -> Result<u64>;
+    /// Mark one running attempt interrupted. Used by restart recovery once the
+    /// prior owner's lease is stale; returns `false` when the attempt is already
+    /// terminal or owned by someone else.
+    fn interrupt_attempt(&mut self, stage_run_id: &str, owner_instance: &str) -> Result<bool>;
+    /// Record the spawned child's OS identity and disposable paths so a later
+    /// process can decide whether the recorded process group is still this
+    /// attempt, and which directories to reclaim.
+    fn record_attempt_process(&mut self, request: RecordAttemptProcessRequest) -> Result<()>;
+    /// Attempts a restart must clean up: interrupted, and still holding
+    /// disposable paths or a recorded process group.
+    fn list_recoverable_attempts(&self) -> Result<Vec<RecoverableAttempt>>;
+    /// Clear the recorded process and paths once recovery has reclaimed them,
+    /// so the same attempt is not swept twice.
+    fn clear_attempt_process(&mut self, stage_run_id: &str) -> Result<()>;
     fn triage_metrics(&self) -> Result<TriageMetricsAggregate>;
 }
 
@@ -348,6 +385,16 @@ impl FactoryRunStore for SqliteFactoryStore {
         let now_s = ts(now);
         let tx = self.conn.transaction().map_err(storage_error)?;
         let stage = select_stage_run(&tx, &request.stage_run_id)?;
+        // Only a still-running attempt may complete. A restart that interrupted
+        // this attempt has already released it for retry, so accepting late
+        // output here would silently turn an abandoned attempt into a success.
+        if stage.status != StageStatus::Running {
+            return Err(SymphonyError::StorageError(format!(
+                "stage run {} is {} and cannot accept triage output",
+                request.stage_run_id,
+                stage.status.as_str()
+            )));
+        }
         let artifact_id = new_id();
         let artifact_json = serde_json::to_string(&request.artifact).map_err(storage_error)?;
 
@@ -979,6 +1026,114 @@ impl FactoryRunStore for SqliteFactoryStore {
         Ok(changed == 1)
     }
 
+    fn interrupt_attempt(&mut self, stage_run_id: &str, owner_instance: &str) -> Result<bool> {
+        let now_s = ts(Self::now());
+        let changed = self
+            .conn
+            .execute(
+                "UPDATE stage_runs
+                 SET status = ?1, completed_at = ?2, updated_at = ?2
+                 WHERE stage_run_id = ?3 AND owner_instance = ?4 AND status = ?5",
+                params![
+                    StageStatus::Interrupted.as_str(),
+                    now_s,
+                    stage_run_id,
+                    owner_instance,
+                    StageStatus::Running.as_str(),
+                ],
+            )
+            .map_err(storage_error)?;
+        Ok(changed == 1)
+    }
+
+    fn record_attempt_process(&mut self, request: RecordAttemptProcessRequest) -> Result<()> {
+        let now_s = ts(Self::now());
+        self.conn
+            .execute(
+                "UPDATE stage_runs
+                 SET pid = ?1, process_group_id = ?2, process_start_token = ?3,
+                     executable_identity = ?4, workspace_path = ?5, output_path = ?6,
+                     updated_at = ?7
+                 WHERE stage_run_id = ?8 AND owner_instance = ?9 AND status = ?10",
+                params![
+                    request.identity.pid,
+                    request.identity.process_group_id,
+                    request.identity.start_token,
+                    request.identity.executable,
+                    request.workspace_path,
+                    request.output_path,
+                    now_s,
+                    request.stage_run_id,
+                    request.owner_instance,
+                    StageStatus::Running.as_str(),
+                ],
+            )
+            .map_err(storage_error)?;
+        Ok(())
+    }
+
+    fn list_recoverable_attempts(&self) -> Result<Vec<RecoverableAttempt>> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT stage_run_id, run_id, owner_instance, pid, process_group_id,
+                        process_start_token, executable_identity, workspace_path, output_path
+                 FROM stage_runs
+                 WHERE stage = ?1 AND status = ?2
+                   AND (pid IS NOT NULL OR workspace_path IS NOT NULL OR output_path IS NOT NULL)
+                 ORDER BY updated_at",
+            )
+            .map_err(storage_error)?;
+        let rows = stmt
+            .query_map(
+                params![TRIAGE_STAGE_NAME, StageStatus::Interrupted.as_str()],
+                |row| {
+                    let pid: Option<i64> = row.get(3)?;
+                    let process_group_id: Option<i64> = row.get(4)?;
+                    let start_token: Option<String> = row.get(5)?;
+                    let executable: Option<String> = row.get(6)?;
+                    // Only a fully recorded identity can authorize signalling.
+                    let identity = match (pid, process_group_id) {
+                        (Some(pid), Some(process_group_id)) => Some(ProcessIdentity {
+                            pid,
+                            process_group_id,
+                            start_token,
+                            executable,
+                        }),
+                        _ => None,
+                    };
+                    Ok(RecoverableAttempt {
+                        stage_run_id: row.get(0)?,
+                        run_id: row.get(1)?,
+                        owner_instance: row.get(2)?,
+                        identity,
+                        workspace_path: row.get(7)?,
+                        output_path: row.get(8)?,
+                    })
+                },
+            )
+            .map_err(storage_error)?;
+        let mut attempts = Vec::new();
+        for row in rows {
+            attempts.push(row.map_err(storage_error)?);
+        }
+        Ok(attempts)
+    }
+
+    fn clear_attempt_process(&mut self, stage_run_id: &str) -> Result<()> {
+        self.conn
+            .execute(
+                "UPDATE stage_runs
+                 SET pid = NULL, process_group_id = NULL, process_start_token = NULL,
+                     executable_identity = NULL, workspace_path = NULL, output_path = NULL,
+                     updated_at = ?1
+                 WHERE stage_run_id = ?2",
+                params![ts(Self::now()), stage_run_id],
+            )
+            .map_err(storage_error)?;
+        Ok(())
+    }
+
     fn interrupt_stale_attempts(&mut self) -> Result<u64> {
         let stale_before = ts(Self::now() - Duration::milliseconds(TRIAGE_LEASE_STALE_AFTER_MS));
         let changed = self
@@ -1533,6 +1688,99 @@ mod tests {
                 usage: StageUsage::default(),
             })
             .is_err());
+    }
+
+    /// Late output from an attempt a restart already gave up on must not be able
+    /// to resurrect it as a success; the interrupted attempt has to stay
+    /// terminal so retry accounting and `max_attempts` keep meaning something.
+    #[test]
+    fn interrupted_attempt_cannot_be_completed_by_late_output() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("state.db");
+        let mut store = store(&path);
+        let attempt = store
+            .claim_attempt(claim_request("issue-rev", "config-rev"))
+            .unwrap();
+        store
+            .interrupt_attempt(&attempt.stage_run_id, "owner-1")
+            .unwrap();
+
+        let late = store.store_artifact(StoreArtifactRequest {
+            stage_run_id: attempt.stage_run_id.clone(),
+            issue_revision: "issue-rev".to_string(),
+            configuration_revision: "config-rev".to_string(),
+            route_mapping_hash: "routes".to_string(),
+            artifact: artifact(TriageRoute::Implement),
+            bytes_len: 200,
+            usage: StageUsage::default(),
+        });
+
+        assert!(late.is_err(), "interrupted attempt must reject late output");
+        let stage = store.get_stage_run(&attempt.stage_run_id).unwrap().unwrap();
+        assert_eq!(stage.status, StageStatus::Interrupted);
+        assert!(store.get_latest_artifact(&stage.run_id).unwrap().is_none());
+    }
+
+    /// Recovery can only reclaim what the running attempt recorded, so the
+    /// child's identity and disposable paths must survive into the interrupted
+    /// record; a claim that never recorded a process must not be swept.
+    #[test]
+    fn interrupted_attempt_exposes_recorded_process_for_recovery() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("state.db");
+        let mut store = store(&path);
+        let attempt = store
+            .claim_attempt(ClaimAttemptRequest {
+                workspace_path: None,
+                output_path: None,
+                pid: None,
+                process_group_id: None,
+                process_start_token: None,
+                executable_identity: None,
+                ..claim_request("issue-rev", "config-rev")
+            })
+            .unwrap();
+
+        assert!(
+            store.list_recoverable_attempts().unwrap().is_empty(),
+            "a running attempt is not recoverable work"
+        );
+
+        store
+            .record_attempt_process(RecordAttemptProcessRequest {
+                stage_run_id: attempt.stage_run_id.clone(),
+                owner_instance: "owner-1".to_string(),
+                identity: ProcessIdentity {
+                    pid: 4321,
+                    process_group_id: 4321,
+                    start_token: Some("99887766".to_string()),
+                    executable: Some("/usr/bin/pi".to_string()),
+                },
+                workspace_path: Some("/tmp/attempt/workspace".to_string()),
+                output_path: Some("/tmp/attempt/stage-output/result.json".to_string()),
+            })
+            .unwrap();
+        store
+            .interrupt_attempt(&attempt.stage_run_id, "owner-1")
+            .unwrap();
+
+        let recoverable = store.list_recoverable_attempts().unwrap();
+        assert_eq!(recoverable.len(), 1);
+        let identity = recoverable[0].identity.as_ref().expect("identity recorded");
+        assert_eq!(identity.pid, 4321);
+        assert_eq!(identity.process_group_id, 4321);
+        assert_eq!(identity.start_token.as_deref(), Some("99887766"));
+        assert_eq!(identity.executable.as_deref(), Some("/usr/bin/pi"));
+        assert_eq!(
+            recoverable[0].workspace_path.as_deref(),
+            Some("/tmp/attempt/workspace")
+        );
+
+        store.clear_attempt_process(&attempt.stage_run_id).unwrap();
+        assert!(
+            store.list_recoverable_attempts().unwrap().is_empty(),
+            "a reclaimed attempt must not be swept again"
+        );
     }
 
     #[test]

--- a/apps/symphony/src/triage/store.rs
+++ b/apps/symphony/src/triage/store.rs
@@ -1188,6 +1188,10 @@ impl FactoryRunStore for SqliteFactoryStore {
     }
 
     fn list_correction_candidates(&self, limit: usize) -> Result<Vec<CorrectionCandidate>> {
+        // Only the latest applied automatic publication per run is measurable:
+        // a later triage attempt resets the decision under observation. RANDOM
+        // ordering rotates the bounded batch so older runs are not starved when
+        // more than `limit` candidates exist.
         let mut stmt = self
             .conn
             .prepare(
@@ -1197,7 +1201,17 @@ impl FactoryRunStore for SqliteFactoryStore {
                  JOIN triage_artifacts a ON a.artifact_id = i.artifact_id
                  JOIN factory_runs r ON r.run_id = i.run_id
                  WHERE i.mode = ?1 AND i.status = ?2
-                 ORDER BY i.updated_at DESC
+                   AND NOT EXISTS (
+                     SELECT 1 FROM publication_intents newer
+                     WHERE newer.run_id = i.run_id
+                       AND newer.mode = i.mode
+                       AND newer.status = i.status
+                       AND (
+                         newer.updated_at > i.updated_at
+                         OR (newer.updated_at = i.updated_at AND newer.intent_id > i.intent_id)
+                       )
+                   )
+                 ORDER BY RANDOM()
                  LIMIT ?3",
             )
             .map_err(storage_error)?;
@@ -1972,6 +1986,100 @@ mod tests {
                 .unwrap(),
             "the same correction must only ever be recorded once"
         );
+    }
+
+    /// A later triage attempt on the same run supersedes the earlier publication
+    /// for correction measurement; comparing against both would count a legitimate
+    /// new route as a correction to the old artifact.
+    #[test]
+    fn correction_candidates_use_latest_applied_publication_per_run() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("state.db");
+        let mut store = store(&path);
+
+        let first_attempt = store
+            .claim_attempt(claim_request("issue-rev-1", "config-rev"))
+            .unwrap();
+        let first_artifact = store
+            .store_artifact(StoreArtifactRequest {
+                stage_run_id: first_attempt.stage_run_id,
+                issue_revision: "issue-rev-1".to_string(),
+                configuration_revision: "config-rev".to_string(),
+                route_mapping_hash: "routes".to_string(),
+                artifact: artifact(TriageRoute::Implement),
+                bytes_len: 200,
+                usage: StageUsage::default(),
+            })
+            .unwrap();
+        let first_intent = store
+            .create_publication_intent(CreatePublicationIntentRequest {
+                run_id: first_artifact.run_id.clone(),
+                artifact_id: Some(first_artifact.artifact_id.clone()),
+                mode: PublicationMode::Automatic,
+                intake_label: "needs-triage".to_string(),
+                route_label: "ready-for-agent".to_string(),
+                project_state: Some("Todo".to_string()),
+                route_mapping_hash: "routes".to_string(),
+                desired_effects: serde_json::json!({"kind": "automatic_route"}),
+                observed_baseline: serde_json::json!({}),
+                expected_projection: serde_json::json!({}),
+            })
+            .unwrap();
+        store
+            .update_publication_step(
+                &first_intent.intent_id,
+                "comment_applied",
+                PublicationStatus::Applied,
+                None,
+            )
+            .unwrap();
+
+        let second_attempt = store
+            .claim_attempt(claim_request("issue-rev-2", "config-rev"))
+            .unwrap();
+        let second_artifact = store
+            .store_artifact(StoreArtifactRequest {
+                stage_run_id: second_attempt.stage_run_id,
+                issue_revision: "issue-rev-2".to_string(),
+                configuration_revision: "config-rev".to_string(),
+                route_mapping_hash: "routes".to_string(),
+                artifact: artifact(TriageRoute::Spec),
+                bytes_len: 200,
+                usage: StageUsage::default(),
+            })
+            .unwrap();
+        assert_eq!(
+            second_artifact.run_id, first_artifact.run_id,
+            "both attempts belong to the same factory run"
+        );
+        let second_intent = store
+            .create_publication_intent(CreatePublicationIntentRequest {
+                run_id: second_artifact.run_id.clone(),
+                artifact_id: Some(second_artifact.artifact_id.clone()),
+                mode: PublicationMode::Automatic,
+                intake_label: "needs-triage".to_string(),
+                route_label: "ready-to-spec".to_string(),
+                project_state: Some("Todo".to_string()),
+                route_mapping_hash: "routes".to_string(),
+                desired_effects: serde_json::json!({"kind": "automatic_route"}),
+                observed_baseline: serde_json::json!({}),
+                expected_projection: serde_json::json!({}),
+            })
+            .unwrap();
+        store
+            .update_publication_step(
+                &second_intent.intent_id,
+                "comment_applied",
+                PublicationStatus::Applied,
+                None,
+            )
+            .unwrap();
+
+        let candidates = store.list_correction_candidates(10).unwrap();
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].artifact_id, second_artifact.artifact_id);
+        assert_eq!(candidates[0].published_route, "spec");
+        assert_eq!(candidates[0].intent_id, second_intent.intent_id);
     }
 
     #[test]

--- a/apps/symphony/src/triage/store.rs
+++ b/apps/symphony/src/triage/store.rs
@@ -16,7 +16,11 @@ use std::path::Path;
 use std::time::Duration as StdDuration;
 use uuid::Uuid;
 
-const INIT_SQL: &str = include_str!("migrations/001_init.sql");
+/// Embedded migrations, applied in order while the exclusive store lock is held.
+const MIGRATIONS: [&str; 2] = [
+    include_str!("migrations/001_init.sql"),
+    include_str!("migrations/002_route_observations.sql"),
+];
 
 #[derive(Debug, Clone)]
 pub struct ClaimAttemptRequest {
@@ -100,6 +104,41 @@ pub struct RecoverableAttempt {
     pub identity: Option<ProcessIdentity>,
     pub workspace_path: Option<String>,
     pub output_path: Option<String>,
+}
+
+/// A published route whose issue can be re-read to measure human agreement.
+///
+/// Carries the route mapping recorded at publication time so a later config
+/// reload cannot reinterpret this observation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CorrectionCandidate {
+    pub run_id: String,
+    pub stage_run_id: Option<String>,
+    pub artifact_id: String,
+    pub intent_id: String,
+    /// Durable forge issue id, used to re-read the issue independently of the
+    /// intake and implementation-candidate queries.
+    pub issue_id: String,
+    pub issue_identifier: String,
+    pub intake_label: String,
+    pub published_route: String,
+    pub desired_effects: serde_json::Value,
+}
+
+/// Kind of post-publication observation recorded against an artifact.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RouteObservationKind {
+    Corrected,
+    Inconsistent,
+}
+
+impl RouteObservationKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Corrected => "corrected",
+            Self::Inconsistent => "inconsistent",
+        }
+    }
 }
 
 /// Durable guard used by the implementation scheduler while automatic
@@ -202,6 +241,18 @@ pub trait FactoryRunStore {
     /// Clear the recorded process and paths once recovery has reclaimed them,
     /// so the same attempt is not swept twice.
     fn clear_attempt_process(&mut self, stage_run_id: &str) -> Result<()>;
+    /// Applied automatic publications whose issues can be re-read to measure
+    /// whether a human later changed the route.
+    fn list_correction_candidates(&self, limit: usize) -> Result<Vec<CorrectionCandidate>>;
+    /// Record one post-publication observation. Returns `false` when this
+    /// artifact already recorded the same observation, which keeps the
+    /// reconciler idempotent across polls.
+    fn record_route_observation(
+        &mut self,
+        artifact_id: &str,
+        kind: RouteObservationKind,
+        value: &str,
+    ) -> Result<bool>;
     fn triage_metrics(&self) -> Result<TriageMetricsAggregate>;
 }
 
@@ -236,7 +287,9 @@ impl SqliteFactoryStore {
         let conn = Connection::open(path).map_err(storage_error)?;
         conn.busy_timeout(StdDuration::from_millis(busy_timeout_ms))
             .map_err(storage_error)?;
-        conn.execute_batch(INIT_SQL).map_err(storage_error)?;
+        for migration in MIGRATIONS {
+            conn.execute_batch(migration).map_err(storage_error)?;
+        }
 
         Ok(Self {
             conn,
@@ -1134,6 +1187,68 @@ impl FactoryRunStore for SqliteFactoryStore {
         Ok(())
     }
 
+    fn list_correction_candidates(&self, limit: usize) -> Result<Vec<CorrectionCandidate>> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT i.run_id, a.stage_run_id, i.artifact_id, i.intent_id, r.issue_id,
+                        r.issue_identifier, i.intake_label, a.route, i.desired_effects_json
+                 FROM publication_intents i
+                 JOIN triage_artifacts a ON a.artifact_id = i.artifact_id
+                 JOIN factory_runs r ON r.run_id = i.run_id
+                 WHERE i.mode = ?1 AND i.status = ?2
+                 ORDER BY i.updated_at DESC
+                 LIMIT ?3",
+            )
+            .map_err(storage_error)?;
+        let rows = stmt
+            .query_map(
+                params![
+                    PublicationMode::Automatic.as_str(),
+                    PublicationStatus::Applied.as_str(),
+                    limit as i64,
+                ],
+                |row| {
+                    let desired: String = row.get(8)?;
+                    Ok(CorrectionCandidate {
+                        run_id: row.get(0)?,
+                        stage_run_id: row.get(1)?,
+                        artifact_id: row.get(2)?,
+                        intent_id: row.get(3)?,
+                        issue_id: row.get(4)?,
+                        issue_identifier: row.get(5)?,
+                        intake_label: row.get(6)?,
+                        published_route: row.get(7)?,
+                        desired_effects: serde_json::from_str(&desired)
+                            .unwrap_or(serde_json::Value::Null),
+                    })
+                },
+            )
+            .map_err(storage_error)?;
+        let mut candidates = Vec::new();
+        for row in rows {
+            candidates.push(row.map_err(storage_error)?);
+        }
+        Ok(candidates)
+    }
+
+    fn record_route_observation(
+        &mut self,
+        artifact_id: &str,
+        kind: RouteObservationKind,
+        value: &str,
+    ) -> Result<bool> {
+        let inserted = self
+            .conn
+            .execute(
+                "INSERT OR IGNORE INTO route_observations (artifact_id, kind, value, observed_at)
+                 VALUES (?1, ?2, ?3, ?4)",
+                params![artifact_id, kind.as_str(), value, ts(Self::now())],
+            )
+            .map_err(storage_error)?;
+        Ok(inserted == 1)
+    }
+
     fn interrupt_stale_attempts(&mut self) -> Result<u64> {
         let stale_before = ts(Self::now() - Duration::milliseconds(TRIAGE_LEASE_STALE_AFTER_MS));
         let changed = self
@@ -1780,6 +1895,82 @@ mod tests {
         assert!(
             store.list_recoverable_attempts().unwrap().is_empty(),
             "a reclaimed attempt must not be swept again"
+        );
+    }
+
+    /// Correction measurement re-reads published issues from durable records,
+    /// so only applied automatic publications are candidates, and each artifact
+    /// records a given observation once.
+    #[test]
+    fn lists_applied_automatic_publications_as_correction_candidates() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("state.db");
+        let mut store = store(&path);
+        let attempt = store
+            .claim_attempt(claim_request("issue-rev", "config-rev"))
+            .unwrap();
+        let artifact = store
+            .store_artifact(StoreArtifactRequest {
+                stage_run_id: attempt.stage_run_id,
+                issue_revision: "issue-rev".to_string(),
+                configuration_revision: "config-rev".to_string(),
+                route_mapping_hash: "routes".to_string(),
+                artifact: artifact(TriageRoute::Implement),
+                bytes_len: 200,
+                usage: StageUsage::default(),
+            })
+            .unwrap();
+        let intent = store
+            .create_publication_intent(CreatePublicationIntentRequest {
+                run_id: artifact.run_id.clone(),
+                artifact_id: Some(artifact.artifact_id.clone()),
+                mode: PublicationMode::Automatic,
+                intake_label: "needs-triage".to_string(),
+                route_label: "ready-for-agent".to_string(),
+                project_state: Some("Todo".to_string()),
+                route_mapping_hash: "routes".to_string(),
+                desired_effects: serde_json::json!({"kind": "automatic_route"}),
+                observed_baseline: serde_json::json!({}),
+                expected_projection: serde_json::json!({}),
+            })
+            .unwrap();
+
+        assert!(
+            store.list_correction_candidates(10).unwrap().is_empty(),
+            "a pending publication is not yet a measurable decision"
+        );
+
+        store
+            .update_publication_step(
+                &intent.intent_id,
+                "comment_applied",
+                PublicationStatus::Applied,
+                None,
+            )
+            .unwrap();
+
+        let candidates = store.list_correction_candidates(10).unwrap();
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].published_route, "implement");
+        assert_eq!(candidates[0].issue_identifier, "#123");
+        assert_eq!(candidates[0].intake_label, "needs-triage");
+
+        assert!(store
+            .record_route_observation(
+                &artifact.artifact_id,
+                RouteObservationKind::Corrected,
+                "spec"
+            )
+            .unwrap());
+        assert!(
+            !store
+                .record_route_observation(
+                    &artifact.artifact_id,
+                    RouteObservationKind::Corrected,
+                    "spec"
+                )
+                .unwrap(),
+            "the same correction must only ever be recorded once"
         );
     }
 

--- a/docs/adrs/0002-triage-process-recovery-identity.md
+++ b/docs/adrs/0002-triage-process-recovery-identity.md
@@ -4,7 +4,7 @@ title: Triage process recovery identity
 status: Accepted
 description: Authorize interrupted-attempt process-group recovery with PID, process group, and OS start token while retaining executable identity as diagnostics.
 tags: [symphony, triage, adr, recovery, process]
-timestamp: 2026-07-25T19:15:00Z
+timestamp: 2026-07-25T22:35:00Z
 ---
 
 # ADR-0002: Triage process recovery identity
@@ -41,6 +41,16 @@ before the child's initial `exec`.
 5. **Verified bounded termination** — Recovery waits five seconds after
    `SIGTERM`, sends `SIGKILL` when a running group member remains, and confirms
    that no running/non-zombie group member remains before reporting success.
+6. **Retain unresolved recovery state** — Symphony clears durable process and
+   workspace fields only after termination or confirmed process absence.
+   Signal denial, identity uncertainty, and bounded `StillRunning` outcomes keep
+   the record for later recovery polls.
+7. **Isolate every supported harness** — On Unix, Pi and Codex triage children
+   start as process-group leaders so recovery never targets Symphony's inherited
+   group.
+8. **Authorize recursive cleanup from configuration and identity** — Recovery
+   removes only the exact `triage-<stage_run_id>` directory directly under the
+   configured `workspace.root`.
 
 ## Consequences
 
@@ -55,9 +65,13 @@ before the child's initial `exec`.
   before the signal minimizes but cannot eliminate that race.
 - A zombie leader may remain until its parent or init reaps it; zombies are not
   treated as running workers.
+- A narrow child-spawn-to-SQLite-persistence window remains. Eliminating it
+  requires runner-side durable identity recording and is outside this decision's
+  current implementation.
 
 ## Links
 
 - Spec: [A1 GitHub Issue Triage](/specs/2026-07-16-a1-github-issue-triage-design.md)
 - Rejected Verify: [A1 PR3 Verify report](/specs/2026-07-25-a1-pr3-verify-report.md)
+- Re-verify and review closeout: [A1 PR3 re-verify report](/specs/2026-07-25-a1-pr3-reverify-report.md)
 - Implementation: `apps/symphony/src/triage/process_identity.rs`

--- a/docs/adrs/0002-triage-process-recovery-identity.md
+++ b/docs/adrs/0002-triage-process-recovery-identity.md
@@ -1,0 +1,63 @@
+---
+type: ADR
+title: Triage process recovery identity
+status: Accepted
+description: Authorize interrupted-attempt process-group recovery with PID, process group, and OS start token while retaining executable identity as diagnostics.
+tags: [symphony, triage, adr, recovery, process]
+timestamp: 2026-07-25T19:15:00Z
+---
+
+# ADR-0002: Triage process recovery identity
+
+## Status
+
+Accepted (2026-07-25) during A1 PR3 remediation.
+
+## Context
+
+Symphony records a triage child immediately after spawn so a replacement
+Symphony process can terminate an orphaned attempt. The initial implementation
+required PID, process group, OS start token, and executable to remain equal.
+
+That executable comparison rejected a legitimate launcher transition observed
+during A1 PR3 Verify: a recorded shell used `exec` to become the worker. Its
+PID, process group, and Linux start token remained stable, but `/proc/<pid>/exe`
+changed. Recovery removed the workspace and retried while leaving the worker
+alive. The same race made a test nondeterministic when identity capture occurred
+before the child's initial `exec`.
+
+## Decision
+
+1. **Stable authorization tuple** — Recovery authorizes a signal using the
+   process leader PID, process-group ID, and OS process start token.
+2. **Executable is diagnostic** — The executable observed at spawn remains in
+   SQLite and the HTTP stage-run record for compatibility and diagnosis. An
+   executable difference is logged as drift and does not deny signaling.
+3. **Fail closed** — Invalid identifiers, Symphony's own group, a missing start
+   token, an absent process, an unreadable live token, a group mismatch, or a
+   start-token mismatch deny signaling with a structured reason.
+4. **Recheck before signal** — Bounded termination repeats the stable-identity
+   assessment immediately before sending `SIGTERM`.
+5. **Verified bounded termination** — Recovery waits five seconds after
+   `SIGTERM`, sends `SIGKILL` when a running group member remains, and confirms
+   that no running/non-zombie group member remains before reporting success.
+
+## Consequences
+
+- Launchers may safely replace themselves through `exec` without becoming
+  unrecoverable.
+- PID reuse remains guarded by the OS start token and exact process-group match.
+- No SQLite migration or breaking HTTP schema change is needed.
+- Linux uses `/proc/<pid>/stat` start ticks. Other supported systems use the
+  coarser `ps -o lstart=` value and retain that platform limitation.
+- A small time-of-check/time-of-signal race remains because POSIX group
+  signaling is not an atomic identity-and-signal operation. Rechecking directly
+  before the signal minimizes but cannot eliminate that race.
+- A zombie leader may remain until its parent or init reaps it; zombies are not
+  treated as running workers.
+
+## Links
+
+- Spec: [A1 GitHub Issue Triage](/specs/2026-07-16-a1-github-issue-triage-design.md)
+- Rejected Verify: [A1 PR3 Verify report](/specs/2026-07-25-a1-pr3-verify-report.md)
+- Implementation: `apps/symphony/src/triage/process_identity.rs`

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -7,6 +7,7 @@ When `/domain-modeling` or architecture work records a decision, place it under 
 # Accepted
 
 * [ADR-0001 A1 triage durability and isolation](0001-a1-triage-durability-and-isolation.md) - SQLite factory runs, forge-host identity, Projects v2 membership keys, local runner isolation, lease renewal, preview intents
+* [ADR-0002 Triage process recovery identity](0002-triage-process-recovery-identity.md) - PID, process group, and OS start token authorize recovery; executable identity is diagnostic
 
 # Proposed
 

--- a/docs/adrs/log.md
+++ b/docs/adrs/log.md
@@ -1,5 +1,8 @@
 # ADRs Update Log
 
+## 2026-07-25
+* **Accepted and updated**: [ADR-0002 triage process recovery identity](/adrs/0002-triage-process-recovery-identity.md) authorizes recovery by PID, process group, and OS start token while treating executable identity as diagnostic; review remediation adds unresolved-state retention, Pi/Codex process-group isolation, cleanup-root authorization, and the remaining spawn-to-persistence window.
+
 ## 2026-07-18
 * **Accepted**: [ADR-0001 A1 triage durability and isolation](/adrs/0001-a1-triage-durability-and-isolation.md) records SQLite durability, forge-host mapping, membership keys, runner isolation, lease renewal, and preview intent recovery from PR1.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ Open Knowledge Format (OKF) bundle for the Kata monorepo: Kata CLI (`apps/cli`) 
 
 * [Symphony Software Factory Platform PRD](specs/symphony-software-factory-platform-prd.md) - product direction and vertical-slice roadmap (Active; A1 PR1 shipped)
 * [Specs roadmap](specs/) - active, planned, and completed work (links into historical Superpowers plans/specs)
-* [A1 GitHub Issue Triage](specs/2026-07-16-a1-github-issue-triage-design.md) - PR1 shipped; PR2 automatic routing Verify accepted (merge pending)
+* [A1 GitHub Issue Triage](specs/2026-07-16-a1-github-issue-triage-design.md) - PR1 shipped; PR2 Verify accepted (merge pending); PR3 implementation PR #599 has all review threads resolved and required CI passing while live acceptance remains blocked on UAT containment
 * [ADRs](adrs/) - architecture decision records ([ADR-0001](adrs/0001-a1-triage-durability-and-isolation.md), [ADR-0002](adrs/0002-triage-process-recovery-identity.md))
 
 # Guides

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ Open Knowledge Format (OKF) bundle for the Kata monorepo: Kata CLI (`apps/cli`) 
 * [Symphony Software Factory Platform PRD](specs/symphony-software-factory-platform-prd.md) - product direction and vertical-slice roadmap (Active; A1 PR1 shipped)
 * [Specs roadmap](specs/) - active, planned, and completed work (links into historical Superpowers plans/specs)
 * [A1 GitHub Issue Triage](specs/2026-07-16-a1-github-issue-triage-design.md) - PR1 shipped; PR2 automatic routing Verify accepted (merge pending)
-* [ADRs](adrs/) - architecture decision records ([ADR-0001](adrs/0001-a1-triage-durability-and-isolation.md))
+* [ADRs](adrs/) - architecture decision records ([ADR-0001](adrs/0001-a1-triage-durability-and-isolation.md), [ADR-0002](adrs/0002-triage-process-recovery-identity.md))
 
 # Guides
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -1,6 +1,7 @@
 # Docs Update Log
 
 ## 2026-07-25
+* **A1 PR3 review threads resolved and CI passed**: [PR #599](https://github.com/gannonh/kata-symphony/pull/599) now isolates Codex process groups, retains unresolved orphan records, authorizes recursive cleanup against `workspace.root` and stage identity, and measures only latest publications using randomized bounded correction batches. All review threads and required CI checks pass; the [re-verify report](/specs/2026-07-25-a1-pr3-reverify-report.md) remains Incomplete pending credential rotation, UAT cleanup PR #18, and live verification.
 * **A1 PR3 remediation automated gates passed; live re-verify blocked**: Stable PID/group/start-token recovery now permits launcher `exec`, UAT evidence records sanitized coordinates, cleanup validates all targets before provider work, and ten repeated library suites plus full validation pass. Added [ADR-0002](/adrs/0002-triage-process-recovery-identity.md) and an [incomplete re-verify report](/specs/2026-07-25-a1-pr3-reverify-report.md). Live UAT awaits provider credential rotation and merge of `gannonh/uat-symphony` cleanup PR #18.
 * **A1 PR3 Verify rejected**: Added the [Verify report](/specs/2026-07-25-a1-pr3-verify-report.md) and updated the [roadmap](/specs/index.md), [A1 design](/specs/2026-07-16-a1-github-issue-triage-design.md), and [factory PRD](/specs/symphony-software-factory-platform-prd.md). Live correction/metrics checks passed; restart recovery leaked a post-`exec` orphan.
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -1,5 +1,8 @@
 # Docs Update Log
 
+## 2026-07-25
+* **A1 PR3 Verify rejected**: Added the [Verify report](/specs/2026-07-25-a1-pr3-verify-report.md) and updated the [roadmap](/specs/index.md), [A1 design](/specs/2026-07-16-a1-github-issue-triage-design.md), and [factory PRD](/specs/symphony-software-factory-platform-prd.md). Live correction/metrics checks passed; restart recovery leaked a post-`exec` orphan.
+
 ## 2026-07-24
 * **A1 PR2 Verify accepted**: Live UAT on `gannonh/uat-symphony` Project #16 + automated suite; [verify report](/specs/2026-07-24-a1-pr2-verify-report.md). Roadmap/PRD/A1 design mark PR2 verified (merge pending).
 * **A1 PR2 build**: Automatic route publication implemented; added [build report](/specs/2026-07-24-a1-pr2-build-report.md) and updated [specs roadmap](/specs/index.md), [A1 design](/specs/2026-07-16-a1-github-issue-triage-design.md), and [factory PRD](/specs/symphony-software-factory-platform-prd.md).

--- a/docs/log.md
+++ b/docs/log.md
@@ -1,6 +1,7 @@
 # Docs Update Log
 
 ## 2026-07-25
+* **A1 PR3 remediation automated gates passed; live re-verify blocked**: Stable PID/group/start-token recovery now permits launcher `exec`, UAT evidence records sanitized coordinates, cleanup validates all targets before provider work, and ten repeated library suites plus full validation pass. Added [ADR-0002](/adrs/0002-triage-process-recovery-identity.md) and an [incomplete re-verify report](/specs/2026-07-25-a1-pr3-reverify-report.md). Live UAT awaits provider credential rotation and merge of `gannonh/uat-symphony` cleanup PR #18.
 * **A1 PR3 Verify rejected**: Added the [Verify report](/specs/2026-07-25-a1-pr3-verify-report.md) and updated the [roadmap](/specs/index.md), [A1 design](/specs/2026-07-16-a1-github-issue-triage-design.md), and [factory PRD](/specs/symphony-software-factory-platform-prd.md). Live correction/metrics checks passed; restart recovery leaked a post-`exec` orphan.
 
 ## 2026-07-24

--- a/docs/specs/2026-07-16-a1-github-issue-triage-design.md
+++ b/docs/specs/2026-07-16-a1-github-issue-triage-design.md
@@ -4,16 +4,16 @@ title: A1 GitHub Issue Triage
 status: Active
 description: Design for a durable, repository-backed GitHub triage stage that routes issues into Symphony's software factory.
 tags: [symphony, software-factory, triage, github]
-timestamp: 2026-07-18T16:45:00Z
+timestamp: 2026-07-25T22:35:00Z
 ---
 
 # A1 GitHub Issue Triage
 
 ## Status
 
-Active — **PR1 (triage preview) shipped** in [#587](https://github.com/gannonh/kata-symphony/pull/587) (`80b3c215`). **PR2 (automatic route publication) Verify accepted** ([build](/specs/2026-07-24-a1-pr2-build-report.md), [verify](/specs/2026-07-24-a1-pr2-verify-report.md)); merge/PR pending. **PR3 (recovery and agreement measurement) remediation passes automated gates; live re-verify is blocked on UAT credential rotation** ([build](/specs/2026-07-25-a1-pr3-build-report.md), [rejected verify](/specs/2026-07-25-a1-pr3-verify-report.md), [incomplete re-verify](/specs/2026-07-25-a1-pr3-reverify-report.md)).
+Active — **PR1 (triage preview) shipped** in [#587](https://github.com/gannonh/kata-symphony/pull/587) (`80b3c215`). **PR2 (automatic route publication) Verify accepted** ([build](/specs/2026-07-24-a1-pr2-build-report.md), [verify](/specs/2026-07-24-a1-pr2-verify-report.md)); merge/PR pending. **PR3 (recovery and agreement measurement) implementation PR [#599](https://github.com/gannonh/kata-symphony/pull/599) has all review threads resolved and required CI passing; live re-verify remains blocked on UAT credential rotation and cleanup PR #18** ([build](/specs/2026-07-25-a1-pr3-build-report.md), [rejected verify](/specs/2026-07-25-a1-pr3-verify-report.md), [incomplete re-verify](/specs/2026-07-25-a1-pr3-reverify-report.md)).
 
-Related decisions: [ADR-0001 A1 triage durability and isolation](/adrs/0001-a1-triage-durability-and-isolation.md).
+Related decisions: [ADR-0001 A1 triage durability and isolation](/adrs/0001-a1-triage-durability-and-isolation.md) and [ADR-0002 triage process recovery identity](/adrs/0002-triage-process-recovery-identity.md).
 
 ## Goal
 

--- a/docs/specs/2026-07-16-a1-github-issue-triage-design.md
+++ b/docs/specs/2026-07-16-a1-github-issue-triage-design.md
@@ -11,7 +11,7 @@ timestamp: 2026-07-18T16:45:00Z
 
 ## Status
 
-Active — **PR1 (triage preview) shipped** in [#587](https://github.com/gannonh/kata-symphony/pull/587) (`80b3c215`). **PR2 (automatic route publication) Verify accepted** ([build](/specs/2026-07-24-a1-pr2-build-report.md), [verify](/specs/2026-07-24-a1-pr2-verify-report.md)); merge/PR pending. PR3 (recovery and agreement measurement) remains open.
+Active — **PR1 (triage preview) shipped** in [#587](https://github.com/gannonh/kata-symphony/pull/587) (`80b3c215`). **PR2 (automatic route publication) Verify accepted** ([build](/specs/2026-07-24-a1-pr2-build-report.md), [verify](/specs/2026-07-24-a1-pr2-verify-report.md)); merge/PR pending. **PR3 (recovery and agreement measurement) implemented** ([build](/specs/2026-07-25-a1-pr3-build-report.md)); automated gates pass, live restart/correction UAT pending Verify.
 
 Related decisions: [ADR-0001 A1 triage durability and isolation](/adrs/0001-a1-triage-durability-and-isolation.md).
 

--- a/docs/specs/2026-07-16-a1-github-issue-triage-design.md
+++ b/docs/specs/2026-07-16-a1-github-issue-triage-design.md
@@ -11,7 +11,7 @@ timestamp: 2026-07-18T16:45:00Z
 
 ## Status
 
-Active — **PR1 (triage preview) shipped** in [#587](https://github.com/gannonh/kata-symphony/pull/587) (`80b3c215`). **PR2 (automatic route publication) Verify accepted** ([build](/specs/2026-07-24-a1-pr2-build-report.md), [verify](/specs/2026-07-24-a1-pr2-verify-report.md)); merge/PR pending. **PR3 (recovery and agreement measurement) implemented** ([build](/specs/2026-07-25-a1-pr3-build-report.md)); automated gates pass, live restart/correction UAT pending Verify.
+Active — **PR1 (triage preview) shipped** in [#587](https://github.com/gannonh/kata-symphony/pull/587) (`80b3c215`). **PR2 (automatic route publication) Verify accepted** ([build](/specs/2026-07-24-a1-pr2-build-report.md), [verify](/specs/2026-07-24-a1-pr2-verify-report.md)); merge/PR pending. **PR3 (recovery and agreement measurement) Verify rejected** ([build](/specs/2026-07-25-a1-pr3-build-report.md), [verify](/specs/2026-07-25-a1-pr3-verify-report.md)): correction/metrics checks pass, but restart recovery leaves a post-`exec` orphan alive.
 
 Related decisions: [ADR-0001 A1 triage durability and isolation](/adrs/0001-a1-triage-durability-and-isolation.md).
 

--- a/docs/specs/2026-07-16-a1-github-issue-triage-design.md
+++ b/docs/specs/2026-07-16-a1-github-issue-triage-design.md
@@ -11,7 +11,7 @@ timestamp: 2026-07-18T16:45:00Z
 
 ## Status
 
-Active — **PR1 (triage preview) shipped** in [#587](https://github.com/gannonh/kata-symphony/pull/587) (`80b3c215`). **PR2 (automatic route publication) Verify accepted** ([build](/specs/2026-07-24-a1-pr2-build-report.md), [verify](/specs/2026-07-24-a1-pr2-verify-report.md)); merge/PR pending. **PR3 (recovery and agreement measurement) Verify rejected** ([build](/specs/2026-07-25-a1-pr3-build-report.md), [verify](/specs/2026-07-25-a1-pr3-verify-report.md)): correction/metrics checks pass, but restart recovery leaves a post-`exec` orphan alive.
+Active — **PR1 (triage preview) shipped** in [#587](https://github.com/gannonh/kata-symphony/pull/587) (`80b3c215`). **PR2 (automatic route publication) Verify accepted** ([build](/specs/2026-07-24-a1-pr2-build-report.md), [verify](/specs/2026-07-24-a1-pr2-verify-report.md)); merge/PR pending. **PR3 (recovery and agreement measurement) remediation passes automated gates; live re-verify is blocked on UAT credential rotation** ([build](/specs/2026-07-25-a1-pr3-build-report.md), [rejected verify](/specs/2026-07-25-a1-pr3-verify-report.md), [incomplete re-verify](/specs/2026-07-25-a1-pr3-reverify-report.md)).
 
 Related decisions: [ADR-0001 A1 triage durability and isolation](/adrs/0001-a1-triage-durability-and-isolation.md).
 

--- a/docs/specs/2026-07-25-a1-pr3-build-report.md
+++ b/docs/specs/2026-07-25-a1-pr3-build-report.md
@@ -4,7 +4,7 @@ title: A1 PR3 Recovery and Agreement Measurement Build Report
 status: Implemented
 description: Build completion report for A1 PR3 interrupted-attempt recovery, route correction measurement, and agreement metrics.
 tags: [symphony, triage, a1, pr3, recovery, correction]
-timestamp: 2026-07-25T00:00:00Z
+timestamp: 2026-07-25T22:35:00Z
 ---
 
 # A1 PR3 Recovery and Agreement Measurement — Build Report
@@ -104,7 +104,7 @@ New behaviour coverage:
 ## Known gaps and follow-ups
 
 - **Live UAT outstanding (AC18).** Restart and correction evidence against `gannonh/uat-symphony` is Verify-phase work; the maintainer confirmed that target.
-- **Codex children are not process-group leaders.** `codex_session_start` does not call `process_group(0)`, so its child shares Symphony's group. Identity is recorded faithfully and recovery correctly refuses to signal it, meaning an orphaned Codex app-server is cleaned up by directory removal but not terminated. The Pi path is unaffected. Worth closing separately.
+- **Spawn identity has a narrow durability window.** Identity is sent to the coordinator immediately after spawn, but a process exit before the coordinator persists it can still leave an unrecorded worker and attempt directory. Closing that window requires runner-side durable recording and remains a focused follow-up.
 - **Non-Linux start tokens use `ps`.** Linux reads `/proc/<pid>/stat`; other platforms shell out to `ps -o lstart=`. Only the Linux path was exercised in this environment.
 - Broader orchestrator integration test proving dispatch exclusion across config reload (carried over from PR2).
 
@@ -129,3 +129,25 @@ Commit `424bd4b` makes Symphony UAT evidence self-contained and validates every
 GitHub cleanup target before provider work. The automated remediation gates pass;
 live re-verification remains gated on credential containment as recorded in the
 [re-verify report](2026-07-25-a1-pr3-reverify-report.md).
+
+## 2026-07-25 PR review addendum
+
+PR [#599](https://github.com/gannonh/kata-symphony/pull/599) review remediation
+closed the following runtime and measurement gaps in `ea6bd9d9`:
+
+- Codex children now start as Unix process-group leaders, matching the Pi path.
+- Recovery retains durable process and workspace state until the process group is
+  confirmed terminated or absent; denied or bounded-still-running outcomes are
+  retried on later polls.
+- Recursive attempt cleanup requires the exact `triage-<stage_run_id>` directory
+  directly under configured `workspace.root`.
+- Correction measurement uses only each run's latest applied automatic
+  publication and randomizes bounded candidate batches instead of repeatedly
+  selecting the fixed newest set.
+
+The focused `triage::` suite passed 89/89 tests. PR CI run
+[`30177679884`](https://github.com/gannonh/kata-symphony/actions/runs/30177679884)
+passed validate, Symphony coverage, GitHub backend validation, golden-path smoke,
+distribution, and aggregate gate checks after the formatting follow-up
+`6833395a`. All PR review threads are resolved. These results close automated PR
+review findings; they do not replace the blocked live-UAT acceptance gate.

--- a/docs/specs/2026-07-25-a1-pr3-build-report.md
+++ b/docs/specs/2026-07-25-a1-pr3-build-report.md
@@ -115,3 +115,17 @@ The sandbox had no Rust toolchain despite the repo's environment notes; stable R
 ## Build handoff to Verify
 
 Verify should cover the restart, retry, correction, and agreement portions of criteria 4 and 14–18, with live GitHub evidence on `gannonh/uat-symphony`.
+
+## 2026-07-25 remediation addendum
+
+The initial Verify run found that executable equality rejected a legitimate
+launcher-to-worker `exec` transition and made the recovery test flaky. Commit
+`66f3da1` now authorizes signaling with PID, process group, and OS start token,
+retains executable identity as diagnostics, rechecks identity before signaling,
+and verifies that no running group member remains. A deterministic FIFO-backed
+launcher regression covers the exact failure shape.
+
+Commit `424bd4b` makes Symphony UAT evidence self-contained and validates every
+GitHub cleanup target before provider work. The automated remediation gates pass;
+live re-verification remains gated on credential containment as recorded in the
+[re-verify report](2026-07-25-a1-pr3-reverify-report.md).

--- a/docs/specs/2026-07-25-a1-pr3-build-report.md
+++ b/docs/specs/2026-07-25-a1-pr3-build-report.md
@@ -1,0 +1,117 @@
+---
+type: Build Report
+title: A1 PR3 Recovery and Agreement Measurement Build Report
+status: Implemented
+description: Build completion report for A1 PR3 interrupted-attempt recovery, route correction measurement, and agreement metrics.
+tags: [symphony, triage, a1, pr3, recovery, correction]
+timestamp: 2026-07-25T00:00:00Z
+---
+
+# A1 PR3 Recovery and Agreement Measurement — Build Report
+
+## Status
+
+**Implemented** — automated gates pass. Live GitHub UAT (AC18 restart + correction evidence) is outstanding and belongs to Verify.
+
+## Spec
+
+- Spec path: [`2026-07-16-a1-github-issue-triage-design.md`](2026-07-16-a1-github-issue-triage-design.md)
+- Scope: A1 PR3 delivery slice — the restart, retry, correction, and agreement portions of criteria 4 and 14–18
+- Prior slice: [PR2 build report](2026-07-24-a1-pr2-build-report.md), [PR2 verify report](2026-07-24-a1-pr2-verify-report.md)
+- Non-goals: A2 spec stage, Linear parity, Docker/SSH execution
+
+## Git range
+
+- Base SHA: `6a454fe93ee3f1358f3ead25642cbb107d87bc5e`
+- Head SHA: `b2199b5`
+- Commits: `09f5422`, `251003d`, `b2199b5`
+
+## Tasks completed
+
+1. Reject late output from an interrupted attempt (`store_artifact` status guard)
+2. Record attempt process identity and disposable paths (`triage::process_identity`, runner spawn sink, store `record_attempt_process`)
+3. Reclaim interrupted attempts: identity-matched bounded termination plus attempt-directory cleanup
+4. Correction reconciler with `triage_route_corrected` events and durable-only consistency diagnostics
+5. Agreement metrics verified through `triage_metrics` / `GET /api/v1/factory-runs/metrics?stage=triage`
+6. Quality gate and reference documentation
+
+## Files changed
+
+- `apps/symphony/src/triage/process_identity.rs` (new)
+- `apps/symphony/src/triage/correction.rs` (new)
+- `apps/symphony/src/triage/migrations/002_route_observations.sql` (new)
+- `apps/symphony/src/triage/coordinator.rs`
+- `apps/symphony/src/triage/store.rs`
+- `apps/symphony/src/triage/runner.rs`
+- `apps/symphony/src/triage/runtime.rs`
+- `apps/symphony/src/triage/mod.rs`
+- `apps/symphony/docs/WORKFLOW-REFERENCE.md`
+
+## Design decisions
+
+- **Route-consistency diagnostic is durable-only.** The spec fixes the live event vocabulary to exactly nine names, while the PR3 slice lists "consistency events". Zero-or-several route labels writes a `triage_route_consistency` factory event and is excluded from the live `EventHub` vocabulary and from `correction_count`. Confirmed with the maintainer before implementation.
+- **Correction dedupe uses a table, not event scanning.** `route_observations` has primary key `(artifact_id, kind, value)`, so the reconciler is idempotent across polls by construction.
+- **Comparison uses the recorded mapping.** Both publication and correction read the five labels from the intent's `desired_effects`, so a live `WORKFLOW.md` reload cannot reinterpret an older publication.
+- **Measurement suspends while intake is reapplied.** A re-added intake label means a new attempt is coming, so the old route is no longer the decision under measurement.
+
+## Bugs found and fixed while building
+
+- `store_artifact` unconditionally set the stage to `completed`, so late output could silently mark an attempt a restart had already abandoned as successful, corrupting retry accounting.
+- `process_identity::capture` read the child's process group back after spawn, racing the child's `setpgid`. Under load it could record *Symphony's own* group. Recovery would then refuse to signal (failing safe, but never terminating real orphans). Group-leader children now record the known group id directly.
+
+## Tests and verification
+
+```bash
+cd apps/symphony
+cargo fmt --check                    # pass
+cargo clippy -- -D warnings          # pass (documented gate)
+cargo test                           # pass
+
+# repository affected-package validation, same command as CI
+pnpm exec turbo run lint typecheck test --affected   # 2 successful, 2 total
+```
+
+Results: **229** lib tests pass (**84** under `triage::`, up from 61 at PR2), plus all integration test binaries. The triage suite was run three consecutive times to confirm the process-signalling tests are not flaky.
+
+New behaviour coverage:
+
+| Area | Test |
+| --- | --- |
+| Late output rejected | `store::interrupted_attempt_cannot_be_completed_by_late_output` |
+| Identity persisted for recovery | `store::interrupted_attempt_exposes_recorded_process_for_recovery` |
+| Candidate query + dedupe | `store::lists_applied_automatic_publications_as_correction_candidates` |
+| Live process identified | `process_identity::captures_identity_for_a_live_process` |
+| Reused PID rejected | `process_identity::rejects_identity_whose_start_token_changed` |
+| setpgid race | `process_identity::child_group_is_recorded_without_racing_setpgid` |
+| Self-group protection | `process_identity::refuses_to_signal_symphonys_own_process_group` |
+| Bounded termination | `process_identity::terminates_a_live_process_group` |
+| Cleanup path safety | `process_identity::cleanup_root_accepts_only_runner_created_attempt_dirs` |
+| Spawn reporting | `runner::reports_spawned_child_identity_and_attempt_paths` |
+| Orphan recovery end to end | `coordinator::recovery_terminates_orphaned_child_and_removes_attempt_directory` |
+| Correction once per artifact + metrics | `coordinator::human_route_swap_records_one_correction_across_repeated_polls` |
+| Agreement records nothing | `coordinator::unchanged_route_label_records_no_correction` |
+| Ambiguity is durable-only | `coordinator::ambiguous_route_labels_record_durable_diagnostic_only` |
+| Intake reapplied suspends measurement | `coordinator::reapplied_intake_label_suspends_correction_measurement` |
+| Route comparison semantics | five tests in `triage::correction` |
+
+## Review gates
+
+- Bundled TDD workflow followed: one behaviour test at a time, RED verified before each implementation step
+- Independent subagent review: **not used** — no subagent was requested for this session; reviews were performed inline
+- Spec compliance (self-check): PR3 merge-gate criteria covered in code and tests, except the live-UAT portion of AC18
+- Code quality (self-check): no new clippy findings; `cargo clippy --all-targets` reports 5 pre-existing findings in `src/github/auth.rs` and `tests/*` that also fail at the base SHA under clippy 1.97
+
+## Known gaps and follow-ups
+
+- **Live UAT outstanding (AC18).** Restart and correction evidence against `gannonh/uat-symphony` is Verify-phase work; the maintainer confirmed that target.
+- **Codex children are not process-group leaders.** `codex_session_start` does not call `process_group(0)`, so its child shares Symphony's group. Identity is recorded faithfully and recovery correctly refuses to signal it, meaning an orphaned Codex app-server is cleaned up by directory removal but not terminated. The Pi path is unaffected. Worth closing separately.
+- **Non-Linux start tokens use `ps`.** Linux reads `/proc/<pid>/stat`; other platforms shell out to `ps -o lstart=`. Only the Linux path was exercised in this environment.
+- Broader orchestrator integration test proving dispatch exclusion across config reload (carried over from PR2).
+
+## Environment note
+
+The sandbox had no Rust toolchain despite the repo's environment notes; stable Rust and `openssl-devel` were installed before any code was written, so every result above comes from a real build.
+
+## Build handoff to Verify
+
+Verify should cover the restart, retry, correction, and agreement portions of criteria 4 and 14–18, with live GitHub evidence on `gannonh/uat-symphony`.

--- a/docs/specs/2026-07-25-a1-pr3-reverify-report.md
+++ b/docs/specs/2026-07-25-a1-pr3-reverify-report.md
@@ -4,7 +4,7 @@ title: A1 PR3 Recovery and Agreement Measurement Re-verify Report
 status: Incomplete
 description: Automated remediation proof for A1 PR3; live GitHub re-verification remains gated on credential revocation and UAT repository cleanup.
 tags: [symphony, triage, a1, pr3, verify, uat, github, security]
-timestamp: 2026-07-25T19:30:00Z
+timestamp: 2026-07-25T22:35:00Z
 ---
 
 # A1 PR3 Recovery and Agreement Measurement — Re-verify Report
@@ -23,6 +23,7 @@ preserved as the historical result.
 
 - Runtime recovery remediation: `66f3da1`
 - Evidence and cleanup remediation: `424bd4b`
+- PR review remediation: `ea6bd9d9`, formatting follow-up `6833395a`
 - Runtime/backend: Symphony runtime and GitHub Projects v2 evidence harness
 - Intended live target after containment: `gannonh/uat-symphony`, Project
   [#16](https://github.com/users/gannonh/projects/16)
@@ -33,10 +34,14 @@ preserved as the historical result.
 | --- | --- | --- |
 | Stable recovery identity | Pass (automated) | PID, process group, and OS start token authorize signaling; executable drift is diagnostic |
 | Launcher `exec` regression | Pass (automated) | Deterministic FIFO barrier captures the shell, releases `exec sleep`, and verifies termination |
-| Recovery state cleanup | Pass (automated) | Prior stage stays interrupted; process/path fields and attempt directory are cleared |
-| Flake gate | Pass | 10 consecutive library runs, 233/233 each (2,330 tests total) |
+| Recovery state cleanup | Implemented; CI pass | Process/path fields and attempt directory clear only after termination or confirmed absence; uncertain/live outcomes retain durable recovery state (retention branches are not covered by a dedicated assertion) |
+| Codex process isolation | Implemented; CI pass | Unix Codex children are configured as process-group leaders, matching Pi recovery isolation (no dedicated Codex group-leader assertion) |
+| Cleanup path authorization | Pass (automated) | Recursive cleanup requires exact stage-run directory under configured `workspace.root` |
+| Correction candidate semantics | Pass (automated) | Latest applied publication per run is measured; randomized bounded batches replace the fixed newest-only selection |
+| Flake gate (pre-review remediation) | Pass | 10 consecutive library runs at `424bd4b`, 233/233 each (2,330 tests total); current HEAD contains 234 library tests |
 | Full Rust suite | Pass | `cargo test --manifest-path apps/symphony/Cargo.toml` |
 | Affected validation | Pass | `pnpm run validate:affected` — lint, typecheck, and tests |
+| PR #599 required checks | Pass | CI run [30177679884](https://github.com/gannonh/kata-symphony/actions/runs/30177679884): validate, coverage, backend validation, smoke, distributions, and gate |
 | Evidence config | Pass (automated/dry-run) | Sanitized effective repository/project coordinates are stored without token values |
 | Cleanup target safety | Pass (automated/dry-run) | Stored config and legacy URL resolution pass; conflicting repositories fail before provider work |
 | UAT repository current-tree cleanup | Draft | [gannonh/uat-symphony#18](https://github.com/gannonh/uat-symphony/pull/18) removes 40,800 generated lines, credentials, logs, and unintended gitlinks |
@@ -76,6 +81,20 @@ The UAT evidence runner also completed a GitHub dry run for
 `gannonh/uat-symphony` Project #16. A synthetic cleanup dry run used stored
 coordinates without overrides, and a mismatched repository dry run failed
 before any provider call. No live issue or project state was created.
+
+## PR thread and CI closeout
+
+PR [#599](https://github.com/gannonh/kata-symphony/pull/599) has a clean merge
+state, all review threads resolved, and all required checks passing at
+`6833395a`. Review remediation added Codex process-group isolation, durable
+retention for unresolved orphan recovery, cleanup-root authorization, and
+latest-per-run randomized correction candidates. The focused `triage::` suite
+passed 89/89 tests before the final CI run.
+
+The narrow spawn-to-coordinator persistence window remains a follow-up: a hard
+process exit immediately after child spawn can occur before SQLite records the
+identity. Closing it requires runner-side durable recording. This does not alter
+the existing credential-containment and live-UAT acceptance gate below.
 
 ## Remaining acceptance gate
 

--- a/docs/specs/2026-07-25-a1-pr3-reverify-report.md
+++ b/docs/specs/2026-07-25-a1-pr3-reverify-report.md
@@ -1,0 +1,97 @@
+---
+type: Verify Report
+title: A1 PR3 Recovery and Agreement Measurement Re-verify Report
+status: Incomplete
+description: Automated remediation proof for A1 PR3; live GitHub re-verification remains gated on credential revocation and UAT repository cleanup.
+tags: [symphony, triage, a1, pr3, verify, uat, github, security]
+timestamp: 2026-07-25T19:30:00Z
+---
+
+# A1 PR3 Recovery and Agreement Measurement — Re-verify Report
+
+## Status
+
+**Incomplete** — the post-`exec` recovery defect, flaky test, and evidence
+cleanup defect are fixed and pass automated validation. Live GitHub
+re-verification was intentionally not run because credentials committed by the
+UAT repository have not yet been confirmed revoked. A1 PR3 remains blocked.
+
+The original [rejected Verify report](2026-07-25-a1-pr3-verify-report.md) is
+preserved as the historical result.
+
+## Code under test
+
+- Runtime recovery remediation: `66f3da1`
+- Evidence and cleanup remediation: `424bd4b`
+- Runtime/backend: Symphony runtime and GitHub Projects v2 evidence harness
+- Intended live target after containment: `gannonh/uat-symphony`, Project
+  [#16](https://github.com/users/gannonh/projects/16)
+
+## Remediation results
+
+| Area | Result | Evidence |
+| --- | --- | --- |
+| Stable recovery identity | Pass (automated) | PID, process group, and OS start token authorize signaling; executable drift is diagnostic |
+| Launcher `exec` regression | Pass (automated) | Deterministic FIFO barrier captures the shell, releases `exec sleep`, and verifies termination |
+| Recovery state cleanup | Pass (automated) | Prior stage stays interrupted; process/path fields and attempt directory are cleared |
+| Flake gate | Pass | 10 consecutive library runs, 233/233 each (2,330 tests total) |
+| Full Rust suite | Pass | `cargo test --manifest-path apps/symphony/Cargo.toml` |
+| Affected validation | Pass | `pnpm run validate:affected` — lint, typecheck, and tests |
+| Evidence config | Pass (automated/dry-run) | Sanitized effective repository/project coordinates are stored without token values |
+| Cleanup target safety | Pass (automated/dry-run) | Stored config and legacy URL resolution pass; conflicting repositories fail before provider work |
+| UAT repository current-tree cleanup | Draft | [gannonh/uat-symphony#18](https://github.com/gannonh/uat-symphony/pull/18) removes 40,800 generated lines, credentials, logs, and unintended gitlinks |
+| Provider credential revocation | **Blocked** | Account-owner confirmation is unavailable in this environment |
+| Live restart recovery | Not run | Deliberately gated on credential revocation and cleanup merge |
+| Live evidence cleanup | Not run | Deliberately gated on credential revocation and cleanup merge |
+
+## Credential containment finding
+
+Seven tracked Pi authentication files exposed credentials for OpenAI Codex,
+Cursor, NVIDIA, Z.ai, Anthropic, Hyper, OpenRouter, Kimi Coding, and xAI. No
+secret values were printed or copied into this report. The current-tree copies
+and generated runtime state are removed by the UAT cleanup PR, with ignore rules
+to prevent recurrence.
+
+The repository intentionally retains history. Every represented credential must
+therefore be revoked or rotated by its provider account owner before live UAT.
+Current-tree deletion alone does not make historical values inert.
+
+## Automated commands
+
+```bash
+cargo test --manifest-path apps/symphony/Cargo.toml process_identity
+cargo test --manifest-path apps/symphony/Cargo.toml \
+  recovery_terminates_orphaned_child_and_removes_attempt_directory
+node --test \
+  .agents/skills/uat-evidence/scripts/symphony-runtime-config.test.mjs
+
+# Ten consecutive successful runs
+cargo test --manifest-path apps/symphony/Cargo.toml --lib
+
+cargo test --manifest-path apps/symphony/Cargo.toml
+pnpm run validate:affected
+```
+
+The UAT evidence runner also completed a GitHub dry run for
+`gannonh/uat-symphony` Project #16. A synthetic cleanup dry run used stored
+coordinates without overrides, and a mismatched repository dry run failed
+before any provider call. No live issue or project state was created.
+
+## Remaining acceptance gate
+
+Re-verification can become **Accepted** only after:
+
+1. Account owners confirm revocation or rotation for every provider listed
+   above and verify replacement credentials outside Git.
+2. UAT cleanup PR #18 is merged and a fresh clone passes current-tree secret and
+   gitlink checks.
+3. The bundled Symphony/GitHub evidence run passes against Project #16 and its
+   cleanup succeeds from the evidence file without repeated overrides.
+4. A hard-restart fixture proves the recorded launcher changes executable,
+   the orphan is live before restart, recovery terminates the old process group,
+   the attempt is interrupted and cleaned, and its retry completes.
+5. All created fixtures are closed and no unrelated implementation dispatch
+   occurs.
+
+Until those gates pass, the roadmap remains blocked and this report must not be
+promoted to Accepted.

--- a/docs/specs/2026-07-25-a1-pr3-verify-report.md
+++ b/docs/specs/2026-07-25-a1-pr3-verify-report.md
@@ -1,0 +1,77 @@
+---
+type: Verify Report
+title: A1 PR3 Recovery and Agreement Measurement Verify Report
+status: Rejected
+description: Live GitHub Verify results for A1 PR3 restart recovery, retry evidence, route correction, and agreement metrics.
+tags: [symphony, triage, a1, pr3, verify, uat, github]
+timestamp: 2026-07-25T17:14:00Z
+---
+
+# A1 PR3 Recovery and Agreement Measurement — Verify Report
+
+## Status
+
+**Rejected** — correction measurement, metrics, durable retry records, preview-to-automatic publication, and restart retry passed, but restart recovery did not terminate the live orphaned child. PR3 does not satisfy its interrupted-process recovery merge gate.
+
+## Scope and environment
+
+- Spec: [A1 GitHub Issue Triage](2026-07-16-a1-github-issue-triage-design.md), PR3 portions of criteria 4 and 14–18
+- Build: [A1 PR3 build report](2026-07-25-a1-pr3-build-report.md)
+- Code under test: `2f0d210`
+- Runtime/backend: Symphony runtime against GitHub Projects v2
+- Target: `gannonh/uat-symphony`, Project [#16](https://github.com/users/gannonh/projects/16)
+- Local evidence: `uat-evidence/a1-pr3-symphony-github-20260725170510/`
+- Standard backend evidence: `uat-evidence/symphony-runtime-github-20260725170315-79465/`
+
+The standard backend proof passed `symphony doctor`, all seven shared helper operations, provider reads, and proof-link capture. Three PR-only helper operations were explicitly skipped because the checkout had no discoverable pull request.
+
+## Acceptance results
+
+| Area | Result | Evidence |
+| --- | --- | --- |
+| AC4 durable attempt/retry | Pass | #17 attempt 1 became `interrupted`; attempt 2 completed against the same issue/configuration revision |
+| AC4 interrupted child termination | **Fail** | PID/PGID `81528` remained alive after restart recovery |
+| AC14 bounded failure records | Pass | #16 exposed three bounded `triage_setup_failed` records before a new configuration revision succeeded |
+| AC15 run/metrics API | Pass | Exact run records remained readable; metrics reported two routes and one correction |
+| AC16 live/durable correction | Pass | WebSocket sequence `197` and durable event `019f9a42-f1c0-7b50-9f9c-4064d9613c72` recorded #17 `implement` → `spec` |
+| AC16 correction dedupe | Pass | Three later polls retained one observation/event, `correction_count: 1`, `correction_rate: 0.5` |
+| AC17 automated coverage | **Fail (flaky)** | Final affected gate failed 1/229 at the recovery test's signalability precondition; 21 focused reruns then passed |
+| AC18 live fixtures | Partial | Expected routes, clarification, preview/automatic publication, off-project diagnostic, restart/retry, and correction observed; orphan termination failed |
+
+## Live fixtures
+
+- [#16](https://github.com/gannonh/uat-symphony/issues/16) — underspecified performance request routed `needs_information`; [preview](https://github.com/gannonh/uat-symphony/issues/16#issuecomment-5079413577), [automatic publication](https://github.com/gannonh/uat-symphony/issues/16#issuecomment-5079423503)
+- [#17](https://github.com/gannonh/uat-symphony/issues/17) — exact documentation replacement routed `implement`; [off-project diagnostic](https://github.com/gannonh/uat-symphony/issues/17#issuecomment-5079415072), [preview](https://github.com/gannonh/uat-symphony/issues/17#issuecomment-5079420439), [automatic publication](https://github.com/gannonh/uat-symphony/issues/17#issuecomment-5079423190)
+
+Both automatic publications completed `comment_pending`, `route_label`, `project_state`, `conflict_cleanup`, `comment_route_effects`, `intake_removed`, and `comment_applied`. The #17 route was then changed from `ready-for-agent` to `ready-to-spec`.
+
+## Blocking recovery defect
+
+Before the hard stop, the durable attempt stored:
+
+- PID/PGID: `81528`
+- Linux start token: `577506`
+- executable identity: `/usr/bin/bash`
+- disposable workspace/output paths
+
+After Symphony PID `81289` was killed, the child remained alive under PID 1. Its shell had executed `/usr/bin/sleep`; the live executable resolved as `/usr/bin/coreutils`. On restart, Symphony correctly:
+
+1. marked attempt `019f9a40-044f-7c50-95d9-35e84f6f3517` interrupted;
+2. removed its disposable attempt directory;
+3. completed retry `019f9a41-6c5f-78a2-a60d-a410dc1be445`.
+
+However, exact executable matching rejected the legitimate post-`exec` child identity, so recovery skipped process-group signaling. PID `81528` remained live and required explicit manual termination. This can also affect launchers whose executable changes after spawn.
+
+The final `pnpm run validate:affected` also failed `triage::coordinator::tests::recovery_terminates_orphaned_child_and_removes_attempt_directory` at `precondition: the orphan must be identifiable and signalable` (228 passed, 1 failed). One immediate focused rerun and 20 additional focused stress runs passed, confirming nondeterministic suite-level recovery-test behavior rather than a consistently failing assertion.
+
+## UAT environment findings
+
+The UAT repository contains tracked `.symphony/workspaces` gitlinks without matching `.gitmodules` entries. Repository-integrity setup therefore failed three times. No remote repository content was changed; Verify continued with a local-only sanitized clone and a new configuration revision.
+
+The bundled cleanup evidence omitted the overridden repository coordinates. Its first safety check correctly skipped all records instead of closing uncertain targets. Cleanup succeeded after rerunning with explicit `gannonh/uat-symphony` coordinates.
+
+All UAT-created issues (#13–#17) are closed. The exact orphan process group was manually terminated; the process remained defunct pending PID 1 reaping.
+
+## Recommendation
+
+Do not merge PR3 as verified. Fix recovery identity handling for legitimate executable changes across an `exec` chain, stabilize the recovery test under the full suite, add a regression test using a launcher script that `exec`s another binary, and rerun the restart portion of live UAT. The correction/metrics evidence can be retained.

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -5,7 +5,7 @@ Roadmap for planned and completed work. Historical Superpowers designs and plans
 # Active
 
 * [Symphony Software Factory Platform PRD](symphony-software-factory-platform-prd.md) - product requirements and vertical-slice roadmap for the full software factory platform
-* [A1 GitHub Issue Triage](2026-07-16-a1-github-issue-triage-design.md) - Active design; **PR1 shipped**; **PR2 Verify accepted** (merge pending) ([build](2026-07-24-a1-pr2-build-report.md), [verify](2026-07-24-a1-pr2-verify-report.md)); **PR3 Verify rejected** on orphan termination ([build](2026-07-25-a1-pr3-build-report.md), [verify](2026-07-25-a1-pr3-verify-report.md))
+* [A1 GitHub Issue Triage](2026-07-16-a1-github-issue-triage-design.md) - Active design; **PR1 shipped**; **PR2 Verify accepted** (merge pending) ([build](2026-07-24-a1-pr2-build-report.md), [verify](2026-07-24-a1-pr2-verify-report.md)); **PR3 remediation passes automated gates, live re-verify blocked on credential rotation** ([build](2026-07-25-a1-pr3-build-report.md), [rejected verify](2026-07-25-a1-pr3-verify-report.md), [incomplete re-verify](2026-07-25-a1-pr3-reverify-report.md))
 * [A2 Spec Stage](2026-07-18-a2-spec-stage-design.md) - Draft design; spec-routed issues → draft/review/revise pipeline → published versioned spec → label-driven approval → implementation-ready run
 * [Pi Symphony Extension Design](../superpowers/specs/2026-05-14-pi-symphony-extension-design.md) - Pi extension to init, launch, monitor, and steer Symphony
 * [Wave 4 Shared Context and Diagnostics Plan](../superpowers/plans/2026-05-17-wave-4-symphony-shared-context-diagnostics.md) - dashboard parity for shared context + diagnostics
@@ -16,7 +16,7 @@ _None recorded._
 
 # Blocked
 
-* A1 PR3 recovery and agreement measurement — live correction/metrics checks pass, but restart recovery leaves a post-`exec` orphan alive; fix executable-identity handling and rerun restart Verify ([report](2026-07-25-a1-pr3-verify-report.md))
+* A1 PR3 recovery and agreement measurement — post-`exec` recovery and evidence cleanup remediation pass automated gates; revoke committed UAT credentials, merge repository cleanup, then rerun live restart/evidence Verify ([rejected report](2026-07-25-a1-pr3-verify-report.md), [incomplete re-verify](2026-07-25-a1-pr3-reverify-report.md))
 
 # Completed (recent)
 

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -5,7 +5,7 @@ Roadmap for planned and completed work. Historical Superpowers designs and plans
 # Active
 
 * [Symphony Software Factory Platform PRD](symphony-software-factory-platform-prd.md) - product requirements and vertical-slice roadmap for the full software factory platform
-* [A1 GitHub Issue Triage](2026-07-16-a1-github-issue-triage-design.md) - Active design; **PR1 shipped**; **PR2 Verify accepted** (merge pending) ([build](2026-07-24-a1-pr2-build-report.md), [verify](2026-07-24-a1-pr2-verify-report.md)); **PR3 remediation passes automated gates, live re-verify blocked on credential rotation** ([build](2026-07-25-a1-pr3-build-report.md), [rejected verify](2026-07-25-a1-pr3-verify-report.md), [incomplete re-verify](2026-07-25-a1-pr3-reverify-report.md))
+* [A1 GitHub Issue Triage](2026-07-16-a1-github-issue-triage-design.md) - Active design; **PR1 shipped**; **PR2 Verify accepted** (merge pending) ([build](2026-07-24-a1-pr2-build-report.md), [verify](2026-07-24-a1-pr2-verify-report.md)); **PR3 implementation PR [#599](https://github.com/gannonh/kata-symphony/pull/599) has all review threads resolved and required CI passing, while live re-verify remains blocked on credential rotation and UAT cleanup** ([build](2026-07-25-a1-pr3-build-report.md), [rejected verify](2026-07-25-a1-pr3-verify-report.md), [incomplete re-verify](2026-07-25-a1-pr3-reverify-report.md))
 * [A2 Spec Stage](2026-07-18-a2-spec-stage-design.md) - Draft design; spec-routed issues → draft/review/revise pipeline → published versioned spec → label-driven approval → implementation-ready run
 * [Pi Symphony Extension Design](../superpowers/specs/2026-05-14-pi-symphony-extension-design.md) - Pi extension to init, launch, monitor, and steer Symphony
 * [Wave 4 Shared Context and Diagnostics Plan](../superpowers/plans/2026-05-17-wave-4-symphony-shared-context-diagnostics.md) - dashboard parity for shared context + diagnostics
@@ -16,7 +16,7 @@ _None recorded._
 
 # Blocked
 
-* A1 PR3 recovery and agreement measurement — post-`exec` recovery and evidence cleanup remediation pass automated gates; revoke committed UAT credentials, merge repository cleanup, then rerun live restart/evidence Verify ([rejected report](2026-07-25-a1-pr3-verify-report.md), [incomplete re-verify](2026-07-25-a1-pr3-reverify-report.md))
+* A1 PR3 recovery and agreement measurement — implementation PR [#599](https://github.com/gannonh/kata-symphony/pull/599) has all review threads resolved and required CI passing; revoke committed UAT credentials, merge [UAT cleanup PR #18](https://github.com/gannonh/uat-symphony/pull/18), then rerun live restart/evidence Verify ([rejected report](2026-07-25-a1-pr3-verify-report.md), [incomplete re-verify](2026-07-25-a1-pr3-reverify-report.md))
 
 # Completed (recent)
 

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -5,7 +5,7 @@ Roadmap for planned and completed work. Historical Superpowers designs and plans
 # Active
 
 * [Symphony Software Factory Platform PRD](symphony-software-factory-platform-prd.md) - product requirements and vertical-slice roadmap for the full software factory platform
-* [A1 GitHub Issue Triage](2026-07-16-a1-github-issue-triage-design.md) - Active design; **PR1 shipped**; **PR2 Verify accepted** (merge pending) ([build](2026-07-24-a1-pr2-build-report.md), [verify](2026-07-24-a1-pr2-verify-report.md)); **PR3 implemented** ([build](2026-07-25-a1-pr3-build-report.md)), live UAT pending Verify
+* [A1 GitHub Issue Triage](2026-07-16-a1-github-issue-triage-design.md) - Active design; **PR1 shipped**; **PR2 Verify accepted** (merge pending) ([build](2026-07-24-a1-pr2-build-report.md), [verify](2026-07-24-a1-pr2-verify-report.md)); **PR3 Verify rejected** on orphan termination ([build](2026-07-25-a1-pr3-build-report.md), [verify](2026-07-25-a1-pr3-verify-report.md))
 * [A2 Spec Stage](2026-07-18-a2-spec-stage-design.md) - Draft design; spec-routed issues → draft/review/revise pipeline → published versioned spec → label-driven approval → implementation-ready run
 * [Pi Symphony Extension Design](../superpowers/specs/2026-05-14-pi-symphony-extension-design.md) - Pi extension to init, launch, monitor, and steer Symphony
 * [Wave 4 Shared Context and Diagnostics Plan](../superpowers/plans/2026-05-17-wave-4-symphony-shared-context-diagnostics.md) - dashboard parity for shared context + diagnostics
@@ -16,11 +16,10 @@ _None recorded._
 
 # Blocked
 
-_None recorded._
+* A1 PR3 recovery and agreement measurement — live correction/metrics checks pass, but restart recovery leaves a post-`exec` orphan alive; fix executable-identity handling and rerun restart Verify ([report](2026-07-25-a1-pr3-verify-report.md))
 
 # Completed (recent)
 
-* A1 PR3 recovery and agreement measurement — implemented; automated gates pass, live restart/correction UAT pending Verify ([build](2026-07-25-a1-pr3-build-report.md))
 * A1 PR2 automatic route publication — Verify accepted on `uat-symphony` Project #16 ([verify](2026-07-24-a1-pr2-verify-report.md)); merge/PR pending
 * A1 PR1 triage preview — durable factory runs, intake, runner, preview comments, HTTP read API ([#587](https://github.com/gannonh/kata-symphony/pull/587); [ADR-0001](../adrs/0001-a1-triage-durability-and-isolation.md))
 

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -5,14 +5,14 @@ Roadmap for planned and completed work. Historical Superpowers designs and plans
 # Active
 
 * [Symphony Software Factory Platform PRD](symphony-software-factory-platform-prd.md) - product requirements and vertical-slice roadmap for the full software factory platform
-* [A1 GitHub Issue Triage](2026-07-16-a1-github-issue-triage-design.md) - Active design; **PR1 shipped**; **PR2 Verify accepted** (merge pending) ([build](2026-07-24-a1-pr2-build-report.md), [verify](2026-07-24-a1-pr2-verify-report.md)); PR3 recovery/agreement remains open
+* [A1 GitHub Issue Triage](2026-07-16-a1-github-issue-triage-design.md) - Active design; **PR1 shipped**; **PR2 Verify accepted** (merge pending) ([build](2026-07-24-a1-pr2-build-report.md), [verify](2026-07-24-a1-pr2-verify-report.md)); **PR3 implemented** ([build](2026-07-25-a1-pr3-build-report.md)), live UAT pending Verify
 * [A2 Spec Stage](2026-07-18-a2-spec-stage-design.md) - Draft design; spec-routed issues → draft/review/revise pipeline → published versioned spec → label-driven approval → implementation-ready run
 * [Pi Symphony Extension Design](../superpowers/specs/2026-05-14-pi-symphony-extension-design.md) - Pi extension to init, launch, monitor, and steer Symphony
 * [Wave 4 Shared Context and Diagnostics Plan](../superpowers/plans/2026-05-17-wave-4-symphony-shared-context-diagnostics.md) - dashboard parity for shared context + diagnostics
 
 # Planned
 
-* A1 PR3: recovery and agreement measurement
+_None recorded._
 
 # Blocked
 
@@ -20,6 +20,7 @@ _None recorded._
 
 # Completed (recent)
 
+* A1 PR3 recovery and agreement measurement — implemented; automated gates pass, live restart/correction UAT pending Verify ([build](2026-07-25-a1-pr3-build-report.md))
 * A1 PR2 automatic route publication — Verify accepted on `uat-symphony` Project #16 ([verify](2026-07-24-a1-pr2-verify-report.md)); merge/PR pending
 * A1 PR1 triage preview — durable factory runs, intake, runner, preview comments, HTTP read API ([#587](https://github.com/gannonh/kata-symphony/pull/587); [ADR-0001](../adrs/0001-a1-triage-durability-and-isolation.md))
 

--- a/docs/specs/log.md
+++ b/docs/specs/log.md
@@ -1,6 +1,7 @@
 # Specs Update Log
 
 ## 2026-07-25
+* **A1 PR3 Verify rejected**: Live GitHub UAT passed retry records, preview/automatic publication, correction events, metrics, and dedupe, but restart recovery left a post-`exec` orphan alive because the executable identity changed from the recorded launcher. See [Verify report](/specs/2026-07-25-a1-pr3-verify-report.md).
 * **A1 PR3 build**: Interrupted-attempt recovery and human route correction measurement implemented in Symphony triage; see [A1 PR3 build report](/specs/2026-07-25-a1-pr3-build-report.md). Adds `triage::process_identity` (identity-matched bounded termination, attempt cleanup) and `triage::correction` (agreement/correction/ambiguity comparison, `triage_route_corrected`, durable-only `triage_route_consistency`). Automated gates pass; live restart/correction UAT on `gannonh/uat-symphony` pending Verify.
 
 ## 2026-07-24

--- a/docs/specs/log.md
+++ b/docs/specs/log.md
@@ -1,6 +1,7 @@
 # Specs Update Log
 
 ## 2026-07-25
+* **A1 PR3 review remediation**: [PR #599](https://github.com/gannonh/kata-symphony/pull/599) has all review threads resolved and required CI checks passing after Codex process isolation, recovery-state retention, cleanup authorization, and latest-per-run randomized correction candidate fixes. Updated the [build report](/specs/2026-07-25-a1-pr3-build-report.md), [re-verify report](/specs/2026-07-25-a1-pr3-reverify-report.md), A1 design, PRD, and roadmap. Live acceptance remains blocked.
 * **A1 PR3 Verify rejected**: Live GitHub UAT passed retry records, preview/automatic publication, correction events, metrics, and dedupe, but restart recovery left a post-`exec` orphan alive because the executable identity changed from the recorded launcher. See [Verify report](/specs/2026-07-25-a1-pr3-verify-report.md).
 * **A1 PR3 build**: Interrupted-attempt recovery and human route correction measurement implemented in Symphony triage; see [A1 PR3 build report](/specs/2026-07-25-a1-pr3-build-report.md). Adds `triage::process_identity` (identity-matched bounded termination, attempt cleanup) and `triage::correction` (agreement/correction/ambiguity comparison, `triage_route_corrected`, durable-only `triage_route_consistency`). Automated gates pass; live restart/correction UAT on `gannonh/uat-symphony` pending Verify.
 

--- a/docs/specs/log.md
+++ b/docs/specs/log.md
@@ -1,5 +1,8 @@
 # Specs Update Log
 
+## 2026-07-25
+* **A1 PR3 build**: Interrupted-attempt recovery and human route correction measurement implemented in Symphony triage; see [A1 PR3 build report](/specs/2026-07-25-a1-pr3-build-report.md). Adds `triage::process_identity` (identity-matched bounded termination, attempt cleanup) and `triage::correction` (agreement/correction/ambiguity comparison, `triage_route_corrected`, durable-only `triage_route_consistency`). Automated gates pass; live restart/correction UAT on `gannonh/uat-symphony` pending Verify.
+
 ## 2026-07-24
 * **A1 PR2 Verify accepted**: [Verify report](/specs/2026-07-24-a1-pr2-verify-report.md) signed off after live UAT on Project #16; PR2 merge still pending. PR3 remains planned.
 * **A1 PR2 build**: Automatic route publication + implement handoff implemented in Symphony triage/orchestrator; see [A1 PR2 build report](/specs/2026-07-24-a1-pr2-build-report.md).

--- a/docs/specs/symphony-software-factory-platform-prd.md
+++ b/docs/specs/symphony-software-factory-platform-prd.md
@@ -216,7 +216,7 @@ A new GitHub or Linear issue triggers a triage stage. Symphony creates the minim
 | --- | --- | --- |
 | PR1 preview | **Shipped** | Intake label + Projects v2 membership, local Pi/Codex triage, immutable artifact, durable preview comment, factory-run HTTP read API, doctor/starter assets |
 | PR2 automatic route publication | **Verify accepted** (merge pending) | Apply route labels/states, remove intake label, implement handoff ([build](/specs/2026-07-24-a1-pr2-build-report.md), [verify](/specs/2026-07-24-a1-pr2-verify-report.md)) |
-| PR3 recovery and agreement | Planned | Interrupted-process recovery, correction events, agreement metrics |
+| PR3 recovery and agreement | **Verify rejected** | Correction events/metrics pass; restart recovery leaks a post-`exec` orphan ([build](/specs/2026-07-25-a1-pr3-build-report.md), [verify](/specs/2026-07-25-a1-pr3-verify-report.md)) |
 | Linear triage | Deferred | Separate vertical slice after GitHub path is complete |
 
 **Demo (PR1):** Label a project-member issue `needs-triage`. Symphony records a factory run, posts a marked preview comment with route/rationale/evidence, and exposes the run over `GET /api/v1/factory-runs`. Off-project intake gets a diagnostic comment without an agent attempt.

--- a/docs/specs/symphony-software-factory-platform-prd.md
+++ b/docs/specs/symphony-software-factory-platform-prd.md
@@ -216,7 +216,7 @@ A new GitHub or Linear issue triggers a triage stage. Symphony creates the minim
 | --- | --- | --- |
 | PR1 preview | **Shipped** | Intake label + Projects v2 membership, local Pi/Codex triage, immutable artifact, durable preview comment, factory-run HTTP read API, doctor/starter assets |
 | PR2 automatic route publication | **Verify accepted** (merge pending) | Apply route labels/states, remove intake label, implement handoff ([build](/specs/2026-07-24-a1-pr2-build-report.md), [verify](/specs/2026-07-24-a1-pr2-verify-report.md)) |
-| PR3 recovery and agreement | **Verify rejected** | Correction events/metrics pass; restart recovery leaks a post-`exec` orphan ([build](/specs/2026-07-25-a1-pr3-build-report.md), [verify](/specs/2026-07-25-a1-pr3-verify-report.md)) |
+| PR3 recovery and agreement | **Automated remediation passed; live re-verify blocked** | Post-`exec` recovery and safe evidence cleanup pass automated gates; credential rotation and clean live UAT remain ([build](/specs/2026-07-25-a1-pr3-build-report.md), [rejected verify](/specs/2026-07-25-a1-pr3-verify-report.md), [incomplete re-verify](/specs/2026-07-25-a1-pr3-reverify-report.md)) |
 | Linear triage | Deferred | Separate vertical slice after GitHub path is complete |
 
 **Demo (PR1):** Label a project-member issue `needs-triage`. Symphony records a factory run, posts a marked preview comment with route/rationale/evidence, and exposes the run over `GET /api/v1/factory-runs`. Off-project intake gets a diagnostic comment without an agent attempt.

--- a/docs/specs/symphony-software-factory-platform-prd.md
+++ b/docs/specs/symphony-software-factory-platform-prd.md
@@ -4,7 +4,7 @@ title: Symphony Software Factory Platform
 status: Active
 description: Product requirements and vertical-slice roadmap for evolving Symphony into a full software factory platform.
 tags: [symphony, software-factory, roadmap, orchestration]
-timestamp: 2026-07-18T17:00:00Z
+timestamp: 2026-07-25T22:35:00Z
 ---
 
 # Symphony Software Factory Platform PRD
@@ -216,7 +216,7 @@ A new GitHub or Linear issue triggers a triage stage. Symphony creates the minim
 | --- | --- | --- |
 | PR1 preview | **Shipped** | Intake label + Projects v2 membership, local Pi/Codex triage, immutable artifact, durable preview comment, factory-run HTTP read API, doctor/starter assets |
 | PR2 automatic route publication | **Verify accepted** (merge pending) | Apply route labels/states, remove intake label, implement handoff ([build](/specs/2026-07-24-a1-pr2-build-report.md), [verify](/specs/2026-07-24-a1-pr2-verify-report.md)) |
-| PR3 recovery and agreement | **Automated remediation passed; live re-verify blocked** | Post-`exec` recovery and safe evidence cleanup pass automated gates; credential rotation and clean live UAT remain ([build](/specs/2026-07-25-a1-pr3-build-report.md), [rejected verify](/specs/2026-07-25-a1-pr3-verify-report.md), [incomplete re-verify](/specs/2026-07-25-a1-pr3-reverify-report.md)) |
+| PR3 recovery and agreement | **PR #599 threads resolved/CI passed; live re-verify blocked** | Post-`exec` recovery, process-group isolation, retained unresolved recovery state, cleanup authorization, correction candidate fixes, and evidence cleanup pass automated gates; credential rotation, UAT cleanup PR #18, and clean live UAT remain ([build](/specs/2026-07-25-a1-pr3-build-report.md), [rejected verify](/specs/2026-07-25-a1-pr3-verify-report.md), [incomplete re-verify](/specs/2026-07-25-a1-pr3-reverify-report.md)) |
 | Linear triage | Deferred | Separate vertical slice after GitHub path is complete |
 
 **Demo (PR1):** Label a project-member issue `needs-triage`. Symphony records a factory run, posts a marked preview comment with route/rationale/evidence, and exposes the run over `GET /api/v1/factory-runs`. Off-project intake gets a diagnostic comment without an agent attempt.

--- a/scripts/ci/github-backend-validation.sh
+++ b/scripts/ci/github-backend-validation.sh
@@ -39,4 +39,9 @@ run_segment \
   --test github_adapter_tests \
   --test github_execution_contract_tests
 
+run_segment \
+  "Symphony UAT evidence cleanup contracts (node test)" \
+  node --test \
+  .agents/skills/uat-evidence/scripts/symphony-runtime-config.test.mjs
+
 echo "GitHub backend validation lane completed successfully."


### PR DESCRIPTION
## What changed

- delivers A1 PR3 interrupted-attempt recovery and agreement measurement
- fixes recovery after a launcher replaces itself through `exec` by authorizing signals with PID, process group, and OS start token
- retains executable identity as diagnostics and reports structured signal-denial/termination outcomes
- adds deterministic launcher-to-worker regression coverage and verified bounded process-group termination
- makes Symphony UAT evidence record sanitized effective backend coordinates
- validates every GitHub cleanup target before the first provider read or mutation, including legacy evidence URL recovery
- adds ADR-0002 and preserves the rejected Verify report alongside an explicitly incomplete re-verify report

## Root cause

The original recovery implementation treated executable equality as stable identity. A shell launcher legitimately became `/usr/bin/sleep` through `exec` while retaining its PID, process group, and Linux start token, so restart recovery skipped signaling and leaked the worker. The same transition made the recovery test nondeterministic. Separately, Symphony UAT evidence omitted override coordinates, allowing cleanup to consult unrelated ambient workflow configuration.

## Validation

- focused process identity suite: 11/11 pass
- focused coordinator recovery regression: pass
- evidence configuration/cleanup contracts: 10/10 pass
- Symphony library suite: 10 consecutive runs, 233/233 each (2,330 tests)
- full `cargo test --manifest-path apps/symphony/Cargo.toml`: pass
- `pnpm run validate:affected`: pass, including clippy with warnings denied and format checks
- evidence generation and cleanup dry-runs: pass; mismatched repository rejected before provider work
- no leaked test process observed

## Live UAT gate

Live GitHub re-verification was deliberately not run. Historical `gannonh/uat-symphony` workspaces contain credentials for multiple providers. Cleanup PR gannonh/uat-symphony#18 removes current-tree state and tracks provider-side rotation, but revocation is not yet confirmed. This PR must remain draft and the re-verify report remains Incomplete until those credentials are revoked, the cleanup PR is merged, and clean Project #16 restart/evidence UAT passes.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Completes interrupted-attempt recovery and route-agreement measurement.
- Persists process identity and safely reclaims recorded orphaned process groups and attempt workspaces.
- Adds durable route-correction observations, metrics, migrations, and bounded candidate reconciliation.
- Records sanitized backend coordinates and validates GitHub cleanup targets before provider access.
- Adds regression coverage, operational documentation, ADRs, and verification reports.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failures remain within the scope of the review threads.

No blocking failure remains.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The focused coordinator recovery regression was re-run and now completes with exit code 0 in 0.13 seconds.
- All 11 process-identity tests passed, including executable\_drift\_after\_exec\_remains\_signalable and terminates\_a\_live\_process\_group.
- A fixture cleanup check was performed by running pgrep -ax sleep, which reported no fixture processes and exited with 0.
- Four log artifacts were collected and attached to support the review.

<a href="https://app.greptile.com/trex/runs/15889523/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/symphony/src/triage/coordinator.rs | Adds interrupted-attempt reclamation, spawn-identity persistence, and route-correction reconciliation. |
| apps/symphony/src/triage/process_identity.rs | Implements Linux process identity assessment and bounded process-group termination across launcher exec transitions. |
| apps/symphony/src/triage/store.rs | Adds durable process recovery operations and randomized latest-per-run correction candidate selection. |
| apps/symphony/src/triage/migrations/002_route_observations.sql | Introduces durable, idempotent route-observation storage. |
| .agents/skills/uat-evidence/scripts/symphony-runtime-config.mjs | Centralizes sanitized runtime configuration and fail-closed GitHub cleanup target resolution. |
| .agents/skills/uat-evidence/scripts/symphony-runtime.mjs | Stores effective backend coordinates and validates all GitHub cleanup targets before provider operations. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
A[Poll begins] --> B[Interrupt stale attempts]
B --> C[List recoverable attempts]
C --> D{Recorded process identity?}
D -->|Yes| E[Validate PID, process group, and start token]
E -->|Authorized| F[Terminate process group]
E -->|Denied and still present| G[Retain process record for later poll]
D -->|No| H[Reclaim validated attempt directory]
F -->|Gone| H
F -->|Still running| G
H --> I[Clear durable process fields]
I --> J[Reconcile publication intents]
J --> K[Sample latest applied route publications]
K --> L[Read current issue labels]
L --> M{Route agreement}
M -->|Corrected| N[Record correction and emit event]
M -->|Inconsistent| O[Record durable diagnostic]
M -->|Agreed| P[No observation emitted]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["docs(symphony): record PR 599 review clo..."](https://github.com/gannonh/kata-symphony/commit/ce74ecb859f348c43bad671462a06f580ad3480f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47272173)</sub>

<!-- /greptile_comment -->