### PR TITLE
feat(review): publish durable formal reviews

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,5 @@ apps/cli/docs/superpowers/
 .agents/kata-setup-manifest.json
 apps/desktop/release/
 .pi-subagents/artifacts/
+statuses/
+events.jsonl

--- a/apps/symphony/WORKFLOW.md
+++ b/apps/symphony/WORKFLOW.md
@@ -132,6 +132,24 @@ server:
 #       timeout_ms: 1800000
 #   # completion_route:
 #   #   state: Agent Review
+# A4 agent review stage. Requires an approved A2 specification and A3 draft PR.
+# review:
+#   enabled: false
+#   mode: preview                 # preview or automatic
+#   prompt: prompts/agent-review.md
+#   # model: provider/model-name  # Pi only
+#   max_turns: 1
+#   invocation_timeout_ms: 1800000
+#   max_attempts: 3
+#   max_reprompts: 2
+#   max_findings: 50
+#   blocking_severity: blocking   # blocking, major, minor, or nit
+#   trigger_state: Agent Review
+#   # permission_probe_pull_request: 123  # optional deterministic doctor probe
+#   # completion_route:
+#   #   state: Human Review
+#   # changes_requested_route:
+#   #   state: Implementation
 # notifications:
 #   slack:
 #     webhook_url: $SLACK_WEBHOOK_URL

--- a/apps/symphony/docs/WORKFLOW-REFERENCE.md
+++ b/apps/symphony/docs/WORKFLOW-REFERENCE.md
@@ -622,6 +622,32 @@ server:
 #   # completion_route:
 #   #   state: Agent Review
 
+# ─── Agent review stage (A4) ───────────────────────────────────────────────────
+# GitHub Projects v2 only. Requires an approved A2 specification and an owned
+# A3 draft PR. Preview mode publishes an issue comment. Automatic mode creates
+# one atomic pull-request review and routes the tracker item by severity.
+#
+# `permission_probe_pull_request` selects a known open PR for `symphony doctor`.
+# When omitted, doctor probes the first open PR in the configured repository.
+#
+# review:
+#   enabled: false
+#   mode: preview                 # preview or automatic
+#   prompt: prompts/agent-review.md
+#   # model: provider/model-name  # Pi only
+#   max_turns: 1
+#   invocation_timeout_ms: 1800000
+#   max_attempts: 3
+#   max_reprompts: 2
+#   max_findings: 50
+#   blocking_severity: blocking   # blocking, major, minor, or nit
+#   trigger_state: Agent Review
+#   # permission_probe_pull_request: 123
+#   # completion_route:
+#   #   state: Human Review
+#   # changes_requested_route:
+#   #   state: Implementation
+
 # ─── Prompts (per-state prompt injection) ─────────────────────────────────────
 # Optional. When configured, the orchestrator selects a prompt template based on
 # the issue's tracker state at dispatch time instead of using the markdown body

--- a/apps/symphony/src/config.rs
+++ b/apps/symphony/src/config.rs
@@ -28,6 +28,7 @@ use crate::implementation::domain::{
 use crate::notifications;
 use crate::repo_url::repo_is_remote;
 use crate::review::domain::{ReviewConfig, ReviewMode, ReviewRoute};
+use crate::review::manifest::ReviewSeverity;
 use crate::spec::domain::{SpecApprovalRoute, SpecConfig, SpecDecisionLabels, SpecPromptsConfig};
 use crate::triage::domain::{
     RouteMapping, StorageConfig, TriageConfig, TriageMode, TriageRoutesConfig,
@@ -481,6 +482,7 @@ struct RawReviewConfig {
     max_attempts: Option<u32>,
     max_reprompts: Option<u32>,
     max_findings: Option<usize>,
+    blocking_severity: Option<String>,
     trigger_state: Option<String>,
     completion_route: Option<RawRouteMapping>,
     changes_requested_route: Option<RawRouteMapping>,
@@ -1593,6 +1595,18 @@ pub fn from_workflow(config: &Value) -> Result<ServiceConfig> {
                 .unwrap_or_default(),
         })
     };
+    let blocking_severity = match raw_review.blocking_severity.as_deref().map(str::trim) {
+        None => review_defaults.blocking_severity,
+        Some("blocking") => ReviewSeverity::Blocking,
+        Some("major") => ReviewSeverity::Major,
+        Some("minor") => ReviewSeverity::Minor,
+        Some("nit") => ReviewSeverity::Nit,
+        Some(other) => {
+            return Err(SymphonyError::InvalidWorkflowConfig(format!(
+                "review.blocking_severity must be 'blocking', 'major', 'minor', or 'nit' (got '{other}')"
+            )));
+        }
+    };
     let review = ReviewConfig {
         enabled: raw_review.enabled.unwrap_or(review_defaults.enabled),
         mode: review_mode,
@@ -1611,6 +1625,7 @@ pub fn from_workflow(config: &Value) -> Result<ServiceConfig> {
         max_findings: raw_review
             .max_findings
             .unwrap_or(review_defaults.max_findings),
+        blocking_severity,
         trigger_state: raw_review
             .trigger_state
             .map(|value| resolve_env(&value))
@@ -2220,18 +2235,31 @@ pub fn validate(config: &ServiceConfig) -> Result<ValidatedServiceConfig> {
                 "review.model is not supported when agent.name is 'codex'".to_string(),
             ));
         }
-        if config.review.mode == ReviewMode::Automatic
-            && config
+        if config.review.mode == ReviewMode::Automatic {
+            if config
                 .review
                 .completion_route
                 .as_ref()
                 .map(|route| route.state.trim().is_empty())
                 .unwrap_or(true)
-        {
-            return Err(SymphonyError::InvalidWorkflowConfig(
-                "review.completion_route.state is required when review.mode is 'automatic'"
-                    .to_string(),
-            ));
+            {
+                return Err(SymphonyError::InvalidWorkflowConfig(
+                    "review.completion_route.state is required when review.mode is 'automatic'"
+                        .to_string(),
+                ));
+            }
+            if config
+                .review
+                .changes_requested_route
+                .as_ref()
+                .map(|route| route.state.trim().is_empty())
+                .unwrap_or(true)
+            {
+                return Err(SymphonyError::InvalidWorkflowConfig(
+                    "review.changes_requested_route.state is required when review.mode is 'automatic'"
+                        .to_string(),
+                ));
+            }
         }
     }
 
@@ -2475,6 +2503,64 @@ implementation:
         let config = from_workflow(&value).unwrap();
         let err = validate(&config).unwrap_err().to_string();
         assert!(err.contains("completion_route.state"));
+    }
+
+    #[test]
+    fn review_rejects_automatic_without_changes_requested_route() {
+        let mut yaml = github_base_yaml();
+        yaml.push_str(
+            r#"
+spec:
+  enabled: true
+implementation:
+  enabled: true
+  validation:
+    - name: unit
+      command: cargo test
+      timeout_ms: 60000
+review:
+  enabled: true
+  mode: automatic
+  completion_route:
+    state: Human Review
+"#,
+        );
+        let value: Value = serde_yaml::from_str(&yaml).unwrap();
+        let config = from_workflow(&value).unwrap();
+        let err = validate(&config).unwrap_err().to_string();
+        assert!(err.contains("changes_requested_route.state"));
+    }
+
+    #[test]
+    fn review_parses_automatic_routes() {
+        let mut yaml = github_base_yaml();
+        yaml.push_str(
+            r#"
+spec:
+  enabled: true
+implementation:
+  enabled: true
+  validation:
+    - name: unit
+      command: cargo test
+      timeout_ms: 60000
+review:
+  enabled: true
+  mode: automatic
+  completion_route:
+    state: Human Review
+  changes_requested_route:
+    state: Implementation
+"#,
+        );
+        let value: Value = serde_yaml::from_str(&yaml).unwrap();
+        let config = from_workflow(&value).unwrap();
+        validate(&config).unwrap();
+        assert_eq!(config.review.mode, ReviewMode::Automatic);
+        assert_eq!(
+            config.review.changes_requested_route.unwrap().state,
+            "Implementation"
+        );
     }
 
     #[test]

--- a/apps/symphony/src/config.rs
+++ b/apps/symphony/src/config.rs
@@ -486,6 +486,7 @@ struct RawReviewConfig {
     trigger_state: Option<String>,
     completion_route: Option<RawRouteMapping>,
     changes_requested_route: Option<RawRouteMapping>,
+    permission_probe_pull_request: Option<u64>,
 }
 
 // ── Section extraction helper ─────────────────────────────────────────────────
@@ -1634,6 +1635,9 @@ pub fn from_workflow(config: &Value) -> Result<ServiceConfig> {
             .unwrap_or(review_defaults.trigger_state),
         completion_route: review_route(raw_review.completion_route),
         changes_requested_route: review_route(raw_review.changes_requested_route),
+        permission_probe_pull_request: raw_review
+            .permission_probe_pull_request
+            .or(review_defaults.permission_probe_pull_request),
     };
 
     Ok(ServiceConfig {
@@ -2224,6 +2228,11 @@ pub fn validate(config: &ServiceConfig) -> Result<ValidatedServiceConfig> {
                     "{field} must be greater than 0"
                 )));
             }
+        }
+        if config.review.permission_probe_pull_request == Some(0) {
+            return Err(SymphonyError::InvalidWorkflowConfig(
+                "review.permission_probe_pull_request must be greater than 0".to_string(),
+            ));
         }
         if config.review.trigger_state.trim().is_empty() {
             return Err(SymphonyError::InvalidWorkflowConfig(

--- a/apps/symphony/src/doctor.rs
+++ b/apps/symphony/src/doctor.rs
@@ -371,11 +371,54 @@ pub async fn check_review(config: &ServiceConfig) -> Vec<DoctorCheckResult> {
         }
     }
 
-    if !automatic {
-        results.push(DoctorCheckResult::skipped(
+    let probe_number = match review.permission_probe_pull_request {
+        Some(number) if number > 0 => Some(number),
+        Some(_) => {
+            results.push(DoctorCheckResult::error(
+                "GitHub Review API",
+                "review.permission_probe_pull_request must be greater than 0",
+            ));
+            None
+        }
+        None => match client.list_pull_requests("open", None, None, 1).await {
+            Ok(pull_requests) => pull_requests
+                .first()
+                .map(|pull_request| pull_request.number),
+            Err(err) => {
+                results.push(DoctorCheckResult::error(
+                    "GitHub Review API",
+                    format!("Could not find an open pull request for the review permission probe: {err}"),
+                ));
+                None
+            }
+        },
+    };
+
+    if let Some(number) = probe_number {
+        match client.probe_pull_request_review_permission(number).await {
+            Ok(()) => results.push(DoctorCheckResult::pass(
+                "GitHub Review API",
+                format!("Review endpoint authorization verified with pull request #{number}"),
+            )),
+            Err(err) => results.push(DoctorCheckResult::error(
+                "GitHub Review API",
+                format!(
+                    "Review endpoint authorization probe failed for pull request #{number}: {err}"
+                ),
+            )),
+        }
+    } else if review.permission_probe_pull_request.is_none()
+        && !results
+            .iter()
+            .any(|result| result.name == "GitHub Review API" && result.status == CheckStatus::Error)
+    {
+        results.push(DoctorCheckResult::error(
             "GitHub Review API",
-            "Skipped repository API write checks in preview mode",
+            "No open pull request is available for the review permission probe",
         ));
+    }
+
+    if !automatic {
         return results;
     }
 
@@ -388,26 +431,26 @@ pub async fn check_review(config: &ServiceConfig) -> Vec<DoctorCheckResult> {
                 .and_then(JsonValue::as_bool)
             {
                 Some(true) => results.push(DoctorCheckResult::warning(
-                    "GitHub Review API",
-                    "GitHub API reports repository push metadata; formal review permission was not verified",
+                    "GitHub Review Metadata",
+                    "GitHub API reports repository push permission; formal review permission is determined by the review endpoint probe",
                 )),
                 Some(false) => results.push(DoctorCheckResult::warning(
-                    "GitHub Review API",
-                    "GitHub API reports no repository push permission; review submission may be denied",
+                    "GitHub Review Metadata",
+                    "GitHub API reports no repository push permission; formal review permission is determined by the review endpoint probe",
                 )),
                 None => results.push(DoctorCheckResult::warning(
-                    "GitHub Review API",
-                    "GitHub API did not expose repository permission metadata; review write permission could not be verified",
+                    "GitHub Review Metadata",
+                    "GitHub API did not expose repository permission metadata; formal review permission is determined by the review endpoint probe",
                 )),
             },
             Err(err) => results.push(DoctorCheckResult::warning(
-                "GitHub Review API",
+                "GitHub Review Metadata",
                 format!("Could not decode repository permission metadata: {err}"),
             )),
         },
         Err(err) => results.push(DoctorCheckResult::warning(
-            "GitHub Review API",
-            format!("Could not check repository permission metadata without mutation: {err}"),
+            "GitHub Review Metadata",
+            format!("Could not check repository permission metadata: {err}"),
         )),
     }
 

--- a/apps/symphony/src/doctor.rs
+++ b/apps/symphony/src/doctor.rs
@@ -332,7 +332,13 @@ pub async fn check_review(config: &ServiceConfig) -> Vec<DoctorCheckResult> {
 
     let projects_client = ProjectsV2Client::new(client.clone());
     let status_field = match projects_client
-        .resolve_status_field(repo_owner, project_number)
+        .resolve_status_field_for_owner_type(
+            repo_owner,
+            project_number,
+            tracker
+                .github_project_owner_type
+                .unwrap_or(crate::domain::GithubProjectOwnerType::User),
+        )
         .await
     {
         Ok(status_field) => {
@@ -430,7 +436,7 @@ pub async fn check_review(config: &ServiceConfig) -> Vec<DoctorCheckResult> {
                 .and_then(|permissions| permissions.get("push"))
                 .and_then(JsonValue::as_bool)
             {
-                Some(true) => results.push(DoctorCheckResult::warning(
+                Some(true) => results.push(DoctorCheckResult::pass(
                     "GitHub Review Metadata",
                     "GitHub API reports repository push permission; formal review permission is determined by the review endpoint probe",
                 )),
@@ -661,7 +667,13 @@ pub async fn check_github(config: &TrackerConfig) -> Vec<DoctorCheckResult> {
         } else {
             let projects_client = ProjectsV2Client::new(client.clone());
             match projects_client
-                .resolve_status_field(repo_owner, project_number)
+                .resolve_status_field_for_owner_type(
+                    repo_owner,
+                    project_number,
+                    config
+                        .github_project_owner_type
+                        .unwrap_or(crate::domain::GithubProjectOwnerType::User),
+                )
                 .await
             {
                 Ok(status_field) => {
@@ -1898,7 +1910,14 @@ pub async fn check_triage_github(config: &ServiceConfig) -> Vec<DoctorCheckResul
 
     let projects_client = ProjectsV2Client::new(client);
     match projects_client
-        .resolve_status_field(repo_owner, project_number)
+        .resolve_status_field_for_owner_type(
+            repo_owner,
+            project_number,
+            config
+                .tracker
+                .github_project_owner_type
+                .unwrap_or(crate::domain::GithubProjectOwnerType::User),
+        )
         .await
     {
         Ok(status_field) => {

--- a/apps/symphony/src/doctor.rs
+++ b/apps/symphony/src/doctor.rs
@@ -22,6 +22,7 @@ use crate::linear::adapter::TrackerAdapter;
 use crate::linear::client::LinearClient;
 use crate::notifications;
 use crate::repo_url::repo_is_remote;
+use crate::review::domain::{ReviewConfig, ReviewMode};
 use crate::workflow;
 use crate::workspace;
 
@@ -248,6 +249,211 @@ pub fn check_config(workflow_path: &Path) -> Vec<DoctorCheckResult> {
     }
 
     results
+}
+
+pub async fn check_review(config: &ServiceConfig) -> Vec<DoctorCheckResult> {
+    let review = &config.review;
+    if !review.enabled {
+        return vec![DoctorCheckResult::skipped(
+            "GitHub Review",
+            "Skipped because review.enabled is false",
+        )];
+    }
+    let automatic = review.mode == ReviewMode::Automatic;
+    let tracker = &config.tracker;
+    let Some(project_number) = tracker.github_project_number else {
+        return vec![DoctorCheckResult::error(
+            "GitHub Review",
+            "review.enabled requires tracker.github_project_number for GitHub Projects v2 trigger validation",
+        )];
+    };
+    let Some(token) = resolve_github_token(tracker).map(|resolved| resolved.token) else {
+        return vec![DoctorCheckResult::error(
+            "GitHub Review",
+            github_token_missing_message(),
+        )];
+    };
+    let Some(repo_owner) = tracker
+        .repo_owner
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return vec![DoctorCheckResult::error(
+            "GitHub Review",
+            "tracker.repo_owner is required for review checks",
+        )];
+    };
+    let Some(repo_name) = tracker
+        .repo_name
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return vec![DoctorCheckResult::error(
+            "GitHub Review",
+            "tracker.repo_name is required for review checks",
+        )];
+    };
+
+    let label_prefix = tracker
+        .label_prefix
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("symphony");
+    let endpoint = if tracker.endpoint.trim().is_empty() {
+        "https://api.github.com"
+    } else {
+        tracker.endpoint.trim()
+    };
+    let client = GithubClient::with_base_url(
+        token,
+        repo_owner.to_string(),
+        repo_name.to_string(),
+        label_prefix.to_string(),
+        endpoint,
+    );
+    let mut results = Vec::new();
+
+    match client.get_authenticated_user().await {
+        Ok(user) => results.push(DoctorCheckResult::pass(
+            "GitHub Review Auth",
+            format!("GitHub client authenticated as {}", user.login),
+        )),
+        Err(err) => {
+            results.push(DoctorCheckResult::error(
+                "GitHub Review Auth",
+                format!("GitHub client authentication failed: {err}"),
+            ));
+            return results;
+        }
+    }
+
+    let projects_client = ProjectsV2Client::new(client.clone());
+    let status_field = match projects_client
+        .resolve_status_field(repo_owner, project_number)
+        .await
+    {
+        Ok(status_field) => {
+            results.push(DoctorCheckResult::pass(
+                "GitHub Review Project",
+                format!(
+                    "Resolved Projects v2 Status field on project #{project_number} ({} options)",
+                    status_field.options.len()
+                ),
+            ));
+            status_field
+        }
+        Err(err) => {
+            results.push(DoctorCheckResult::error(
+                "GitHub Review Project",
+                format!(
+                    "Failed to resolve Projects v2 Status field on project #{project_number}: {err}"
+                ),
+            ));
+            return results;
+        }
+    };
+
+    let missing_routes = validate_review_route_options(review, &status_field.options, automatic);
+    if missing_routes.is_empty() {
+        results.push(DoctorCheckResult::pass(
+            "GitHub Review Routes",
+            "Configured review trigger and route states exist as Projects v2 Status options",
+        ));
+    } else {
+        for missing in missing_routes {
+            results.push(DoctorCheckResult::error(
+                "GitHub Review Routes",
+                format!("Configured review state is not a Projects v2 Status option: {missing}"),
+            ));
+        }
+    }
+
+    if !automatic {
+        results.push(DoctorCheckResult::skipped(
+            "GitHub Review API",
+            "Skipped repository API write checks in preview mode",
+        ));
+        return results;
+    }
+
+    let repo_path = format!("/repos/{repo_owner}/{repo_name}");
+    match client.request(Method::GET, &repo_path, None).await {
+        Ok(response) => match response.json::<JsonValue>().await {
+            Ok(payload) => match payload
+                .get("permissions")
+                .and_then(|permissions| permissions.get("push"))
+                .and_then(JsonValue::as_bool)
+            {
+                Some(true) => results.push(DoctorCheckResult::warning(
+                    "GitHub Review API",
+                    "GitHub API reports repository push metadata; formal review permission was not verified",
+                )),
+                Some(false) => results.push(DoctorCheckResult::warning(
+                    "GitHub Review API",
+                    "GitHub API reports no repository push permission; review submission may be denied",
+                )),
+                None => results.push(DoctorCheckResult::warning(
+                    "GitHub Review API",
+                    "GitHub API did not expose repository permission metadata; review write permission could not be verified",
+                )),
+            },
+            Err(err) => results.push(DoctorCheckResult::warning(
+                "GitHub Review API",
+                format!("Could not decode repository permission metadata: {err}"),
+            )),
+        },
+        Err(err) => results.push(DoctorCheckResult::warning(
+            "GitHub Review API",
+            format!("Could not check repository permission metadata without mutation: {err}"),
+        )),
+    }
+
+    results
+}
+
+fn validate_review_route_options(
+    review: &ReviewConfig,
+    options: &[crate::github::projects_v2::StatusOption],
+    automatic: bool,
+) -> Vec<String> {
+    let available: HashSet<String> = options
+        .iter()
+        .map(|option| option.name.trim().to_ascii_lowercase())
+        .filter(|name| !name.is_empty())
+        .collect();
+    let mut missing = Vec::new();
+    let mut routes = vec![("review.trigger_state", Some(review.trigger_state.as_str()))];
+    if automatic {
+        routes.extend([
+            (
+                "review.completion_route.state",
+                review
+                    .completion_route
+                    .as_ref()
+                    .map(|route| route.state.as_str()),
+            ),
+            (
+                "review.changes_requested_route.state",
+                review
+                    .changes_requested_route
+                    .as_ref()
+                    .map(|route| route.state.as_str()),
+            ),
+        ]);
+    }
+    for (field, state) in routes {
+        let Some(state) = state.map(str::trim).filter(|state| !state.is_empty()) else {
+            missing.push(format!("{field} is not configured"));
+            continue;
+        };
+        if !available.contains(&state.to_ascii_lowercase()) {
+            missing.push(format!("{field}='{state}'"));
+        }
+    }
+    missing
 }
 
 pub async fn check_github(config: &TrackerConfig) -> Vec<DoctorCheckResult> {
@@ -2087,6 +2293,53 @@ mod tests {
         ];
 
         assert!(!has_errors(&results));
+    }
+
+    #[test]
+    fn review_route_options_report_missing_states() {
+        let review = ReviewConfig {
+            enabled: true,
+            mode: ReviewMode::Automatic,
+            trigger_state: "Needs Review".to_string(),
+            completion_route: Some(crate::review::domain::ReviewRoute {
+                state: "Approved".to_string(),
+            }),
+            changes_requested_route: Some(crate::review::domain::ReviewRoute {
+                state: "Changes Requested".to_string(),
+            }),
+            ..ReviewConfig::default()
+        };
+        let options = vec![
+            crate::github::projects_v2::StatusOption {
+                id: "1".to_string(),
+                name: "needs review".to_string(),
+            },
+            crate::github::projects_v2::StatusOption {
+                id: "2".to_string(),
+                name: "Approved".to_string(),
+            },
+        ];
+
+        let missing = validate_review_route_options(&review, &options, true);
+        assert_eq!(
+            missing,
+            vec!["review.changes_requested_route.state='Changes Requested'"]
+        );
+    }
+
+    #[tokio::test]
+    async fn review_check_skips_when_disabled_and_validates_preview_configuration() {
+        let mut config = ServiceConfig::default();
+        let disabled = check_review(&config).await;
+        assert_eq!(disabled.len(), 1);
+        assert_eq!(disabled[0].status, CheckStatus::Skipped);
+
+        config.review.enabled = true;
+        config.review.mode = ReviewMode::Preview;
+        let preview = check_review(&config).await;
+        assert_eq!(preview.len(), 1);
+        assert_eq!(preview[0].status, CheckStatus::Error);
+        assert!(preview[0].message.contains("github_project_number"));
     }
 
     #[test]

--- a/apps/symphony/src/error.rs
+++ b/apps/symphony/src/error.rs
@@ -110,6 +110,12 @@ pub enum SymphonyError {
     #[error("triage error: {0}")]
     TriageError(String),
 
+    #[error("review cycle reopened: {0}")]
+    ReviewCycleReopened(String),
+
+    #[error("review publication conflict: {0}")]
+    ReviewPublicationConflict(String),
+
     #[error("storage error: {0}")]
     StorageError(String),
 

--- a/apps/symphony/src/github/client.rs
+++ b/apps/symphony/src/github/client.rs
@@ -152,7 +152,8 @@ pub struct GithubPullRequestReview {
     pub user: Option<GithubUser>,
     #[serde(default)]
     pub body: Option<String>,
-    pub commit_id: String,
+    #[serde(default)]
+    pub commit_id: Option<String>,
     #[serde(default)]
     pub state: String,
     #[serde(default)]

--- a/apps/symphony/src/github/client.rs
+++ b/apps/symphony/src/github/client.rs
@@ -145,6 +145,34 @@ pub struct GithubPullRequestFile {
     pub patch: Option<String>,
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+pub struct GithubPullRequestReview {
+    pub id: u64,
+    #[serde(default)]
+    pub user: Option<GithubUser>,
+    #[serde(default)]
+    pub body: Option<String>,
+    pub commit_id: String,
+    #[serde(default)]
+    pub state: String,
+    #[serde(default)]
+    pub html_url: Option<String>,
+    #[serde(default)]
+    pub submitted_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct GithubPullRequestReviewComment {
+    pub path: String,
+    pub line: u32,
+    pub side: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start_line: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start_side: Option<String>,
+    pub body: String,
+}
+
 #[derive(Clone)]
 pub struct GithubClient {
     pub http_client: reqwest::Client,
@@ -518,6 +546,45 @@ impl GithubClient {
         url.query_pairs_mut().append_pair("per_page", "100");
         self.paginated_get_capped(url.as_ref(), max_pages, "pull files")
             .await
+    }
+
+    /// List reviews for a pull request, including author, body, and reviewed commit.
+    pub async fn list_pull_request_reviews(
+        &self,
+        number: u64,
+        max_pages: u32,
+    ) -> Result<Vec<GithubPullRequestReview>> {
+        let mut url = reqwest::Url::parse(&format!(
+            "{}/repos/{}/{}/pulls/{number}/reviews",
+            self.base_url, self.repo_owner, self.repo_name
+        ))
+        .map_err(|err| {
+            SymphonyError::GithubApiRequest(format!("invalid pull reviews URL: {err}"))
+        })?;
+        url.query_pairs_mut().append_pair("per_page", "100");
+        self.paginated_get_capped(url.as_ref(), max_pages, "pull reviews")
+            .await
+    }
+
+    /// Create one atomic review containing a summary and all inline comments.
+    pub async fn create_pull_request_review(
+        &self,
+        number: u64,
+        commit_id: &str,
+        body: &str,
+        comments: &[GithubPullRequestReviewComment],
+    ) -> Result<GithubPullRequestReview> {
+        let path = format!(
+            "/repos/{}/{}/pulls/{number}/reviews",
+            self.repo_owner, self.repo_name
+        );
+        let payload = serde_json::json!({
+            "commit_id": commit_id,
+            "body": body,
+            "event": "COMMENT",
+            "comments": comments,
+        });
+        self.request_json(Method::POST, &path, Some(&payload)).await
     }
 
     /// Create a pull request. Callers that need draft publication pass `draft: true`.

--- a/apps/symphony/src/github/client.rs
+++ b/apps/symphony/src/github/client.rs
@@ -566,6 +566,41 @@ impl GithubClient {
             .await
     }
 
+    /// Probe pull request review write authorization without creating a review.
+    ///
+    /// GitHub rejects the intentionally invalid event with HTTP 422 after it
+    /// authorizes the endpoint. Any other status is surfaced to the caller.
+    pub async fn probe_pull_request_review_permission(&self, number: u64) -> Result<()> {
+        let path = format!(
+            "/repos/{}/{}/pulls/{number}/reviews",
+            self.repo_owner, self.repo_name
+        );
+        let url = format!("{}{}", self.base_url, path);
+        let payload = serde_json::json!({ "event": "INVALID" });
+
+        self.wait_for_rate_limit_if_needed().await;
+        let response = self
+            .http_client
+            .request(Method::POST, &url)
+            .json(&payload)
+            .send()
+            .await
+            .map_err(|err| {
+                SymphonyError::GithubApiRequest(format!("request to {url} failed: {err}"))
+            })?;
+        self.update_rate_limit_state(response.headers()).await;
+
+        let status = response.status().as_u16();
+        let body = response.text().await.unwrap_or_default();
+        if status == 422 {
+            return Ok(());
+        }
+        Err(SymphonyError::GithubApiStatus {
+            status,
+            message: truncate_error_preview(&body),
+        })
+    }
+
     /// Create one atomic review containing a summary and all inline comments.
     pub async fn create_pull_request_review(
         &self,

--- a/apps/symphony/src/github/projects_v2.rs
+++ b/apps/symphony/src/github/projects_v2.rs
@@ -5,6 +5,7 @@ use serde::de::DeserializeOwned;
 use serde::Deserialize;
 use serde_json::{json, Value};
 
+use crate::domain::GithubProjectOwnerType;
 use crate::error::{Result, SymphonyError};
 use crate::github::client::GithubClient;
 
@@ -148,6 +149,26 @@ impl ProjectsV2Client {
         owner: &str,
         project_number: u64,
     ) -> Result<StatusFieldInfo> {
+        self.resolve_status_field_with_owner_type(owner, project_number, None)
+            .await
+    }
+
+    pub async fn resolve_status_field_for_owner_type(
+        &self,
+        owner: &str,
+        project_number: u64,
+        owner_type: GithubProjectOwnerType,
+    ) -> Result<StatusFieldInfo> {
+        self.resolve_status_field_with_owner_type(owner, project_number, Some(owner_type))
+            .await
+    }
+
+    async fn resolve_status_field_with_owner_type(
+        &self,
+        owner: &str,
+        project_number: u64,
+        owner_type: Option<GithubProjectOwnerType>,
+    ) -> Result<StatusFieldInfo> {
         let variables = json!({
             "owner": owner,
             "projectNumber": project_number as i64,
@@ -157,15 +178,19 @@ impl ProjectsV2Client {
             .graphql_request(QUERY_PROJECT_FIELDS, variables)
             .await?;
 
-        let project = data
-            .user
-            .and_then(|user| user.project_v2)
-            .or_else(|| data.organization.and_then(|org| org.project_v2))
-            .ok_or_else(|| {
-                SymphonyError::GithubProjectsV2Error(format!(
-                    "Project #{project_number} not found for owner '{owner}'"
-                ))
-            })?;
+        let project = match owner_type {
+            Some(GithubProjectOwnerType::User) => data.user.and_then(|user| user.project_v2),
+            Some(GithubProjectOwnerType::Org) => data.organization.and_then(|org| org.project_v2),
+            None => data
+                .user
+                .and_then(|user| user.project_v2)
+                .or_else(|| data.organization.and_then(|org| org.project_v2)),
+        }
+        .ok_or_else(|| {
+            SymphonyError::GithubProjectsV2Error(format!(
+                "Project #{project_number} not found for owner '{owner}'"
+            ))
+        })?;
 
         let Some(field) = project.field else {
             tracing::warn!(project_number, owner, "Projects v2 status field not found");

--- a/apps/symphony/src/http_server.rs
+++ b/apps/symphony/src/http_server.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -884,6 +884,16 @@ pub struct FactoryRunReviewHttp {
     pub no_findings: bool,
     pub received_at: chrono::DateTime<Utc>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub current_cycle: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cycle_count: Option<u32>,
+    #[serde(default)]
+    pub finding_counts_by_severity: BTreeMap<String, u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub review_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub review_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub publication: Option<FactoryRunReviewPublicationHttp>,
 }
 
@@ -894,6 +904,8 @@ pub struct FactoryRunReviewPublicationHttp {
     pub status: String,
     pub completed_steps: Vec<String>,
     pub retry_count: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub route_state: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error: Option<crate::triage::domain::FactoryError>,
 }
@@ -958,9 +970,41 @@ pub fn attach_review_http_response(
     artifact: Option<&crate::review::domain::ReviewFindingsArtifactRecord>,
     publication: Option<&crate::review::domain::ReviewPublicationIntent>,
 ) {
+    attach_review_http_response_with_attempts(response, artifact, publication, &[]);
+}
+
+pub fn attach_review_http_response_with_attempts(
+    response: &mut FactoryRunHttpResponse,
+    artifact: Option<&crate::review::domain::ReviewFindingsArtifactRecord>,
+    publication: Option<&crate::review::domain::ReviewPublicationIntent>,
+    attempts: &[crate::triage::domain::StageRunRecord],
+) {
     let Some(artifact) = artifact else {
         return;
     };
+    let review_attempts = attempts
+        .iter()
+        .filter(|attempt| attempt.stage == crate::review::domain::REVIEW_STAGE_NAME)
+        .collect::<Vec<_>>();
+    let current_cycle = review_attempts.iter().map(|attempt| attempt.attempt).max();
+    let cycle_count = (!review_attempts.is_empty()).then_some(review_attempts.len() as u32);
+    let mut finding_counts_by_severity = BTreeMap::from([
+        ("blocking".to_string(), 0),
+        ("major".to_string(), 0),
+        ("minor".to_string(), 0),
+        ("nit".to_string(), 0),
+    ]);
+    for finding in &artifact.manifest.findings {
+        let severity = match finding.severity {
+            crate::review::manifest::ReviewSeverity::Blocking => "blocking",
+            crate::review::manifest::ReviewSeverity::Major => "major",
+            crate::review::manifest::ReviewSeverity::Minor => "minor",
+            crate::review::manifest::ReviewSeverity::Nit => "nit",
+        };
+        *finding_counts_by_severity
+            .entry(severity.to_string())
+            .or_insert(0) += 1;
+    }
     response.review = Some(FactoryRunReviewHttp {
         status: publication
             .map(|intent| intent.status.as_str().to_string())
@@ -971,12 +1015,18 @@ pub fn attach_review_http_response(
         finding_count: artifact.finding_count,
         no_findings: artifact.no_findings,
         received_at: artifact.received_at,
+        current_cycle,
+        cycle_count,
+        finding_counts_by_severity,
+        review_id: publication.and_then(|intent| intent.review_id.clone()),
+        review_url: publication.and_then(|intent| intent.review_url.clone()),
         publication: publication.map(|intent| FactoryRunReviewPublicationHttp {
             intent_id: intent.intent_id.clone(),
             kind: intent.kind.clone(),
             status: intent.status.as_str().to_string(),
             completed_steps: intent.completed_steps.clone(),
             retry_count: intent.retry_count,
+            route_state: intent.route_state.clone(),
             error: intent.last_error.clone(),
         }),
     });
@@ -1050,6 +1100,7 @@ pub struct ReviewRunMetricsHttpResponse {
     pub base: FactoryRunMetricsHttpResponse,
     pub blocked_publications: u64,
     pub preview_publications: u64,
+    pub automatic_publications: u64,
     pub findings: u64,
     pub no_findings: u64,
 }
@@ -1063,6 +1114,7 @@ pub fn review_run_metrics_http_response(
         base,
         blocked_publications: metrics.blocked_publications,
         preview_publications: metrics.preview_publications,
+        automatic_publications: metrics.automatic_publications,
         findings: metrics.findings,
         no_findings: metrics.no_findings,
     }
@@ -3439,5 +3491,56 @@ mod tests {
             err.message.contains(&allowed_values),
             "error should list deterministic allowed values"
         );
+    }
+
+    #[test]
+    fn review_http_fields_are_serialized_and_new_fields_default_on_old_payloads() {
+        let old_payload = serde_json::json!({
+            "status": "completed",
+            "artifact_id": "artifact-1",
+            "reviewed_head_sha": "head",
+            "base_sha": "base",
+            "finding_count": 1,
+            "no_findings": false,
+            "received_at": Utc::now(),
+            "publication": null
+        });
+        let old: FactoryRunReviewHttp = serde_json::from_value(old_payload).unwrap();
+        assert!(old.current_cycle.is_none());
+        assert!(old.review_id.is_none());
+        assert!(old.finding_counts_by_severity.is_empty());
+
+        let mut counts = BTreeMap::new();
+        counts.insert("blocking".to_string(), 1);
+        let review = FactoryRunReviewHttp {
+            status: "applied".to_string(),
+            artifact_id: "artifact-1".to_string(),
+            reviewed_head_sha: "head".to_string(),
+            base_sha: "base".to_string(),
+            finding_count: 1,
+            no_findings: false,
+            received_at: Utc::now(),
+            current_cycle: Some(2),
+            cycle_count: Some(2),
+            finding_counts_by_severity: counts,
+            review_id: Some("review-1".to_string()),
+            review_url: Some("https://github.com/review/1".to_string()),
+            publication: Some(FactoryRunReviewPublicationHttp {
+                intent_id: "intent-1".to_string(),
+                kind: "automatic".to_string(),
+                status: "applied".to_string(),
+                completed_steps: vec!["route_applied".to_string()],
+                retry_count: 0,
+                route_state: Some("Human Review".to_string()),
+                error: None,
+            }),
+        };
+        let payload = serde_json::to_value(review).unwrap();
+        assert_eq!(payload["current_cycle"], 2);
+        assert_eq!(payload["cycle_count"], 2);
+        assert_eq!(payload["finding_counts_by_severity"]["blocking"], 1);
+        assert_eq!(payload["review_id"], "review-1");
+        assert_eq!(payload["review_url"], "https://github.com/review/1");
+        assert_eq!(payload["publication"]["route_state"], "Human Review");
     }
 }

--- a/apps/symphony/src/main.rs
+++ b/apps/symphony/src/main.rs
@@ -852,6 +852,10 @@ fn run_doctor(workflow_path: &Path) -> Result<i32, String> {
                         runtime.block_on(doctor::check_github(&service_config.tracker))
                     });
                     results.extend(github_results);
+                    let review_results = tokio::task::block_in_place(|| {
+                        runtime.block_on(doctor::check_review(&service_config))
+                    });
+                    results.extend(review_results);
 
                     results.extend(doctor::check_backend(&service_config));
                     results.extend(doctor::check_workspace(&service_config.workspace));

--- a/apps/symphony/src/review/coordinator.rs
+++ b/apps/symphony/src/review/coordinator.rs
@@ -655,6 +655,20 @@ where
                 return Ok(ProcessOutcome::Waiting);
             }
             if let Err(error) = formal_result {
+                if is_review_cycle_reopened_error(&error) {
+                    self.record_event(
+                        Some(&candidate.run_id),
+                        Some(&stage.stage_run_id),
+                        "review_cycle_reopened",
+                        serde_json::json!({
+                            "status": "waiting",
+                            "reason": "publication_head_sha_changed_during_creation",
+                            "pr_number": candidate.pr_number,
+                            "reviewed_head_sha": pull.head.sha,
+                        }),
+                    )?;
+                    return Ok(ProcessOutcome::Waiting);
+                }
                 let classified = classify_review_publication_error(&error);
                 let status = self.record_publication_failure(
                     &intent,
@@ -952,6 +966,19 @@ where
                 .await;
                 match publisher_result {
                     Ok(ReviewPublicationResult::Waiting) => Ok(ReviewPublicationResult::Waiting),
+                    Err(error) if is_review_cycle_reopened_error(&error) => {
+                        self.record_event(
+                            Some(&intent.run_id),
+                            None,
+                            "review_cycle_reopened",
+                            serde_json::json!({
+                                "status": "waiting",
+                                "reason": "publication_head_sha_changed_during_creation",
+                                "intent_id": intent.intent_id,
+                            }),
+                        )?;
+                        Ok(ReviewPublicationResult::Waiting)
+                    }
                     Err(error) => Err(error),
                     Ok(ReviewPublicationResult::Published) => self
                         .apply_automatic_route_with_data(
@@ -1267,6 +1294,13 @@ where
 
 fn review_attempt_retry_exhausted(failed_attempts: u32, max_attempts: u32) -> bool {
     failed_attempts.saturating_add(1) >= max_attempts.max(1)
+}
+
+fn is_review_cycle_reopened_error(error: &SymphonyError) -> bool {
+    error
+        .to_string()
+        .to_ascii_lowercase()
+        .contains("review cycle reopened")
 }
 
 fn classify_review_publication_error(error: &SymphonyError) -> FactoryError {

--- a/apps/symphony/src/review/coordinator.rs
+++ b/apps/symphony/src/review/coordinator.rs
@@ -667,6 +667,22 @@ where
                             "reviewed_head_sha": pull.head.sha,
                         }),
                     )?;
+                    let superseded = FactoryError::new(
+                        "review_publication_superseded",
+                        "review_publisher",
+                        format!(
+                            "review publication intent {} was superseded after the PR head changed: {}",
+                            intent.intent_id, error
+                        ),
+                        false,
+                        None,
+                    );
+                    self.supersede_publication(
+                        &intent.intent_id,
+                        &candidate.run_id,
+                        Some(&stage.stage_run_id),
+                        superseded,
+                    )?;
                     return Ok(ProcessOutcome::Waiting);
                 }
                 let classified = classify_review_publication_error(&error);
@@ -947,6 +963,22 @@ where
                                 "observed_head_sha": pull.head.sha,
                             }),
                         )?;
+                        let superseded = FactoryError::new(
+                            "review_publication_superseded",
+                            "review_publisher",
+                            format!(
+                                "review publication intent {} was superseded because the PR head changed from {} to {}",
+                                intent.intent_id, expected_head, pull.head.sha
+                            ),
+                            false,
+                            None,
+                        );
+                        self.supersede_publication(
+                            &intent.intent_id,
+                            &intent.run_id,
+                            None,
+                            superseded,
+                        )?;
                         return Ok(ReviewPublicationResult::Waiting);
                     }
                     publisher
@@ -980,6 +1012,22 @@ where
                                 "reason": "publication_head_sha_changed_during_creation",
                                 "intent_id": intent.intent_id,
                             }),
+                        )?;
+                        let superseded = FactoryError::new(
+                            "review_publication_superseded",
+                            "review_publisher",
+                            format!(
+                                "review publication intent {} was superseded after the PR head changed: {}",
+                                intent.intent_id, error
+                            ),
+                            false,
+                            None,
+                        );
+                        self.supersede_publication(
+                            &intent.intent_id,
+                            &intent.run_id,
+                            None,
+                            superseded,
                         )?;
                         Ok(ReviewPublicationResult::Waiting)
                     }
@@ -1276,6 +1324,27 @@ where
             )?;
         }
         Ok(())
+    }
+
+    fn supersede_publication(
+        &self,
+        intent_id: &str,
+        run_id: &str,
+        stage_run_id: Option<&str>,
+        error: FactoryError,
+    ) -> Result<()> {
+        let store = self.store.clone();
+        store.supersede_review_publication(intent_id, error.clone())?;
+        self.record_event(
+            Some(run_id),
+            stage_run_id,
+            "review_publication_superseded",
+            serde_json::json!({
+                "status": "conflict",
+                "intent_id": intent_id,
+                "error": error,
+            }),
+        )
     }
 
     fn record_event(

--- a/apps/symphony/src/review/coordinator.rs
+++ b/apps/symphony/src/review/coordinator.rs
@@ -1334,7 +1334,9 @@ where
         error: FactoryError,
     ) -> Result<()> {
         let store = self.store.clone();
-        store.supersede_review_publication(intent_id, error.clone())?;
+        if !store.supersede_review_publication(intent_id, error.clone())? {
+            return Ok(());
+        }
         self.record_event(
             Some(run_id),
             stage_run_id,

--- a/apps/symphony/src/review/coordinator.rs
+++ b/apps/symphony/src/review/coordinator.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 use crate::domain::{AgentBackend, ServiceConfig};
 use crate::error::{Result, SymphonyError};
 use crate::github::client::GithubClient;
-use crate::github::projects_v2::ProjectsV2Client;
+use crate::github::projects_v2::{ProjectItem, ProjectsV2Client, StatusFieldInfo};
 use crate::path_safety::canonicalize;
 use crate::review::domain::ReviewConfig;
 use crate::review::findings::reviewed_files;
@@ -50,6 +50,7 @@ pub struct ReviewPollSummary {
     pub attempts_failed: u32,
     pub waiting: u32,
     pub preview_published: u32,
+    pub automatic_published: u32,
     pub blocked: u32,
 }
 
@@ -127,7 +128,7 @@ where
             };
             let in_trigger_state = project_items.iter().any(|item| {
                 item.issue_number == issue_number
-                    && item.repository.as_deref().is_none_or(|repository| {
+                    && item.repository.as_deref().is_some_and(|repository| {
                         repository.eq_ignore_ascii_case(&candidate.repository)
                     })
                     && item
@@ -146,7 +147,11 @@ where
                 Ok(ProcessOutcome::Completed) => {
                     summary.attempts_started += 1;
                     summary.attempts_completed += 1;
-                    summary.preview_published += 1;
+                    if service.review.mode == crate::review::domain::ReviewMode::Automatic {
+                        summary.automatic_published += 1;
+                    } else {
+                        summary.preview_published += 1;
+                    }
                 }
                 Ok(ProcessOutcome::Waiting) => summary.waiting += 1,
                 Ok(ProcessOutcome::Blocked) => {
@@ -178,6 +183,68 @@ where
         if !pull.state.eq_ignore_ascii_case("open") {
             return Ok(ProcessOutcome::Waiting);
         }
+        let failed_attempts = self
+            .store
+            .count_review_attempt_failures_for_head(&candidate.run_id, &pull.head.sha)?;
+        if failed_attempts >= service.review.max_attempts.max(1) {
+            return Ok(ProcessOutcome::Waiting);
+        }
+        if self
+            .store
+            .review_artifact_exists_for_head(&candidate.run_id, &pull.head.sha)?
+        {
+            if let Some(artifact) = self
+                .store
+                .get_orphaned_review_artifact_for_head(&candidate.run_id, &pull.head.sha)?
+            {
+                let spec = self
+                    .store
+                    .get_spec_artifact(&candidate.approved_artifact_id)?
+                    .ok_or_else(|| {
+                        SymphonyError::StorageError(format!(
+                            "approved spec artifact {} is missing",
+                            candidate.approved_artifact_id
+                        ))
+                    })?;
+                let kind = service.review.mode.as_str();
+                let route_state = review_route_state(&artifact, service);
+                self.store.create_review_publication_intent(
+                    &candidate.run_id,
+                    &artifact.artifact_id,
+                    kind,
+                    &review_publication_effects(
+                        issue_number,
+                        candidate,
+                        &pull,
+                        service,
+                        route_state,
+                        spec.version,
+                    ),
+                )?;
+                self.reconcile_pending_publications(service).await?;
+                let intent = self
+                    .store
+                    .list_review_publications_for_run(&candidate.run_id)?
+                    .into_iter()
+                    .find(|intent| intent.artifact_id == artifact.artifact_id)
+                    .ok_or_else(|| {
+                        SymphonyError::StorageError(format!(
+                            "recreated review intent for artifact {} is missing",
+                            artifact.artifact_id
+                        ))
+                    })?;
+                return Ok(
+                    if intent.status == crate::triage::domain::PublicationStatus::Applied {
+                        ProcessOutcome::Completed
+                    } else {
+                        ProcessOutcome::Waiting
+                    },
+                );
+            }
+            // An artifact with an intent is already complete or pending durable
+            // publication. Reconciliation owns pending intents.
+            return Ok(ProcessOutcome::Waiting);
+        }
         if pull.head.sha != candidate.head_sha {
             self.record_event(
                 Some(&candidate.run_id),
@@ -190,12 +257,28 @@ where
                     "observed_head_sha": pull.head.sha,
                 }),
             )?;
-            return Ok(ProcessOutcome::Waiting);
         }
         let files = self
             .github
             .list_pull_request_files(candidate.pr_number, self.config.max_pages)
             .await?;
+        let refreshed_pull = self.github.get_pull_request(candidate.pr_number).await?;
+        if pull_revision_changed(&pull, &refreshed_pull) {
+            self.record_event(
+                Some(&candidate.run_id),
+                None,
+                "review_cycle_reopened",
+                serde_json::json!({
+                    "status": "waiting",
+                    "reason": "head_or_base_sha_changed_during_file_retrieval",
+                    "expected_head_sha": pull.head.sha,
+                    "observed_head_sha": refreshed_pull.head.sha,
+                    "expected_base_sha": pull.base.sha,
+                    "observed_base_sha": refreshed_pull.base.sha,
+                }),
+            )?;
+            return Ok(ProcessOutcome::Waiting);
+        }
         let changed = reviewed_files(&files);
         let diff = files
             .iter()
@@ -344,6 +427,50 @@ where
                     continue;
                 }
             };
+            let completed_pull = self.github.get_pull_request(candidate.pr_number).await?;
+            if pull_revision_changed(&pull, &completed_pull) {
+                self.record_event(
+                    Some(&candidate.run_id),
+                    Some(&stage.stage_run_id),
+                    "review_cycle_reopened",
+                    serde_json::json!({
+                        "status": "waiting",
+                        "reason": "head_or_base_sha_changed_after_worker",
+                        "expected_head_sha": pull.head.sha,
+                        "observed_head_sha": completed_pull.head.sha,
+                        "expected_base_sha": pull.base.sha,
+                        "observed_base_sha": completed_pull.base.sha,
+                    }),
+                )?;
+                let reopened_error = FactoryError::new(
+                    "review_cycle_reopened",
+                    "review_coordinator",
+                    "review cycle reopened while worker was running",
+                    true,
+                    None,
+                );
+                self.store.update_review_attempt(UpdateReviewAttemptRequest {
+                    attempt_id: &attempt_id,
+                    status: "interrupted",
+                    reprompt_count: reprompt,
+                    worker_turn: None,
+                    manifest: None,
+                    validation_result: Some(&serde_json::json!({
+                        "accepted": false,
+                        "status": "waiting",
+                        "reason": "head_or_base_sha_changed_after_worker",
+                        "expected_head_sha": pull.head.sha,
+                        "observed_head_sha": completed_pull.head.sha,
+                        "expected_base_sha": pull.base.sha,
+                        "observed_base_sha": completed_pull.base.sha,
+                    })),
+                    error: Some(&reopened_error),
+                })?;
+                let _ = self
+                    .store
+                    .interrupt_review_attempt(&stage.stage_run_id, &self.config.owner_instance)?;
+                return Ok(ProcessOutcome::Waiting);
+            }
             total_usage.input_tokens = total_usage
                 .input_tokens
                 .saturating_add(result.usage.input_tokens);
@@ -437,40 +564,184 @@ where
                 "finding_count": artifact.finding_count,
             }),
         )?;
+        let kind = service.review.mode.as_str();
+        let route_state = if artifact
+            .manifest
+            .findings
+            .iter()
+            .any(|finding| finding.severity <= service.review.blocking_severity)
+        {
+            service
+                .review
+                .changes_requested_route
+                .as_ref()
+                .map(|route| route.state.trim().to_string())
+        } else {
+            service
+                .review
+                .completion_route
+                .as_ref()
+                .map(|route| route.state.trim().to_string())
+        };
         let intent = self.store.create_review_publication_intent(
             &candidate.run_id,
             &artifact.artifact_id,
-            "preview",
+            kind,
             &serde_json::json!({
                 "issue_number": issue_number,
+                "repository": candidate.repository,
                 "pr_number": candidate.pr_number,
                 "reviewed_head_sha": pull.head.sha,
                 "base_sha": pull.base.sha,
+                "trigger_state": service.review.trigger_state,
+                "route_state": route_state,
+                "approved_spec_version": spec.version,
             }),
         )?;
         let publisher = ReviewPublisher::new(self.comments.clone());
-        publisher
-            .publish_preview(
-                &self.store,
-                &intent,
-                &artifact,
-                issue_number,
-                self.config.max_pages,
-            )
-            .await?;
-        self.record_event(
-            Some(&candidate.run_id),
-            Some(&stage.stage_run_id),
-            "review_published",
-            serde_json::json!({"status":"applied","intent_id":intent.intent_id,"artifact_id":artifact.artifact_id}),
-        )?;
+        if service.review.mode == crate::review::domain::ReviewMode::Preview {
+            if let Err(error) = publisher
+                .publish_preview(
+                    &self.store,
+                    &intent,
+                    &artifact,
+                    issue_number,
+                    self.config.max_pages,
+                )
+                .await
+            {
+                let classified = classify_review_publication_error(&error);
+                let status = self.record_publication_failure(
+                    &intent,
+                    classified.clone(),
+                    service.review.max_attempts,
+                )?;
+                if matches!(
+                    status,
+                    crate::triage::domain::PublicationStatus::Conflict
+                        | crate::triage::domain::PublicationStatus::Blocked
+                ) {
+                    self.record_event(
+                        Some(&candidate.run_id),
+                        Some(&stage.stage_run_id),
+                        "review_blocked",
+                        serde_json::json!({
+                            "status": status.as_str(),
+                            "classification": status.as_str(),
+                            "intent_id": intent.intent_id,
+                            "artifact_id": artifact.artifact_id,
+                            "error": classified,
+                        }),
+                    )?;
+                    return Ok(ProcessOutcome::Blocked);
+                }
+                return Err(error);
+            }
+        } else {
+            if let Err(error) = publisher
+                .publish_formal(
+                    &self.store,
+                    &self.github,
+                    &intent,
+                    &artifact,
+                    candidate.pr_number,
+                    self.config.max_pages,
+                )
+                .await
+            {
+                let classified = classify_review_publication_error(&error);
+                let status = self.record_publication_failure(
+                    &intent,
+                    classified.clone(),
+                    service.review.max_attempts,
+                )?;
+                if matches!(
+                    status,
+                    crate::triage::domain::PublicationStatus::Conflict
+                        | crate::triage::domain::PublicationStatus::Blocked
+                ) {
+                    self.record_event(
+                        Some(&candidate.run_id),
+                        Some(&stage.stage_run_id),
+                        "review_blocked",
+                        serde_json::json!({
+                            "status": status.as_str(),
+                            "classification": status.as_str(),
+                            "intent_id": intent.intent_id,
+                            "artifact_id": artifact.artifact_id,
+                            "error": classified,
+                        }),
+                    )?;
+                    return Ok(ProcessOutcome::Blocked);
+                }
+                return Err(error);
+            }
+            let pending = self
+                .store
+                .get_review_publication_intent(&intent.intent_id)?
+                .ok_or_else(|| {
+                    SymphonyError::StorageError(format!(
+                        "review intent {} disappeared after publication",
+                        intent.intent_id
+                    ))
+                })?;
+            self.apply_automatic_route(service, &pending, issue_number).await?;
+            let routed = self
+                .store
+                .get_review_publication_intent(&intent.intent_id)?
+                .ok_or_else(|| {
+                    SymphonyError::StorageError(format!(
+                        "review intent {} disappeared after routing",
+                        intent.intent_id
+                    ))
+                })?;
+            if !routed.completed_steps.iter().any(|step| step == "route_applied") {
+                return Ok(ProcessOutcome::Waiting);
+            }
+            self.store.record_review_publication_step(
+                &routed.intent_id,
+                "comment_final",
+                crate::triage::domain::PublicationStatus::Pending,
+                &serde_json::json!({
+                    "review_id": routed.review_id,
+                    "review_url": routed.review_url,
+                    "route_state": routed.route_state,
+                }),
+            )?;
+        }
+        let final_intent = self
+            .store
+            .get_review_publication_intent(&intent.intent_id)?
+            .ok_or_else(|| {
+                SymphonyError::StorageError(format!(
+                    "review intent {} disappeared before completion",
+                    intent.intent_id
+                ))
+            })?;
+        if final_intent.status == crate::triage::domain::PublicationStatus::Applied {
+            self.record_event(
+                Some(&candidate.run_id),
+                Some(&stage.stage_run_id),
+                "review_published",
+                serde_json::json!({"status":"applied","intent_id":intent.intent_id,"artifact_id":artifact.artifact_id}),
+            )?;
             Ok(ProcessOutcome::Completed)
+        } else {
+            Ok(ProcessOutcome::Waiting)
+        }
         }
         .await;
 
         if let Err(error) = &result {
+            let cycle_reopened = error
+                .to_string()
+                .contains("review cycle reopened while worker was running");
             let factory_error = FactoryError::new(
-                "review_attempt_failed",
+                if cycle_reopened {
+                    "review_cycle_reopened"
+                } else {
+                    "review_attempt_failed"
+                },
                 "review_coordinator",
                 error.to_string(),
                 true,
@@ -511,10 +782,39 @@ where
         result
     }
 
-    async fn reconcile_pending_publications(&self, _service: &ServiceConfig) -> Result<()> {
+    async fn reconcile_pending_publications(&self, service: &ServiceConfig) -> Result<()> {
         let publisher = ReviewPublisher::new(self.comments.clone());
-        for intent in self.store.list_pending_review_publications()? {
+        let pending = self.store.list_pending_review_publications()?;
+        let has_automatic = pending.iter().any(|intent| intent.kind == "automatic");
+        let project_data = if has_automatic {
+            let field = self
+                .projects
+                .resolve_status_field(&self.config.project_owner, self.config.project_number)
+                .await?;
+            let items = self
+                .projects
+                .query_all_items(&field.project_id, self.config.max_pages)
+                .await?;
+            Some((field, items))
+        } else {
+            None
+        };
+
+        for intent in pending {
             let Some(artifact) = self.store.get_review_artifact(&intent.artifact_id)? else {
+                let error = FactoryError::new(
+                    "review_publication_missing_artifact",
+                    "review_publisher",
+                    format!("review artifact {} is missing", intent.artifact_id),
+                    false,
+                    None,
+                );
+                self.record_publication_failure(
+                    &intent,
+                    error.clone(),
+                    service.review.max_attempts,
+                )?;
+                self.record_reconciliation_blocked(&intent, &error)?;
                 continue;
             };
             let Some(issue_number) = intent
@@ -522,41 +822,351 @@ where
                 .get("issue_number")
                 .and_then(serde_json::Value::as_u64)
             else {
-                self.store.set_review_publication_error(
-                    &intent.intent_id,
-                    crate::triage::domain::PublicationStatus::Blocked,
-                    FactoryError::new(
-                        "review_publication_missing_issue_number",
-                        "review_publisher",
-                        format!("review intent {} is missing issue_number", intent.intent_id),
-                        false,
-                        None,
-                    ),
+                let error = FactoryError::new(
+                    "review_publication_missing_issue_number",
+                    "review_publisher",
+                    format!("review intent {} is missing issue_number", intent.intent_id),
+                    false,
+                    None,
+                );
+                self.record_publication_failure(
+                    &intent,
+                    error.clone(),
+                    service.review.max_attempts,
                 )?;
+                self.record_reconciliation_blocked(&intent, &error)?;
                 continue;
             };
-            if let Err(error) = publisher
-                .publish_preview(
-                    &self.store,
-                    &intent,
-                    &artifact,
-                    issue_number,
-                    self.config.max_pages,
-                )
-                .await
-            {
-                self.store.set_review_publication_error(
-                    &intent.intent_id,
-                    crate::triage::domain::PublicationStatus::Pending,
-                    FactoryError::new(
-                        "review_publication_retryable",
-                        "review_publisher",
-                        error.to_string(),
-                        true,
-                        None,
-                    ),
-                )?;
+
+            let result = if intent.kind == "automatic" {
+                let publisher_result = async {
+                    let pr_number = intent
+                        .desired_effects
+                        .get("pr_number")
+                        .and_then(serde_json::Value::as_u64)
+                        .unwrap_or(issue_number);
+                    let expected_head = intent
+                        .desired_effects
+                        .get("reviewed_head_sha")
+                        .and_then(serde_json::Value::as_str)
+                        .unwrap_or("");
+                    let pull = self.github.get_pull_request(pr_number).await?;
+                    if pull.head.sha != expected_head {
+                        self.record_event(
+                            Some(&intent.run_id),
+                            None,
+                            "review_cycle_reopened",
+                            serde_json::json!({
+                                "status": "waiting",
+                                "reason": "publication_head_sha_changed",
+                                "intent_id": intent.intent_id,
+                                "expected_head_sha": expected_head,
+                                "observed_head_sha": pull.head.sha,
+                            }),
+                        )?;
+                        return Ok(ReviewPublicationResult::Waiting);
+                    }
+                    publisher
+                        .publish_formal(
+                            &self.store,
+                            &self.github,
+                            &intent,
+                            &artifact,
+                            pr_number,
+                            self.config.max_pages,
+                        )
+                        .await
+                        .map(|()| ReviewPublicationResult::Published)
+                }
+                .await;
+                match publisher_result {
+                    Ok(ReviewPublicationResult::Waiting) => Ok(ReviewPublicationResult::Waiting),
+                    Err(error) => Err(error),
+                    Ok(ReviewPublicationResult::Published) => self
+                        .apply_automatic_route_with_data(
+                            service,
+                            &intent,
+                            issue_number,
+                            project_data.as_ref().expect("automatic project data"),
+                        )
+                        .await
+                        .and_then(|applied| {
+                            if !applied {
+                                return Ok(ReviewPublicationResult::Published);
+                            }
+                            let latest = self
+                                .store
+                                .get_review_publication_intent(&intent.intent_id)?
+                                .ok_or_else(|| {
+                                    SymphonyError::StorageError(format!(
+                                        "review intent {} disappeared during reconciliation",
+                                        intent.intent_id
+                                    ))
+                                })?;
+                            if latest
+                                .completed_steps
+                                .iter()
+                                .any(|step| step == "comment_final")
+                            {
+                                return Ok(ReviewPublicationResult::Published);
+                            }
+                            self.store.record_review_publication_step(
+                                &intent.intent_id,
+                                "comment_final",
+                                crate::triage::domain::PublicationStatus::Pending,
+                                &serde_json::json!({
+                                    "review_id": latest.review_id,
+                                    "review_url": latest.review_url,
+                                    "route_state": latest.route_state,
+                                }),
+                            )?;
+                            Ok(ReviewPublicationResult::Published)
+                        }),
+                }
+            } else {
+                publisher
+                    .publish_preview(
+                        &self.store,
+                        &intent,
+                        &artifact,
+                        issue_number,
+                        self.config.max_pages,
+                    )
+                    .await
+                    .map(|()| ReviewPublicationResult::Published)
+            };
+            match result {
+                Ok(ReviewPublicationResult::Waiting) => {}
+                Ok(ReviewPublicationResult::Published) => {
+                    let latest = self
+                        .store
+                        .get_review_publication_intent(&intent.intent_id)?
+                        .ok_or_else(|| {
+                            SymphonyError::StorageError(format!(
+                                "review intent {} disappeared during reconciliation",
+                                intent.intent_id
+                            ))
+                        })?;
+                    if latest.status == crate::triage::domain::PublicationStatus::Applied {
+                        self.record_event(
+                            Some(&intent.run_id),
+                            None,
+                            "review_published",
+                            serde_json::json!({
+                                "status": "applied",
+                                "intent_id": intent.intent_id,
+                                "artifact_id": intent.artifact_id,
+                                "reconciled": true,
+                            }),
+                        )?;
+                    }
+                }
+                Err(error) => {
+                    let classified = classify_review_publication_error(&error);
+                    self.record_publication_failure(
+                        &intent,
+                        classified.clone(),
+                        service.review.max_attempts,
+                    )?;
+                    let latest = self
+                        .store
+                        .get_review_publication_intent(&intent.intent_id)?
+                        .ok_or_else(|| {
+                            SymphonyError::StorageError(format!(
+                                "review intent {} disappeared after publication failure",
+                                intent.intent_id
+                            ))
+                        })?;
+                    if matches!(
+                        latest.status,
+                        crate::triage::domain::PublicationStatus::Conflict
+                            | crate::triage::domain::PublicationStatus::Blocked
+                    ) {
+                        self.record_reconciliation_blocked(&intent, &classified)?;
+                    }
+                }
             }
+        }
+        Ok(())
+    }
+
+    async fn apply_automatic_route(
+        &self,
+        service: &ServiceConfig,
+        intent: &crate::review::domain::ReviewPublicationIntent,
+        issue_number: u64,
+    ) -> Result<bool> {
+        let field = self
+            .projects
+            .resolve_status_field(&self.config.project_owner, self.config.project_number)
+            .await?;
+        let items = self
+            .projects
+            .query_all_items(&field.project_id, self.config.max_pages)
+            .await?;
+        self.apply_automatic_route_with_data(service, intent, issue_number, &(field, items))
+            .await
+    }
+
+    async fn apply_automatic_route_with_data(
+        &self,
+        _service: &ServiceConfig,
+        intent: &crate::review::domain::ReviewPublicationIntent,
+        issue_number: u64,
+        project_data: &(StatusFieldInfo, Vec<ProjectItem>),
+    ) -> Result<bool> {
+        if intent
+            .completed_steps
+            .iter()
+            .any(|step| step == "route_applied")
+        {
+            return Ok(true);
+        }
+        let route_state = intent
+            .desired_effects
+            .get("route_state")
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .filter(|state| !state.is_empty())
+            .ok_or_else(|| {
+                SymphonyError::InvalidWorkflowConfig(
+                    "automatic review intent has no route_state".to_string(),
+                )
+            })?;
+        let field = &project_data.0;
+        let target = field
+            .options
+            .iter()
+            .find(|option| option.name.trim().eq_ignore_ascii_case(route_state))
+            .ok_or_else(|| {
+                SymphonyError::GithubProjectsV2Error(format!(
+                    "review route state '{route_state}' is not a Projects v2 option"
+                ))
+            })?;
+        let repository = intent
+            .desired_effects
+            .get("repository")
+            .and_then(serde_json::Value::as_str);
+        let item = project_data.1.iter().find(|item| {
+            item.issue_number == issue_number
+                && item.repository.as_deref().is_some_and(|repo| {
+                    repository.is_some_and(|expected| repo.eq_ignore_ascii_case(expected))
+                })
+        });
+        let Some(item) = item else {
+            return Ok(false);
+        };
+        let current = item.status.as_deref().map(str::trim).unwrap_or("");
+        if current.eq_ignore_ascii_case(route_state) {
+            self.store
+                .set_review_publication_route_state(&intent.intent_id, route_state)?;
+            self.store.record_review_publication_step(
+                &intent.intent_id,
+                "route_applied",
+                crate::triage::domain::PublicationStatus::Pending,
+                &serde_json::json!({"route_state": route_state, "already_applied": true}),
+            )?;
+            return Ok(true);
+        }
+        let trigger = intent
+            .desired_effects
+            .get("trigger_state")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("")
+            .trim();
+        if !current.eq_ignore_ascii_case(trigger) {
+            // A human moved the item. Preserve the pending intent and retry after it returns
+            // to the trigger state instead of overwriting the unexpected state.
+            return Ok(false);
+        }
+        self.projects
+            .update_item_status(
+                &field.project_id,
+                &item.item_id,
+                &field.field_id,
+                &target.id,
+            )
+            .await?;
+        let updated_items = self
+            .projects
+            .query_all_items(&field.project_id, self.config.max_pages)
+            .await?;
+        let updated = updated_items.iter().find(|updated_item| {
+            updated_item.issue_number == issue_number
+                && updated_item.repository.as_deref().is_some_and(|repo| {
+                    repository.is_some_and(|expected| repo.eq_ignore_ascii_case(expected))
+                })
+        });
+        let verified = updated
+            .and_then(|updated_item| updated_item.status.as_deref())
+            .is_some_and(|status| status.trim().eq_ignore_ascii_case(route_state));
+        if !verified {
+            return Err(SymphonyError::GithubProjectsV2Error(format!(
+                "Projects v2 route update for issue {issue_number} did not reach '{route_state}'"
+            )));
+        }
+        self.store
+            .set_review_publication_route_state(&intent.intent_id, route_state)?;
+        self.store.record_review_publication_step(
+            &intent.intent_id,
+            "route_applied",
+            crate::triage::domain::PublicationStatus::Pending,
+            &serde_json::json!({"route_state": route_state, "option_id": target.id}),
+        )?;
+        Ok(true)
+    }
+
+    fn record_publication_failure(
+        &self,
+        intent: &crate::review::domain::ReviewPublicationIntent,
+        error: FactoryError,
+        max_attempts: u32,
+    ) -> Result<crate::triage::domain::PublicationStatus> {
+        let next = intent.retry_count.saturating_add(1);
+        let status = if error.code == "review_publication_conflict" {
+            crate::triage::domain::PublicationStatus::Conflict
+        } else if !error.retryable || next >= max_attempts.max(1) {
+            crate::triage::domain::PublicationStatus::Blocked
+        } else {
+            crate::triage::domain::PublicationStatus::Pending
+        };
+        self.store
+            .set_review_publication_error(&intent.intent_id, status, error)?;
+        Ok(status)
+    }
+
+    fn record_reconciliation_blocked(
+        &self,
+        intent: &crate::review::domain::ReviewPublicationIntent,
+        error: &FactoryError,
+    ) -> Result<()> {
+        let latest = self
+            .store
+            .get_review_publication_intent(&intent.intent_id)?
+            .ok_or_else(|| {
+                SymphonyError::StorageError(format!(
+                    "review intent {} disappeared while recording blocked outcome",
+                    intent.intent_id
+                ))
+            })?;
+        if matches!(
+            latest.status,
+            crate::triage::domain::PublicationStatus::Conflict
+                | crate::triage::domain::PublicationStatus::Blocked
+        ) {
+            self.record_event(
+                Some(&intent.run_id),
+                None,
+                "review_blocked",
+                serde_json::json!({
+                    "status": latest.status.as_str(),
+                    "classification": latest.status.as_str(),
+                    "intent_id": intent.intent_id,
+                    "artifact_id": intent.artifact_id,
+                    "error": error,
+                    "reconciled": true,
+                }),
+            )?;
         }
         Ok(())
     }
@@ -584,6 +1194,82 @@ where
     }
 }
 
+fn classify_review_publication_error(error: &SymphonyError) -> FactoryError {
+    let message = error.to_string();
+    let lower = message.to_ascii_lowercase();
+    let conflict = [
+        "marker",
+        "foreign",
+        "owned by another",
+        "head does not match",
+        "drift",
+        "conflict",
+    ]
+    .iter()
+    .any(|needle| lower.contains(needle));
+    if conflict {
+        FactoryError::new(
+            "review_publication_conflict",
+            "review_publisher",
+            message,
+            false,
+            None,
+        )
+    } else {
+        FactoryError::new(
+            "review_publication_retryable",
+            "review_publisher",
+            message,
+            true,
+            None,
+        )
+    }
+}
+
+fn pull_revision_changed(
+    before: &crate::github::client::GithubPullRequest,
+    after: &crate::github::client::GithubPullRequest,
+) -> bool {
+    before.head.sha != after.head.sha || before.base.sha != after.base.sha
+}
+
+fn review_route_state(
+    artifact: &crate::review::domain::ReviewFindingsArtifactRecord,
+    service: &ServiceConfig,
+) -> Option<String> {
+    let route = if artifact
+        .manifest
+        .findings
+        .iter()
+        .any(|finding| finding.severity <= service.review.blocking_severity)
+    {
+        service.review.changes_requested_route.as_ref()
+    } else {
+        service.review.completion_route.as_ref()
+    };
+    route.map(|route| route.state.trim().to_string())
+}
+
+fn review_publication_effects(
+    issue_number: u64,
+    candidate: &A4EligibleReviewRun,
+    pull: &crate::github::client::GithubPullRequest,
+    service: &ServiceConfig,
+    route_state: Option<String>,
+    approved_spec_version: u32,
+) -> serde_json::Value {
+    serde_json::json!({
+        "issue_number": issue_number,
+        "repository": candidate.repository,
+        "pr_number": candidate.pr_number,
+        "reviewed_head_sha": pull.head.sha,
+        "base_sha": pull.base.sha,
+        "trigger_state": service.review.trigger_state,
+        "route_state": route_state,
+        "approved_spec_version": approved_spec_version,
+    })
+}
+
 fn resolve_review_path(value: &str, field: &str) -> Result<PathBuf> {
     let trimmed = value.trim();
     if trimmed.is_empty() {
@@ -604,15 +1290,57 @@ enum ProcessOutcome {
     Blocked,
 }
 
+enum ReviewPublicationResult {
+    Published,
+    Waiting,
+}
+
 #[cfg(test)]
 mod tests {
-    use super::resolve_review_path;
+    use super::{pull_revision_changed, resolve_review_path};
+    use crate::github::client::{GithubPullRequest, GithubPullRequestRef};
+
+    fn pull(head: &str, base: &str) -> GithubPullRequest {
+        GithubPullRequest {
+            number: 1,
+            html_url: String::new(),
+            draft: false,
+            state: "open".to_string(),
+            title: String::new(),
+            head: GithubPullRequestRef {
+                ref_name: "head".to_string(),
+                sha: head.to_string(),
+            },
+            base: GithubPullRequestRef {
+                ref_name: "base".to_string(),
+                sha: base.to_string(),
+            },
+            user: None,
+            body: None,
+        }
+    }
 
     #[test]
     fn review_relative_paths_are_resolved_before_worker_setup() {
         assert!(resolve_review_path(".", "workspace.repo")
             .unwrap()
             .is_absolute());
+    }
+
+    #[test]
+    fn file_retrieval_revision_guard_catches_head_or_base_changes() {
+        let initial = pull("head-1", "base-1");
+        assert!(!pull_revision_changed(&initial, &pull("head-1", "base-1")));
+        assert!(pull_revision_changed(&initial, &pull("head-2", "base-1")));
+        assert!(pull_revision_changed(&initial, &pull("head-1", "base-2")));
+    }
+
+    #[test]
+    fn live_head_after_candidate_reopen_is_a_valid_revision_baseline() {
+        let candidate_head = "head-1";
+        let live = pull("head-2", "base-1");
+        assert_ne!(candidate_head, live.head.sha);
+        assert!(!pull_revision_changed(&live, &pull("head-2", "base-1")));
     }
 }
 

--- a/apps/symphony/src/review/coordinator.rs
+++ b/apps/symphony/src/review/coordinator.rs
@@ -16,7 +16,9 @@ use crate::path_safety::canonicalize;
 use crate::review::domain::ReviewConfig;
 use crate::review::findings::reviewed_files;
 use crate::review::manifest::parse_and_validate_review_manifest;
-use crate::review::publisher::ReviewPublisher;
+use crate::review::publisher::{
+    ReviewPublicationLeaseGuard, ReviewPublisher, REVIEW_PUBLICATION_LEASE_SECONDS,
+};
 use crate::review::worker::{
     command_for_review, harness_for_service, model_for_review, ReviewWorker, ReviewWorkerRequest,
 };
@@ -618,6 +620,7 @@ where
                     &intent,
                     classified.clone(),
                     service.review.max_attempts,
+                    &self.config.owner_instance,
                 )?;
                 if matches!(
                     status,
@@ -690,6 +693,7 @@ where
                     &intent,
                     classified.clone(),
                     service.review.max_attempts,
+                    &self.config.owner_instance,
                 )?;
                 if matches!(
                     status,
@@ -734,8 +738,9 @@ where
             if !routed.completed_steps.iter().any(|step| step == "route_applied") {
                 return Ok(ProcessOutcome::Waiting);
             }
-            self.store.record_review_publication_step(
+            if !self.store.record_review_publication_step_owned(
                 &routed.intent_id,
+                &self.config.owner_instance,
                 "comment_final",
                 crate::triage::domain::PublicationStatus::Pending,
                 &serde_json::json!({
@@ -743,7 +748,9 @@ where
                     "review_url": routed.review_url,
                     "route_state": routed.route_state,
                 }),
-            )?;
+            )? {
+                return Ok(ProcessOutcome::Waiting);
+            }
         }
         let final_intent = self
             .store
@@ -894,6 +901,7 @@ where
                     &intent,
                     error.clone(),
                     service.review.max_attempts,
+                    &self.config.owner_instance,
                 )?;
                 self.record_reconciliation_blocked(&intent, &error)?;
                 continue;
@@ -914,6 +922,7 @@ where
                     &intent,
                     error.clone(),
                     service.review.max_attempts,
+                    &self.config.owner_instance,
                 )?;
                 self.record_reconciliation_blocked(&intent, &error)?;
                 continue;
@@ -932,6 +941,7 @@ where
                         &intent,
                         error.clone(),
                         service.review.max_attempts,
+                        &self.config.owner_instance,
                     )?;
                     self.record_reconciliation_blocked(&intent, &error)?;
                     continue;
@@ -1064,8 +1074,9 @@ where
                                 {
                                     return Ok(ReviewPublicationResult::Published);
                                 }
-                                self.store.record_review_publication_step(
+                                if !self.store.record_review_publication_step_owned(
                                     &intent.intent_id,
+                                    &self.config.owner_instance,
                                     "comment_final",
                                     crate::triage::domain::PublicationStatus::Pending,
                                     &serde_json::json!({
@@ -1073,7 +1084,9 @@ where
                                         "review_url": latest.review_url,
                                         "route_state": latest.route_state,
                                     }),
-                                )?;
+                                )? {
+                                    return Ok(ReviewPublicationResult::Waiting);
+                                }
                                 Ok(ReviewPublicationResult::Published)
                             })
                     }
@@ -1122,6 +1135,7 @@ where
                         &intent,
                         classified.clone(),
                         service.review.max_attempts,
+                        &self.config.owner_instance,
                     )?;
                     let latest = self
                         .store
@@ -1151,16 +1165,42 @@ where
         intent: &crate::review::domain::ReviewPublicationIntent,
         issue_number: u64,
     ) -> Result<bool> {
-        let field = self
-            .projects
-            .resolve_status_field(&self.config.project_owner, self.config.project_number)
-            .await?;
-        let items = self
-            .projects
-            .query_all_items(&field.project_id, self.config.max_pages)
-            .await?;
-        self.apply_automatic_route_with_data(service, intent, issue_number, &(field, items))
-            .await
+        if !self.store.claim_review_publication(
+            &intent.intent_id,
+            &self.config.owner_instance,
+            REVIEW_PUBLICATION_LEASE_SECONDS,
+        )? {
+            return Ok(false);
+        }
+        let _lease = ReviewPublicationLeaseGuard::start(
+            &self.store,
+            &intent.intent_id,
+            &self.config.owner_instance,
+        );
+        let result = async {
+            let field = self
+                .projects
+                .resolve_status_field(&self.config.project_owner, self.config.project_number)
+                .await?;
+            let items = self
+                .projects
+                .query_all_items(&field.project_id, self.config.max_pages)
+                .await?;
+            self.apply_automatic_route_with_data(service, intent, issue_number, &(field, items))
+                .await
+        }
+        .await;
+        match result {
+            Ok(true) => Ok(true),
+            Ok(false) => {
+                self.store.clear_review_publication_lease(
+                    &intent.intent_id,
+                    &self.config.owner_instance,
+                )?;
+                Ok(false)
+            }
+            Err(error) => Err(error),
+        }
     }
 
     async fn apply_automatic_route_with_data(
@@ -1213,14 +1253,22 @@ where
         };
         let current = item.status.as_deref().map(str::trim).unwrap_or("");
         if current.eq_ignore_ascii_case(route_state) {
-            self.store
-                .set_review_publication_route_state(&intent.intent_id, route_state)?;
-            self.store.record_review_publication_step(
+            if !self.store.set_review_publication_route_state_owned(
                 &intent.intent_id,
+                &self.config.owner_instance,
+                route_state,
+            )? {
+                return Ok(false);
+            }
+            if !self.store.record_review_publication_step_owned(
+                &intent.intent_id,
+                &self.config.owner_instance,
                 "route_applied",
                 crate::triage::domain::PublicationStatus::Pending,
                 &serde_json::json!({"route_state": route_state, "already_applied": true}),
-            )?;
+            )? {
+                return Ok(false);
+            }
             return Ok(true);
         }
         let trigger = intent
@@ -1260,14 +1308,22 @@ where
                 "Projects v2 route update for issue {issue_number} did not reach '{route_state}'"
             )));
         }
-        self.store
-            .set_review_publication_route_state(&intent.intent_id, route_state)?;
-        self.store.record_review_publication_step(
+        if !self.store.set_review_publication_route_state_owned(
             &intent.intent_id,
+            &self.config.owner_instance,
+            route_state,
+        )? {
+            return Ok(false);
+        }
+        if !self.store.record_review_publication_step_owned(
+            &intent.intent_id,
+            &self.config.owner_instance,
             "route_applied",
             crate::triage::domain::PublicationStatus::Pending,
             &serde_json::json!({"route_state": route_state, "option_id": target.id}),
-        )?;
+        )? {
+            return Ok(false);
+        }
         Ok(true)
     }
 
@@ -1276,6 +1332,7 @@ where
         intent: &crate::review::domain::ReviewPublicationIntent,
         error: FactoryError,
         max_attempts: u32,
+        owner: &str,
     ) -> Result<crate::triage::domain::PublicationStatus> {
         let next = intent.retry_count.saturating_add(1);
         let status = if error.code == "review_publication_conflict" {
@@ -1285,9 +1342,28 @@ where
         } else {
             crate::triage::domain::PublicationStatus::Pending
         };
-        self.store
-            .set_review_publication_error(&intent.intent_id, status, error)?;
-        Ok(status)
+        if self.store.claim_review_publication(
+            &intent.intent_id,
+            owner,
+            REVIEW_PUBLICATION_LEASE_SECONDS,
+        )? && self.store.set_review_publication_error_owned(
+            &intent.intent_id,
+            owner,
+            status,
+            error,
+        )? {
+            return Ok(status);
+        }
+        let latest = self
+            .store
+            .get_review_publication_intent(&intent.intent_id)?
+            .ok_or_else(|| {
+                SymphonyError::StorageError(format!(
+                    "review intent {} disappeared while recording publication failure",
+                    intent.intent_id
+                ))
+            })?;
+        Ok(latest.status)
     }
 
     fn record_reconciliation_blocked(
@@ -1334,7 +1410,18 @@ where
         error: FactoryError,
     ) -> Result<()> {
         let store = self.store.clone();
-        if !store.supersede_review_publication(intent_id, error.clone())? {
+        if !store.claim_review_publication(
+            intent_id,
+            &self.config.owner_instance,
+            REVIEW_PUBLICATION_LEASE_SECONDS,
+        )? {
+            return Ok(());
+        }
+        if !store.supersede_review_publication_owned(
+            intent_id,
+            &self.config.owner_instance,
+            error.clone(),
+        )? {
             return Ok(());
         }
         self.record_event(

--- a/apps/symphony/src/review/coordinator.rs
+++ b/apps/symphony/src/review/coordinator.rs
@@ -185,12 +185,6 @@ where
         if !pull.state.eq_ignore_ascii_case("open") {
             return Ok(ProcessOutcome::Waiting);
         }
-        let failed_attempts = self
-            .store
-            .count_review_attempt_failures_for_head(&candidate.run_id, &pull.head.sha)?;
-        if failed_attempts >= service.review.max_attempts.max(1) {
-            return Ok(ProcessOutcome::Waiting);
-        }
         if self
             .store
             .review_artifact_exists_for_head(&candidate.run_id, &pull.head.sha)?
@@ -245,6 +239,12 @@ where
             }
             // An artifact with an intent is already complete or pending durable
             // publication. Reconciliation owns pending intents.
+            return Ok(ProcessOutcome::Waiting);
+        }
+        let failed_attempts = self
+            .store
+            .count_review_attempt_failures_for_head(&candidate.run_id, &pull.head.sha)?;
+        if failed_attempts >= service.review.max_attempts.max(1) {
             return Ok(ProcessOutcome::Waiting);
         }
         if pull.head.sha != candidate.head_sha {
@@ -567,38 +567,19 @@ where
             }),
         )?;
         let kind = service.review.mode.as_str();
-        let route_state = if artifact
-            .manifest
-            .findings
-            .iter()
-            .any(|finding| finding.severity <= service.review.blocking_severity)
-        {
-            service
-                .review
-                .changes_requested_route
-                .as_ref()
-                .map(|route| route.state.trim().to_string())
-        } else {
-            service
-                .review
-                .completion_route
-                .as_ref()
-                .map(|route| route.state.trim().to_string())
-        };
+        let route_state = review_route_state(&artifact, service);
         let intent = self.store.create_review_publication_intent(
             &candidate.run_id,
             &artifact.artifact_id,
             kind,
-            &serde_json::json!({
-                "issue_number": issue_number,
-                "repository": candidate.repository,
-                "pr_number": candidate.pr_number,
-                "reviewed_head_sha": pull.head.sha,
-                "base_sha": pull.base.sha,
-                "trigger_state": service.review.trigger_state,
-                "route_state": route_state,
-                "approved_spec_version": spec.version,
-            }),
+            &review_publication_effects(
+                issue_number,
+                candidate,
+                &pull,
+                service,
+                route_state,
+                spec.version,
+            ),
         )?;
         let publisher = ReviewPublisher::with_owner(
             self.comments.clone(),
@@ -725,7 +706,19 @@ where
                         intent.intent_id
                     ))
                 })?;
-            self.apply_automatic_route(service, &pending, issue_number).await?;
+            if let Err(error) = self
+                .apply_automatic_route(service, &pending, issue_number)
+                .await
+            {
+                let classified = classify_review_publication_error(&error);
+                self.record_publication_failure(
+                    &pending,
+                    classified,
+                    service.review.max_attempts,
+                    &self.config.owner_instance,
+                )?;
+                return Ok(ProcessOutcome::Waiting);
+            }
             let routed = self
                 .store
                 .get_review_publication_intent(&intent.intent_id)?
@@ -927,6 +920,55 @@ where
                 self.record_reconciliation_blocked(&intent, &error)?;
                 continue;
             };
+
+            if intent
+                .desired_effects
+                .get("repository")
+                .and_then(serde_json::Value::as_str)
+                .is_none_or(|repository| repository.trim().is_empty())
+            {
+                let error = FactoryError::new(
+                    "review_publication_missing_repository",
+                    "review_publisher",
+                    format!("review intent {} is missing repository", intent.intent_id),
+                    false,
+                    None,
+                );
+                self.record_publication_failure(
+                    &intent,
+                    error.clone(),
+                    service.review.max_attempts,
+                    &self.config.owner_instance,
+                )?;
+                self.record_reconciliation_blocked(&intent, &error)?;
+                continue;
+            }
+            if intent.kind == "automatic"
+                && intent
+                    .desired_effects
+                    .get("reviewed_head_sha")
+                    .and_then(serde_json::Value::as_str)
+                    .is_none_or(|head| head.trim().is_empty())
+            {
+                let error = FactoryError::new(
+                    "review_publication_missing_reviewed_head_sha",
+                    "review_publisher",
+                    format!(
+                        "review intent {} is missing reviewed_head_sha",
+                        intent.intent_id
+                    ),
+                    false,
+                    None,
+                );
+                self.record_publication_failure(
+                    &intent,
+                    error.clone(),
+                    service.review.max_attempts,
+                    &self.config.owner_instance,
+                )?;
+                self.record_reconciliation_blocked(&intent, &error)?;
+                continue;
+            }
 
             let pr_number = if intent.kind == "automatic" {
                 let Some(pr_number) = review_publication_pr_number(&intent.desired_effects) else {
@@ -1464,26 +1506,12 @@ fn review_attempt_retry_exhausted(failed_attempts: u32, max_attempts: u32) -> bo
 }
 
 fn is_review_cycle_reopened_error(error: &SymphonyError) -> bool {
-    error
-        .to_string()
-        .to_ascii_lowercase()
-        .contains("review cycle reopened")
+    matches!(error, SymphonyError::ReviewCycleReopened(_))
 }
 
 fn classify_review_publication_error(error: &SymphonyError) -> FactoryError {
     let message = error.to_string();
-    let lower = message.to_ascii_lowercase();
-    let conflict = [
-        "marker",
-        "foreign",
-        "owned by another",
-        "head does not match",
-        "drift",
-        "conflict",
-    ]
-    .iter()
-    .any(|needle| lower.contains(needle));
-    if conflict {
+    if matches!(error, SymphonyError::ReviewPublicationConflict(_)) {
         FactoryError::new(
             "review_publication_conflict",
             "review_publisher",

--- a/apps/symphony/src/review/coordinator.rs
+++ b/apps/symphony/src/review/coordinator.rs
@@ -598,7 +598,10 @@ where
                 "approved_spec_version": spec.version,
             }),
         )?;
-        let publisher = ReviewPublisher::new(self.comments.clone());
+        let publisher = ReviewPublisher::with_owner(
+            self.comments.clone(),
+            self.config.owner_instance.clone(),
+        );
         if service.review.mode == crate::review::domain::ReviewMode::Preview {
             if let Err(error) = publisher
                 .publish_preview(
@@ -638,7 +641,7 @@ where
                 return Err(error);
             }
         } else {
-            if let Err(error) = publisher
+            let formal_result = publisher
                 .publish_formal(
                     &self.store,
                     &self.github,
@@ -647,8 +650,11 @@ where
                     candidate.pr_number,
                     self.config.max_pages,
                 )
-                .await
-            {
+                .await;
+            if formal_result.as_ref().is_ok_and(|published| !published) {
+                return Ok(ProcessOutcome::Waiting);
+            }
+            if let Err(error) = formal_result {
                 let classified = classify_review_publication_error(&error);
                 let status = self.record_publication_failure(
                     &intent,
@@ -733,31 +739,68 @@ where
         .await;
 
         if let Err(error) = &result {
-            let cycle_reopened = error
-                .to_string()
-                .contains("review cycle reopened while worker was running");
-            let factory_error = FactoryError::new(
-                if cycle_reopened {
-                    "review_cycle_reopened"
-                } else {
-                    "review_attempt_failed"
-                },
-                "review_coordinator",
-                error.to_string(),
-                true,
-                None,
-            );
+            let error_message = error.to_string();
+            let cycle_reopened =
+                error_message.contains("review cycle reopened while worker was running");
+            let retry_exhausted = match self
+                .store
+                .count_review_attempt_failures_for_head(&candidate.run_id, &pull.head.sha)
+            {
+                Ok(failed_attempts) => {
+                    review_attempt_retry_exhausted(failed_attempts, service.review.max_attempts)
+                }
+                Err(count_error) => {
+                    tracing::error!(
+                        event = "review_attempt_retry_count_failed",
+                        run_id = %candidate.run_id,
+                        reviewed_head_sha = %pull.head.sha,
+                        error = %count_error,
+                        "could not determine review attempt retry ceiling"
+                    );
+                    false
+                }
+            };
+            let (status, factory_error) = if retry_exhausted {
+                (
+                    "blocked",
+                    FactoryError::new(
+                        "review_attempt_retry_exhausted",
+                        "review_coordinator",
+                        format!(
+                            "review attempt retry budget exhausted for head {}: {error_message}",
+                            pull.head.sha
+                        ),
+                        false,
+                        None,
+                    ),
+                )
+            } else {
+                (
+                    "failed",
+                    FactoryError::new(
+                        if cycle_reopened {
+                            "review_cycle_reopened"
+                        } else {
+                            "review_attempt_failed"
+                        },
+                        "review_coordinator",
+                        error_message.clone(),
+                        true,
+                        None,
+                    ),
+                )
+            };
             if let Err(cleanup_error) =
                 self.store
                     .update_review_attempt(UpdateReviewAttemptRequest {
                         attempt_id: &attempt_id,
-                        status: "failed",
+                        status,
                         reprompt_count: service.review.max_reprompts,
                         worker_turn: None,
                         manifest: None,
                         validation_result: Some(&serde_json::json!({
                             "accepted": false,
-                            "error": error.to_string()
+                            "error": error_message
                         })),
                         error: Some(&factory_error),
                     })
@@ -769,7 +812,9 @@ where
                     "could not persist failed review attempt"
                 );
             }
-            if let Err(cleanup_error) = self.store.fail_attempt(&stage.stage_run_id, factory_error)
+            if let Err(cleanup_error) = self
+                .store
+                .fail_attempt(&stage.stage_run_id, factory_error.clone())
             {
                 tracing::error!(
                     event = "review_stage_cleanup_failed",
@@ -778,12 +823,32 @@ where
                     "could not terminate failed review stage"
                 );
             }
+            if retry_exhausted {
+                if let Err(event_error) = self.record_event(
+                    Some(&candidate.run_id),
+                    Some(&stage.stage_run_id),
+                    "review_blocked",
+                    serde_json::json!({
+                        "status": "blocked",
+                        "error": factory_error,
+                        "reviewed_head_sha": pull.head.sha,
+                    }),
+                ) {
+                    tracing::error!(
+                        event = "review_attempt_blocked_event_failed",
+                        attempt_id = %attempt_id,
+                        error = %event_error,
+                        "could not persist review blocked event"
+                    );
+                }
+            }
         }
         result
     }
 
     async fn reconcile_pending_publications(&self, service: &ServiceConfig) -> Result<()> {
-        let publisher = ReviewPublisher::new(self.comments.clone());
+        let publisher =
+            ReviewPublisher::with_owner(self.comments.clone(), self.config.owner_instance.clone());
         let pending = self.store.list_pending_review_publications()?;
         let has_automatic = pending.iter().any(|intent| intent.kind == "automatic");
         let project_data = if has_automatic {
@@ -876,7 +941,13 @@ where
                             self.config.max_pages,
                         )
                         .await
-                        .map(|()| ReviewPublicationResult::Published)
+                        .map(|published| {
+                            if published {
+                                ReviewPublicationResult::Published
+                            } else {
+                                ReviewPublicationResult::Waiting
+                            }
+                        })
                 }
                 .await;
                 match publisher_result {
@@ -1194,6 +1265,10 @@ where
     }
 }
 
+fn review_attempt_retry_exhausted(failed_attempts: u32, max_attempts: u32) -> bool {
+    failed_attempts.saturating_add(1) >= max_attempts.max(1)
+}
+
 fn classify_review_publication_error(error: &SymphonyError) -> FactoryError {
     let message = error.to_string();
     let lower = message.to_ascii_lowercase();
@@ -1297,8 +1372,17 @@ enum ReviewPublicationResult {
 
 #[cfg(test)]
 mod tests {
-    use super::{pull_revision_changed, resolve_review_path};
+    use super::{pull_revision_changed, resolve_review_path, review_attempt_retry_exhausted};
     use crate::github::client::{GithubPullRequest, GithubPullRequestRef};
+
+    #[test]
+    fn review_attempt_retry_ceiling_resets_for_a_new_head() {
+        // With max_attempts=2, the first failure remains retryable and the
+        // second failure blocks the same head. A new head starts at zero.
+        assert!(!review_attempt_retry_exhausted(0, 2));
+        assert!(review_attempt_retry_exhausted(1, 2));
+        assert!(!review_attempt_retry_exhausted(0, 2));
+    }
 
     fn pull(head: &str, base: &str) -> GithubPullRequest {
         GithubPullRequest {

--- a/apps/symphony/src/review/coordinator.rs
+++ b/apps/symphony/src/review/coordinator.rs
@@ -864,20 +864,6 @@ where
         let publisher =
             ReviewPublisher::with_owner(self.comments.clone(), self.config.owner_instance.clone());
         let pending = self.store.list_pending_review_publications()?;
-        let has_automatic = pending.iter().any(|intent| intent.kind == "automatic");
-        let project_data = if has_automatic {
-            let field = self
-                .projects
-                .resolve_status_field(&self.config.project_owner, self.config.project_number)
-                .await?;
-            let items = self
-                .projects
-                .query_all_items(&field.project_id, self.config.max_pages)
-                .await?;
-            Some((field, items))
-        } else {
-            None
-        };
 
         for intent in pending {
             let Some(artifact) = self.store.get_review_artifact(&intent.artifact_id)? else {
@@ -917,13 +903,31 @@ where
                 continue;
             };
 
+            let pr_number = if intent.kind == "automatic" {
+                let Some(pr_number) = review_publication_pr_number(&intent.desired_effects) else {
+                    let error = FactoryError::new(
+                        "review_publication_missing_pr_number",
+                        "review_publisher",
+                        format!("review intent {} is missing pr_number", intent.intent_id),
+                        false,
+                        None,
+                    );
+                    self.record_publication_failure(
+                        &intent,
+                        error.clone(),
+                        service.review.max_attempts,
+                    )?;
+                    self.record_reconciliation_blocked(&intent, &error)?;
+                    continue;
+                };
+                Some(pr_number)
+            } else {
+                None
+            };
+
             let result = if intent.kind == "automatic" {
                 let publisher_result = async {
-                    let pr_number = intent
-                        .desired_effects
-                        .get("pr_number")
-                        .and_then(serde_json::Value::as_u64)
-                        .unwrap_or(issue_number);
+                    let pr_number = pr_number.expect("automatic review intent has PR number");
                     let expected_head = intent
                         .desired_effects
                         .get("reviewed_head_sha")
@@ -980,46 +984,51 @@ where
                         Ok(ReviewPublicationResult::Waiting)
                     }
                     Err(error) => Err(error),
-                    Ok(ReviewPublicationResult::Published) => self
-                        .apply_automatic_route_with_data(
-                            service,
-                            &intent,
-                            issue_number,
-                            project_data.as_ref().expect("automatic project data"),
-                        )
-                        .await
-                        .and_then(|applied| {
-                            if !applied {
-                                return Ok(ReviewPublicationResult::Published);
-                            }
-                            let latest = self
-                                .store
-                                .get_review_publication_intent(&intent.intent_id)?
-                                .ok_or_else(|| {
-                                    SymphonyError::StorageError(format!(
-                                        "review intent {} disappeared during reconciliation",
-                                        intent.intent_id
-                                    ))
-                                })?;
-                            if latest
-                                .completed_steps
-                                .iter()
-                                .any(|step| step == "comment_final")
-                            {
-                                return Ok(ReviewPublicationResult::Published);
-                            }
-                            self.store.record_review_publication_step(
-                                &intent.intent_id,
-                                "comment_final",
-                                crate::triage::domain::PublicationStatus::Pending,
-                                &serde_json::json!({
-                                    "review_id": latest.review_id,
-                                    "review_url": latest.review_url,
-                                    "route_state": latest.route_state,
-                                }),
-                            )?;
-                            Ok(ReviewPublicationResult::Published)
-                        }),
+                    Ok(ReviewPublicationResult::Published) => {
+                        let latest = self
+                            .store
+                            .get_review_publication_intent(&intent.intent_id)?
+                            .ok_or_else(|| {
+                                SymphonyError::StorageError(format!(
+                                    "review intent {} disappeared during reconciliation",
+                                    intent.intent_id
+                                ))
+                            })?;
+                        self.apply_automatic_route(service, &latest, issue_number)
+                            .await
+                            .and_then(|applied| {
+                                if !applied {
+                                    return Ok(ReviewPublicationResult::Published);
+                                }
+                                let latest = self
+                                    .store
+                                    .get_review_publication_intent(&intent.intent_id)?
+                                    .ok_or_else(|| {
+                                        SymphonyError::StorageError(format!(
+                                            "review intent {} disappeared during reconciliation",
+                                            intent.intent_id
+                                        ))
+                                    })?;
+                                if latest
+                                    .completed_steps
+                                    .iter()
+                                    .any(|step| step == "comment_final")
+                                {
+                                    return Ok(ReviewPublicationResult::Published);
+                                }
+                                self.store.record_review_publication_step(
+                                    &intent.intent_id,
+                                    "comment_final",
+                                    crate::triage::domain::PublicationStatus::Pending,
+                                    &serde_json::json!({
+                                        "review_id": latest.review_id,
+                                        "review_url": latest.review_url,
+                                        "route_state": latest.route_state,
+                                    }),
+                                )?;
+                                Ok(ReviewPublicationResult::Published)
+                            })
+                    }
                 }
             } else {
                 publisher
@@ -1342,6 +1351,10 @@ fn pull_revision_changed(
     before.head.sha != after.head.sha || before.base.sha != after.base.sha
 }
 
+fn review_publication_pr_number(effects: &serde_json::Value) -> Option<u64> {
+    effects.get("pr_number").and_then(serde_json::Value::as_u64)
+}
+
 fn review_route_state(
     artifact: &crate::review::domain::ReviewFindingsArtifactRecord,
     service: &ServiceConfig,
@@ -1406,7 +1419,10 @@ enum ReviewPublicationResult {
 
 #[cfg(test)]
 mod tests {
-    use super::{pull_revision_changed, resolve_review_path, review_attempt_retry_exhausted};
+    use super::{
+        pull_revision_changed, resolve_review_path, review_attempt_retry_exhausted,
+        review_publication_pr_number,
+    };
     use crate::github::client::{GithubPullRequest, GithubPullRequestRef};
 
     #[test]
@@ -1416,6 +1432,18 @@ mod tests {
         assert!(!review_attempt_retry_exhausted(0, 2));
         assert!(review_attempt_retry_exhausted(1, 2));
         assert!(!review_attempt_retry_exhausted(0, 2));
+    }
+
+    #[test]
+    fn review_publication_requires_a_durable_pr_number() {
+        assert_eq!(
+            review_publication_pr_number(&serde_json::json!({"issue_number": 42})),
+            None
+        );
+        assert_eq!(
+            review_publication_pr_number(&serde_json::json!({"pr_number": 46})),
+            Some(46)
+        );
     }
 
     fn pull(head: &str, base: &str) -> GithubPullRequest {

--- a/apps/symphony/src/review/domain.rs
+++ b/apps/symphony/src/review/domain.rs
@@ -55,6 +55,8 @@ pub struct ReviewConfig {
     pub completion_route: Option<ReviewRoute>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub changes_requested_route: Option<ReviewRoute>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub permission_probe_pull_request: Option<u64>,
 }
 
 impl Default for ReviewConfig {
@@ -73,6 +75,7 @@ impl Default for ReviewConfig {
             trigger_state: "Agent Review".to_string(),
             completion_route: None,
             changes_requested_route: None,
+            permission_probe_pull_request: None,
         }
     }
 }

--- a/apps/symphony/src/review/domain.rs
+++ b/apps/symphony/src/review/domain.rs
@@ -3,6 +3,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+use crate::review::manifest::ReviewSeverity;
 use crate::triage::domain::{FactoryError, StageUsage};
 
 pub const REVIEW_STAGE_NAME: &str = "review";
@@ -47,6 +48,8 @@ pub struct ReviewConfig {
     pub max_attempts: u32,
     pub max_reprompts: u32,
     pub max_findings: usize,
+    #[serde(default)]
+    pub blocking_severity: ReviewSeverity,
     pub trigger_state: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub completion_route: Option<ReviewRoute>,
@@ -66,6 +69,7 @@ impl Default for ReviewConfig {
             max_attempts: 3,
             max_reprompts: REVIEW_MAX_REPROMPTS_DEFAULT,
             max_findings: REVIEW_MAX_FINDINGS_DEFAULT,
+            blocking_severity: ReviewSeverity::Blocking,
             trigger_state: "Agent Review".to_string(),
             completion_route: None,
             changes_requested_route: None,
@@ -175,6 +179,7 @@ pub struct ReviewMetricsAggregate {
     pub failed_attempts: u64,
     pub blocked_publications: u64,
     pub preview_publications: u64,
+    pub automatic_publications: u64,
     pub findings: u64,
     pub no_findings: u64,
     pub base: crate::triage::domain::TriageMetricsAggregate,

--- a/apps/symphony/src/review/domain.rs
+++ b/apps/symphony/src/review/domain.rs
@@ -132,6 +132,12 @@ pub struct ReviewPublicationIntent {
     pub comment_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub publisher_login: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub review_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub review_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub route_state: Option<String>,
     pub desired_effects: serde_json::Value,
     pub observed_baseline: serde_json::Value,
     pub expected_projection: serde_json::Value,

--- a/apps/symphony/src/review/findings.rs
+++ b/apps/symphony/src/review/findings.rs
@@ -4,9 +4,28 @@ use std::collections::BTreeMap;
 
 use crate::github::client::GithubPullRequestFile;
 use crate::review::domain::{
-    ReviewFindingsArtifactRecord, REVIEW_COMMENT_MARKER_PREFIX, REVIEW_COMMENT_MARKER_SUFFIX,
+    ReviewFindingRecord, ReviewFindingsArtifactRecord, REVIEW_COMMENT_MARKER_PREFIX,
+    REVIEW_COMMENT_MARKER_SUFFIX,
 };
-use crate::review::manifest::{ReviewSeverity, ReviewedFile, ReviewedLineRange};
+use crate::review::manifest::{ReviewFinding, ReviewSeverity, ReviewedFile, ReviewedLineRange};
+
+/// Stable finding identity used for lifecycle carry-forward across review cycles.
+/// Location lines are deliberately excluded so edits that move a finding retain identity.
+pub fn finding_identity_key(finding: &ReviewFinding) -> String {
+    let category = match finding.category {
+        crate::review::manifest::ReviewFindingCategory::Correctness => "correctness",
+        crate::review::manifest::ReviewFindingCategory::Security => "security",
+        crate::review::manifest::ReviewFindingCategory::SpecConformance => "spec-conformance",
+        crate::review::manifest::ReviewFindingCategory::TestCoverage => "test-coverage",
+        crate::review::manifest::ReviewFindingCategory::Maintainability => "maintainability",
+    };
+    format!(
+        "{}:{}:{}",
+        finding.path.trim(),
+        category,
+        finding.claim.trim()
+    )
+}
 
 /// Convert GitHub file patches into the right-side line ranges accepted by
 /// review comments. A hunk's full new-file span includes both changed and
@@ -122,24 +141,75 @@ pub fn render_formal_review_body(
     intent_id: &str,
     run_id: &str,
     artifact: &ReviewFindingsArtifactRecord,
+    approved_spec_version: Option<u32>,
+) -> String {
+    render_formal_review_body_with_records(
+        issue_number,
+        intent_id,
+        run_id,
+        artifact,
+        approved_spec_version,
+        &[],
+    )
+}
+
+pub fn render_formal_review_body_with_records(
+    issue_number: u64,
+    intent_id: &str,
+    run_id: &str,
+    artifact: &ReviewFindingsArtifactRecord,
+    approved_spec_version: Option<u32>,
+    finding_records: &[ReviewFindingRecord],
 ) -> String {
     let marker = format!("{REVIEW_COMMENT_MARKER_PREFIX}{intent_id}{REVIEW_COMMENT_MARKER_SUFFIX}");
+    let persisting = finding_records
+        .iter()
+        .filter(|record| record.lifecycle_state == "persisting")
+        .collect::<Vec<_>>();
     let findings = if artifact.manifest.no_findings {
         "**No findings.** The worker explicitly affirmed `no_findings`.".to_string()
-    } else {
+    } else if persisting.is_empty() {
         format!(
             "Findings: {}. Every finding is attached as an inline comment.",
             artifact.finding_count
         )
+    } else {
+        format!(
+            "Findings: {}. New findings are attached as inline comments. {} persisting finding(s) remain summarized below.",
+            artifact.finding_count,
+            persisting.len()
+        )
+    };
+    let persisting_summary = if persisting.is_empty() {
+        String::new()
+    } else {
+        let mut summary = String::from("\n\n### Persisting findings\n\n");
+        summary.push_str("| ID | Location | Claim |\n| --- | --- | --- |\n");
+        for record in persisting {
+            let end = record
+                .end_line
+                .map(|line| format!("-{line}"))
+                .unwrap_or_default();
+            summary.push_str(&format!(
+                "| `{}` | `{}`:{}{} | {} |\n",
+                record.finding_id,
+                record.path,
+                record.line,
+                end,
+                record.claim.replace(['\r', '\n'], " ").replace('|', "\\|")
+            ));
+        }
+        summary
     };
     format!(
-        "{marker}\n## Symphony A4 formal review\n\nIssue `#{issue_number}`.\n\nSpec artifact `{}` (version `{}`).\n\nFactory run `{run_id}` reviewed head `{}` against base `{}`.\n\n{}\n\n{}\n",
+        "{marker}\n## Symphony A4 formal review\n\nIssue `#{issue_number}`.\n\nSpec artifact `{}` (version `{}`).\n\nFactory run `{run_id}` reviewed head `{}` against base `{}`.\n\n{}\n\n{}{}\n",
         artifact.spec_artifact_id,
-        artifact.schema_version,
+        approved_spec_version.unwrap_or(artifact.schema_version),
         artifact.reviewed_head_sha,
         artifact.base_sha,
         artifact.manifest.spec_conformance_summary.trim(),
         findings,
+        persisting_summary,
     )
 }
 

--- a/apps/symphony/src/review/findings.rs
+++ b/apps/symphony/src/review/findings.rs
@@ -204,7 +204,7 @@ pub fn render_formal_review_body_with_records(
     format!(
         "{marker}\n## Symphony A4 formal review\n\nIssue `#{issue_number}`.\n\nSpec artifact `{}` (version `{}`).\n\nFactory run `{run_id}` reviewed head `{}` against base `{}`.\n\n{}\n\n{}{}\n",
         artifact.spec_artifact_id,
-        approved_spec_version.unwrap_or(artifact.schema_version),
+        approved_spec_version.map_or_else(|| "unknown".to_string(), |version| version.to_string()),
         artifact.reviewed_head_sha,
         artifact.base_sha,
         artifact.manifest.spec_conformance_summary.trim(),

--- a/apps/symphony/src/review/findings.rs
+++ b/apps/symphony/src/review/findings.rs
@@ -115,6 +115,34 @@ pub fn render_preview_comment(
     body
 }
 
+/// Render the marker-owned body used by an atomic GitHub pull-request review.
+/// Inline finding details are carried by the review comments themselves.
+pub fn render_formal_review_body(
+    issue_number: u64,
+    intent_id: &str,
+    run_id: &str,
+    artifact: &ReviewFindingsArtifactRecord,
+) -> String {
+    let marker = format!("{REVIEW_COMMENT_MARKER_PREFIX}{intent_id}{REVIEW_COMMENT_MARKER_SUFFIX}");
+    let findings = if artifact.manifest.no_findings {
+        "**No findings.** The worker explicitly affirmed `no_findings`.".to_string()
+    } else {
+        format!(
+            "Findings: {}. Every finding is attached as an inline comment.",
+            artifact.finding_count
+        )
+    };
+    format!(
+        "{marker}\n## Symphony A4 formal review\n\nIssue `#{issue_number}`.\n\nSpec artifact `{}` (version `{}`).\n\nFactory run `{run_id}` reviewed head `{}` against base `{}`.\n\n{}\n\n{}\n",
+        artifact.spec_artifact_id,
+        artifact.schema_version,
+        artifact.reviewed_head_sha,
+        artifact.base_sha,
+        artifact.manifest.spec_conformance_summary.trim(),
+        findings,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/apps/symphony/src/review/manifest.rs
+++ b/apps/symphony/src/review/manifest.rs
@@ -8,9 +8,10 @@ use serde::{Deserialize, Serialize};
 pub const REVIEW_SCHEMA_VERSION: u32 = 1;
 pub const REVIEW_MANIFEST_MAX_BYTES: usize = 256 * 1024;
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(rename_all = "snake_case")]
 pub enum ReviewSeverity {
+    #[default]
     Blocking,
     Major,
     Minor,

--- a/apps/symphony/src/review/publisher.rs
+++ b/apps/symphony/src/review/publisher.rs
@@ -263,20 +263,22 @@ where
                         return Err(error);
                     }
                 };
-                let live_head = review_port
-                    .pull_request_head_sha(pull_request_number)
-                    .await?;
-                if live_head != artifact.reviewed_head_sha {
-                    store
-                        .clear_review_publication_lease(&intent.intent_id, &self.owner_instance)?;
-                    return Err(SymphonyError::TriageError(format!(
-                        "review cycle reopened after formal review creation: live head {} does not match expected {}",
-                        live_head, artifact.reviewed_head_sha
-                    )));
-                }
                 Some(created)
             }
         };
+
+        if review.is_some() || bound_identity {
+            let live_head = review_port
+                .pull_request_head_sha(pull_request_number)
+                .await?;
+            if live_head != artifact.reviewed_head_sha {
+                store.clear_review_publication_lease(&intent.intent_id, &self.owner_instance)?;
+                return Err(SymphonyError::TriageError(format!(
+                    "review cycle reopened while accepting formal review identity: live head {} does not match expected {}",
+                    live_head, artifact.reviewed_head_sha
+                )));
+            }
+        }
 
         if let Some(review) = review {
             let review_url = review.html_url.clone().unwrap_or_default();
@@ -1405,6 +1407,84 @@ mod tests {
             .unwrap()
             .completed_steps
             .is_empty());
+    }
+
+    #[tokio::test]
+    async fn formal_publication_waits_when_owned_marker_head_changes_after_precheck() {
+        let (_dir, store) = open_store();
+        let comments = FakeComments::new("symphony-bot");
+        let reviews = FakeReviews::new("symphony-bot");
+        let publisher = ReviewPublisher::new(comments);
+        let (artifact, intent) = setup_review_fixture(&store, "formal").await;
+        let marker = format!(
+            "{REVIEW_COMMENT_MARKER_PREFIX}{}{REVIEW_COMMENT_MARKER_SUFFIX}",
+            intent.intent_id
+        );
+        reviews
+            .reviews
+            .lock()
+            .unwrap()
+            .push(GithubPullRequestReview {
+                id: 902,
+                user: Some(GithubUser {
+                    login: "symphony-bot".to_string(),
+                }),
+                body: Some(marker),
+                commit_id: "head".to_string(),
+                state: "COMMENTED".to_string(),
+                html_url: Some("https://github.test/reviews/902".to_string()),
+                submitted_at: None,
+            });
+        *reviews.head_sha.lock().unwrap() = "new-head".to_string();
+
+        let error = publisher
+            .publish_formal(&store, &reviews, &intent, &artifact, 42, 2)
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("review cycle reopened"));
+        assert!(store
+            .get_review_publication_intent(&intent.intent_id)
+            .unwrap()
+            .unwrap()
+            .completed_steps
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn formal_publication_waits_when_bound_identity_head_changes_after_precheck() {
+        let (_dir, store) = open_store();
+        let comments = FakeComments::new("symphony-bot");
+        let reviews = FakeReviews::new("symphony-bot");
+        let publisher = ReviewPublisher::new(comments);
+        let (artifact, intent) = setup_review_fixture(&store, "formal").await;
+        store
+            .bind_review_publication_review(
+                &intent.intent_id,
+                "review-17",
+                "https://github.test/reviews/17",
+                "symphony-bot",
+            )
+            .unwrap();
+        *reviews.head_sha.lock().unwrap() = "new-head".to_string();
+        let bound = store
+            .get_review_publication_intent(&intent.intent_id)
+            .unwrap()
+            .unwrap();
+
+        let error = publisher
+            .publish_formal(&store, &reviews, &bound, &artifact, 42, 2)
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("review cycle reopened"));
+        let persisted = store
+            .get_review_publication_intent(&intent.intent_id)
+            .unwrap()
+            .unwrap();
+        assert!(!persisted
+            .completed_steps
+            .iter()
+            .any(|step| step == FINDINGS_RECORDED_STEP));
+        assert_eq!(persisted.retry_count, 0);
     }
 
     #[tokio::test]

--- a/apps/symphony/src/review/publisher.rs
+++ b/apps/symphony/src/review/publisher.rs
@@ -6,7 +6,7 @@ use crate::review::domain::{
     ReviewFindingsArtifactRecord, ReviewPublicationIntent, REVIEW_COMMENT_MARKER_PREFIX,
     REVIEW_COMMENT_MARKER_SUFFIX,
 };
-use crate::review::findings::{render_formal_review_body, render_preview_comment};
+use crate::review::findings::{render_formal_review_body_with_records, render_preview_comment};
 use crate::triage::publisher::TriageCommentPort;
 use crate::triage::runtime::SharedFactoryStore;
 
@@ -111,13 +111,24 @@ where
             "{REVIEW_COMMENT_MARKER_PREFIX}{}{REVIEW_COMMENT_MARKER_SUFFIX}",
             intent.intent_id
         );
-        let body = render_formal_review_body(
+        // The approved specification version is captured in the intent at claim time.
+        // Older intents fall back to the review schema version for compatibility.
+        let approved_spec_version = intent
+            .desired_effects
+            .get("approved_spec_version")
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|version| u32::try_from(version).ok());
+        let finding_records =
+            store.list_review_finding_records_for_artifact(&artifact.artifact_id)?;
+        let body = render_formal_review_body_with_records(
             pull_request_number,
             &intent.intent_id,
             &intent.run_id,
             artifact,
+            approved_spec_version,
+            &finding_records,
         );
-        let comments = render_review_comments(artifact);
+        let comments = render_review_comments(artifact, &finding_records);
 
         let review_created = intent
             .completed_steps
@@ -126,28 +137,33 @@ where
         let bound_identity = intent.review_id.is_some()
             && intent.review_url.is_some()
             && intent.publisher_login.is_some();
-        if bound_identity && !review_created {
+        if bound_identity {
             let review_id = intent.review_id.as_deref().expect("bound review id");
             let review_url = intent.review_url.as_deref().expect("bound review URL");
-            let publisher_login = intent
+            let durable_publisher_login = intent
                 .publisher_login
                 .as_deref()
                 .expect("bound publisher login");
-            store.record_review_publication_step(
-                &intent.intent_id,
-                REVIEW_CREATED_STEP,
-                crate::triage::domain::PublicationStatus::Pending,
-                &serde_json::json!({
-                    "review_id": review_id,
-                    "review_url": review_url,
-                    "publisher_login": publisher_login,
-                }),
-            )?;
+            if !durable_publisher_login.eq_ignore_ascii_case(&publisher_login) {
+                return Err(SymphonyError::TriageError(format!(
+                    "formal review publisher identity conflict: durable login {durable_publisher_login} does not match authenticated login {publisher_login}"
+                )));
+            }
+            if !review_created {
+                store.record_review_publication_step(
+                    &intent.intent_id,
+                    REVIEW_CREATED_STEP,
+                    crate::triage::domain::PublicationStatus::Pending,
+                    &serde_json::json!({
+                        "review_id": review_id,
+                        "review_url": review_url,
+                        "publisher_login": durable_publisher_login,
+                    }),
+                )?;
+            }
         }
 
-        let review = if review_created || bound_identity {
-            None
-        } else if intent.review_id.is_some() {
+        let review = if review_created || bound_identity || intent.review_id.is_some() {
             None
         } else {
             let existing = review_port
@@ -374,11 +390,19 @@ where
 
 fn render_review_comments(
     artifact: &ReviewFindingsArtifactRecord,
+    finding_records: &[crate::review::domain::ReviewFindingRecord],
 ) -> Vec<GithubPullRequestReviewComment> {
     artifact
         .manifest
         .findings
         .iter()
+        .filter(|finding| {
+            !finding_records.iter().any(|record| {
+                record.artifact_id == artifact.artifact_id
+                    && record.finding_id == finding.finding_id
+                    && record.lifecycle_state == "persisting"
+            })
+        })
         .map(|finding| {
             let end_line = finding.end_line.unwrap_or(finding.line);
             let multiline = end_line > finding.line;
@@ -420,7 +444,7 @@ mod tests {
         ImplementationEvidence, ImplementationManifest, ImplementationPublicationKind,
         ManifestStatus,
     };
-    use crate::review::domain::ReviewFindingsArtifactRecord;
+    use crate::review::domain::{ReviewFindingRecord, ReviewFindingsArtifactRecord};
     use crate::review::manifest::{
         ReviewFinding, ReviewFindingCategory, ReviewFindingsManifest, ReviewSeverity,
     };
@@ -433,6 +457,7 @@ mod tests {
         StoreReviewArtifactRequest, StoreReviewAttemptRequest, StoreSpecArtifactRequest,
     };
     use async_trait::async_trait;
+    use chrono::Utc;
     use std::collections::HashMap;
     use std::sync::{Arc, Mutex};
     use tempfile::tempdir;
@@ -760,10 +785,119 @@ mod tests {
                 &artifact.run_id,
                 &artifact.artifact_id,
                 kind,
-                &serde_json::json!({"issue_number":42}),
+                &serde_json::json!({"issue_number":42, "approved_spec_version": 7}),
             )
             .unwrap();
         (artifact, intent)
+    }
+
+    #[test]
+    fn formal_comments_suppress_only_persisting_findings() {
+        let now = Utc::now();
+        let finding = |id: &str, claim: &str| ReviewFinding {
+            finding_id: id.to_string(),
+            severity: ReviewSeverity::Major,
+            category: ReviewFindingCategory::Correctness,
+            path: "src/lib.rs".to_string(),
+            line: 10,
+            end_line: None,
+            claim: claim.to_string(),
+            rationale: "rationale".to_string(),
+            remediation: "remediation".to_string(),
+            acceptance_criterion: None,
+            confidence: 0.9,
+        };
+        let artifact = ReviewFindingsArtifactRecord {
+            artifact_id: "artifact".to_string(),
+            run_id: "run".to_string(),
+            stage_run_id: "stage".to_string(),
+            attempt_id: "attempt".to_string(),
+            draft_pr_artifact_id: "draft".to_string(),
+            implementation_artifact_id: "implementation".to_string(),
+            spec_artifact_id: "spec".to_string(),
+            schema_version: 1,
+            reviewed_head_sha: "head".to_string(),
+            base_sha: "base".to_string(),
+            manifest: ReviewFindingsManifest {
+                schema_version: 1,
+                reviewed_head_sha: "head".to_string(),
+                base_sha: "base".to_string(),
+                spec_conformance_summary: "Conforms".to_string(),
+                no_findings: false,
+                findings: vec![
+                    finding("persisting", "keep in summary"),
+                    finding("new", "fresh"),
+                ],
+            },
+            no_findings: false,
+            finding_count: 2,
+            received_at: now,
+            bytes_len: 1,
+        };
+        let records = vec![
+            ReviewFindingRecord {
+                finding_record_id: "record-1".to_string(),
+                run_id: "run".to_string(),
+                artifact_id: "artifact".to_string(),
+                finding_id: "persisting".to_string(),
+                identity_key: "src/lib.rs:10:10:keep in summary".to_string(),
+                reviewed_head_sha: "head".to_string(),
+                severity: ReviewSeverity::Major,
+                category: ReviewFindingCategory::Correctness,
+                path: "src/lib.rs".to_string(),
+                line: 10,
+                end_line: None,
+                claim: "keep in summary".to_string(),
+                rationale: "rationale".to_string(),
+                remediation: "remediation".to_string(),
+                acceptance_criterion: None,
+                confidence: 0.9,
+                lifecycle_state: "persisting".to_string(),
+                created_at: now,
+                updated_at: now,
+            },
+            ReviewFindingRecord {
+                finding_record_id: "record-2".to_string(),
+                run_id: "run".to_string(),
+                artifact_id: "artifact".to_string(),
+                finding_id: "new".to_string(),
+                identity_key: "src/lib.rs:10:10:fresh".to_string(),
+                reviewed_head_sha: "head".to_string(),
+                severity: ReviewSeverity::Major,
+                category: ReviewFindingCategory::Correctness,
+                path: "src/lib.rs".to_string(),
+                line: 10,
+                end_line: None,
+                claim: "fresh".to_string(),
+                rationale: "rationale".to_string(),
+                remediation: "remediation".to_string(),
+                acceptance_criterion: None,
+                confidence: 0.9,
+                lifecycle_state: "new".to_string(),
+                created_at: now,
+                updated_at: now,
+            },
+        ];
+        let comments = render_review_comments(&artifact, &records);
+        assert_eq!(comments.len(), 1);
+        assert!(comments[0].body.contains("fresh"));
+        assert!(!comments[0].body.contains("keep in summary"));
+        let body =
+            render_formal_review_body_with_records(42, "intent", "run", &artifact, None, &records);
+        assert!(body.contains("keep in summary"));
+    }
+
+    #[tokio::test]
+    async fn artifact_head_lookup_distinguishes_review_cycles() {
+        let (_dir, store) = open_store();
+        let (artifact, _intent) = setup_preview_fixture(&store).await;
+
+        assert!(store
+            .review_artifact_exists_for_head(&artifact.run_id, "head")
+            .unwrap());
+        assert!(!store
+            .review_artifact_exists_for_head(&artifact.run_id, "new-head")
+            .unwrap());
     }
 
     #[tokio::test]
@@ -970,7 +1104,7 @@ mod tests {
         assert!(payloads[0].0.contains("formal review"));
         assert!(payloads[0].0.contains("Issue `#42`"));
         assert!(payloads[0].0.contains(&artifact.spec_artifact_id));
-        assert!(payloads[0].0.contains("version `1`"));
+        assert!(payloads[0].0.contains("version `7`"));
         assert!(payloads[0].0.contains(&artifact.run_id));
         assert!(payloads[0]
             .0
@@ -1018,6 +1152,41 @@ mod tests {
         assert_eq!(
             persisted.completed_steps,
             vec![REVIEW_CREATED_STEP, FINDINGS_RECORDED_STEP]
+        );
+    }
+
+    #[tokio::test]
+    async fn resuming_bound_formal_review_requires_the_durable_publisher_identity() {
+        let (_dir, store) = open_store();
+        let comments = FakeComments::new("comment-bot");
+        let reviews = FakeReviews::new("current-bot");
+        let publisher = ReviewPublisher::new(comments);
+        let (artifact, intent) = setup_review_fixture(&store, "formal").await;
+        store
+            .bind_review_publication_review(
+                &intent.intent_id,
+                "review-17",
+                "https://github.test/reviews/17",
+                "durable-bot",
+            )
+            .unwrap();
+        let bound_intent = store
+            .get_review_publication_intent(&intent.intent_id)
+            .unwrap()
+            .unwrap();
+
+        let error = publisher
+            .publish_formal(&store, &reviews, &bound_intent, &artifact, 42, 2)
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("publisher identity conflict"));
+        assert_eq!(
+            store
+                .get_review_publication_intent(&intent.intent_id)
+                .unwrap()
+                .unwrap()
+                .retry_count,
+            0
         );
     }
 

--- a/apps/symphony/src/review/publisher.rs
+++ b/apps/symphony/src/review/publisher.rs
@@ -263,6 +263,17 @@ where
                         return Err(error);
                     }
                 };
+                let live_head = review_port
+                    .pull_request_head_sha(pull_request_number)
+                    .await?;
+                if live_head != artifact.reviewed_head_sha {
+                    store
+                        .clear_review_publication_lease(&intent.intent_id, &self.owner_instance)?;
+                    return Err(SymphonyError::TriageError(format!(
+                        "review cycle reopened after formal review creation: live head {} does not match expected {}",
+                        live_head, artifact.reviewed_head_sha
+                    )));
+                }
                 Some(created)
             }
         };
@@ -606,6 +617,7 @@ mod tests {
         login: String,
         head_sha: Mutex<String>,
         change_head_on_create: Mutex<bool>,
+        change_head_after_create: Mutex<bool>,
         reviews: Mutex<Vec<GithubPullRequestReview>>,
         review_payloads: Mutex<Vec<(String, Vec<GithubPullRequestReviewComment>)>>,
     }
@@ -616,6 +628,7 @@ mod tests {
                 login: login.to_string(),
                 head_sha: Mutex::new("head".to_string()),
                 change_head_on_create: Mutex::new(false),
+                change_head_after_create: Mutex::new(false),
                 reviews: Mutex::new(Vec::new()),
                 review_payloads: Mutex::new(Vec::new()),
             })
@@ -670,6 +683,9 @@ mod tests {
                 submitted_at: None,
             };
             self.reviews.lock().unwrap().push(review.clone());
+            if *self.change_head_after_create.lock().unwrap() {
+                *self.head_sha.lock().unwrap() = "new-head".to_string();
+            }
             Ok(review)
         }
     }
@@ -1325,6 +1341,29 @@ mod tests {
             .unwrap_err();
         assert!(error.to_string().contains("review cycle reopened"));
         assert!(reviews.review_payloads.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn formal_publication_waits_when_successful_create_returns_stale_head() {
+        let (_temp, store) = open_store();
+        let reviews = FakeReviews::new("symphony-bot");
+        *reviews.change_head_after_create.lock().unwrap() = true;
+        let publisher = ReviewPublisher::new(FakeComments::new("symphony-bot"));
+        let (artifact, intent) = setup_review_fixture(&store, "formal").await;
+
+        let error = publisher
+            .publish_formal(&store, &reviews, &intent, &artifact, 42, 2)
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("review cycle reopened"));
+        assert_eq!(reviews.review_payloads.lock().unwrap().len(), 1);
+        assert_eq!(reviews.reviews.lock().unwrap().len(), 1);
+        let persisted = store
+            .get_review_publication_intent(&intent.intent_id)
+            .unwrap()
+            .unwrap();
+        assert!(persisted.completed_steps.is_empty());
+        assert_eq!(persisted.retry_count, 0);
     }
 
     #[tokio::test]

--- a/apps/symphony/src/review/publisher.rs
+++ b/apps/symphony/src/review/publisher.rs
@@ -12,9 +12,77 @@ use crate::triage::runtime::SharedFactoryStore;
 use uuid::Uuid;
 
 pub const REVIEW_PREVIEW_COMMENT_STEP: &str = "review_preview_comment";
-const REVIEW_PUBLICATION_LEASE_SECONDS: i64 = 900;
+pub const REVIEW_PUBLICATION_LEASE_SECONDS: i64 = 900;
 pub const REVIEW_CREATED_STEP: &str = "review_created";
 pub const FINDINGS_RECORDED_STEP: &str = "findings_recorded";
+const REVIEW_PUBLICATION_LEASE_RENEW_INTERVAL: std::time::Duration =
+    std::time::Duration::from_secs(1);
+
+/// Keep a claimed publication lease fenced while a forge request is in flight.
+///
+/// The durable write guards remain authoritative after the request returns. The
+/// heartbeat prevents a healthy but slow request from becoming reclaimable
+/// during normal operation.
+pub(crate) struct ReviewPublicationLeaseGuard {
+    stop: Option<tokio::sync::oneshot::Sender<()>>,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl ReviewPublicationLeaseGuard {
+    pub(crate) fn start(store: &SharedFactoryStore, intent_id: &str, owner: &str) -> Self {
+        let (stop, mut stopped) = tokio::sync::oneshot::channel();
+        let shared_store = store.clone();
+        let intent_id = intent_id.to_string();
+        let owner = owner.to_string();
+        let task = tokio::spawn(async move {
+            let mut interval = tokio::time::interval(REVIEW_PUBLICATION_LEASE_RENEW_INTERVAL);
+            loop {
+                tokio::select! {
+                    _ = &mut stopped => break,
+                    _ = interval.tick() => {
+                        match shared_store.renew_review_publication_lease(
+                            &intent_id,
+                            &owner,
+                            REVIEW_PUBLICATION_LEASE_SECONDS,
+                        ) {
+                            Ok(true) => {}
+                            Ok(false) => {
+                                tracing::debug!(
+                                    intent_id = %intent_id,
+                                    owner = %owner,
+                                    "review publication lease is no longer owned"
+                                );
+                                break;
+                            }
+                            Err(error) => {
+                                tracing::warn!(
+                                    intent_id = %intent_id,
+                                    owner = %owner,
+                                    error = %error,
+                                    "review publication lease renewal failed"
+                                );
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        Self {
+            stop: Some(stop),
+            task,
+        }
+    }
+}
+
+impl Drop for ReviewPublicationLeaseGuard {
+    fn drop(&mut self) {
+        if let Some(stop) = self.stop.take() {
+            let _ = stop.send(());
+        }
+        self.task.abort();
+    }
+}
 
 /// Forge operations required for atomic pull-request review publication.
 #[async_trait::async_trait]
@@ -127,6 +195,8 @@ where
         )? {
             return Ok(false);
         }
+        let _lease =
+            ReviewPublicationLeaseGuard::start(store, &intent.intent_id, &self.owner_instance);
 
         let publisher_login = review_port.authenticated_login().await?;
         let marker = format!(
@@ -214,8 +284,6 @@ where
                     .pull_request_head_sha(pull_request_number)
                     .await?;
                 if live_head != artifact.reviewed_head_sha {
-                    store
-                        .clear_review_publication_lease(&intent.intent_id, &self.owner_instance)?;
                     return Err(SymphonyError::TriageError(format!(
                         "review cycle reopened before formal review creation: live head {} does not match expected {}",
                         live_head, artifact.reviewed_head_sha
@@ -236,10 +304,6 @@ where
                             review_port.pull_request_head_sha(pull_request_number).await;
                         if let Ok(live_head) = live_head {
                             if live_head != artifact.reviewed_head_sha {
-                                store.clear_review_publication_lease(
-                                    &intent.intent_id,
-                                    &self.owner_instance,
-                                )?;
                                 return Err(SymphonyError::TriageError(format!(
                                     "review cycle reopened during formal review creation: live head {} does not match expected {}",
                                     live_head, artifact.reviewed_head_sha
@@ -258,7 +322,6 @@ where
                 .pull_request_head_sha(pull_request_number)
                 .await?;
             if live_head != artifact.reviewed_head_sha {
-                store.clear_review_publication_lease(&intent.intent_id, &self.owner_instance)?;
                 return Err(SymphonyError::TriageError(format!(
                     "review cycle reopened while accepting formal review identity: live head {} does not match expected {}",
                     live_head, artifact.reviewed_head_sha
@@ -273,8 +336,9 @@ where
                 .publisher_login
                 .as_deref()
                 .expect("bound publisher login");
-            store.record_review_publication_step(
+            if !store.record_review_publication_step_owned(
                 &intent.intent_id,
+                &self.owner_instance,
                 REVIEW_CREATED_STEP,
                 crate::triage::domain::PublicationStatus::Pending,
                 &serde_json::json!({
@@ -282,19 +346,25 @@ where
                     "review_url": review_url,
                     "publisher_login": durable_publisher_login,
                 }),
-            )?;
+            )? {
+                return Ok(false);
+            }
         }
 
         if let Some(review) = review {
             let review_url = review.html_url.clone().unwrap_or_default();
-            store.bind_review_publication_review(
+            if !store.bind_review_publication_review_owned(
                 &intent.intent_id,
+                &self.owner_instance,
                 &review.id.to_string(),
                 &review_url,
                 &publisher_login,
-            )?;
-            store.record_review_publication_step(
+            )? {
+                return Ok(false);
+            }
+            if !store.record_review_publication_step_owned(
                 &intent.intent_id,
+                &self.owner_instance,
                 REVIEW_CREATED_STEP,
                 crate::triage::domain::PublicationStatus::Pending,
                 &serde_json::json!({
@@ -302,23 +372,27 @@ where
                     "review_url": review_url,
                     "publisher_login": publisher_login,
                 }),
-            )?;
+            )? {
+                return Ok(false);
+            }
         } else if !review_created && !bound_identity {
             return Err(SymphonyError::TriageError(
                 "formal review has no forge identity to record".to_string(),
             ));
         }
 
-        store.record_review_publication_step(
+        if !store.record_review_publication_step_owned(
             &intent.intent_id,
+            &self.owner_instance,
             FINDINGS_RECORDED_STEP,
             crate::triage::domain::PublicationStatus::Pending,
             &serde_json::json!({
                 "finding_count": artifact.finding_count,
                 "inline_comment_count": comments.len(),
             }),
-        )?;
-        store.clear_review_publication_lease(&intent.intent_id, &self.owner_instance)?;
+        )? {
+            return Ok(false);
+        }
         Ok(true)
     }
 
@@ -344,10 +418,40 @@ where
         {
             return Ok(());
         }
+        if !store.claim_review_publication(
+            &intent.intent_id,
+            &self.owner_instance,
+            REVIEW_PUBLICATION_LEASE_SECONDS,
+        )? {
+            return Ok(());
+        }
+        let _lease =
+            ReviewPublicationLeaseGuard::start(store, &intent.intent_id, &self.owner_instance);
         let body = render_preview_comment(&intent.intent_id, &intent.run_id, artifact);
-        self.upsert_owned_comment(store, intent, issue_number, &body, max_pages)
-            .await?;
-        store.complete_review_publication(&intent.intent_id, REVIEW_PREVIEW_COMMENT_STEP)
+        let result = async {
+            if !self
+                .upsert_owned_comment(store, intent, issue_number, &body, max_pages)
+                .await?
+            {
+                return Ok(false);
+            }
+            store.complete_review_publication_owned(
+                &intent.intent_id,
+                &self.owner_instance,
+                REVIEW_PREVIEW_COMMENT_STEP,
+            )
+        }
+        .await;
+        match result {
+            Ok(completed) => {
+                if !completed {
+                    store
+                        .clear_review_publication_lease(&intent.intent_id, &self.owner_instance)?;
+                }
+                Ok(())
+            }
+            Err(error) => Err(error),
+        }
     }
 
     async fn upsert_owned_comment(
@@ -357,7 +461,7 @@ where
         issue_number: u64,
         body: &str,
         max_pages: u32,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         let publisher_login = self.comments.authenticated_login().await?;
         let mut comment_id = if let Some(raw) = intent.comment_id.as_deref() {
             raw.parse::<u64>().map_err(|error| {
@@ -372,37 +476,51 @@ where
             found
         } else {
             let created = self.comments.create_comment(issue_number, body).await?;
-            store.bind_review_publication_comment(
+            if !store.bind_review_publication_comment_owned(
                 &intent.intent_id,
+                &self.owner_instance,
                 &created.id.to_string(),
                 &publisher_login,
-            )?;
-            return Ok(());
+            )? {
+                return Ok(false);
+            }
+            return Ok(true);
         };
 
         let existing = match self.comments.get_comment(comment_id).await {
             Ok(existing) => existing,
             Err(SymphonyError::GithubApiStatus { status: 404, .. }) => {
-                store.clear_review_publication_comment(&intent.intent_id)?;
+                if !store.clear_review_publication_comment_owned(
+                    &intent.intent_id,
+                    &self.owner_instance,
+                )? {
+                    return Ok(false);
+                }
                 if let Some(recovered) = self
                     .find_owned_marker(issue_number, &intent.intent_id, &publisher_login, max_pages)
                     .await?
                 {
                     comment_id = recovered;
-                    store.bind_review_publication_comment(
+                    if !store.bind_review_publication_comment_owned(
                         &intent.intent_id,
+                        &self.owner_instance,
                         &comment_id.to_string(),
                         &publisher_login,
-                    )?;
+                    )? {
+                        return Ok(false);
+                    }
                     self.comments.get_comment(comment_id).await?
                 } else {
                     let created = self.comments.create_comment(issue_number, body).await?;
-                    store.bind_review_publication_comment(
+                    if !store.bind_review_publication_comment_owned(
                         &intent.intent_id,
+                        &self.owner_instance,
                         &created.id.to_string(),
                         &publisher_login,
-                    )?;
-                    return Ok(());
+                    )? {
+                        return Ok(false);
+                    }
+                    return Ok(true);
                 }
             }
             Err(error) => return Err(error),
@@ -418,16 +536,19 @@ where
             )));
         }
         self.comments.update_comment(comment_id, body).await?;
-        if intent.comment_id.is_none()
-            || intent.publisher_login.as_deref() != Some(publisher_login.as_str())
-        {
-            store.bind_review_publication_comment(
+        let needs_binding = intent.comment_id.is_none()
+            || intent.publisher_login.as_deref() != Some(publisher_login.as_str());
+        if needs_binding
+            && !store.bind_review_publication_comment_owned(
                 &intent.intent_id,
+                &self.owner_instance,
                 &comment_id.to_string(),
                 &publisher_login,
-            )?;
+            )?
+        {
+            return Ok(false);
         }
-        Ok(())
+        Ok(true)
     }
 
     async fn find_owned_marker(
@@ -1032,7 +1153,7 @@ mod tests {
             .unwrap();
         assert_eq!(comments.comments.lock().unwrap().len(), 1);
         assert_eq!(*comments.create_count.lock().unwrap(), 1);
-        assert_eq!(*comments.update_count.lock().unwrap(), 1);
+        assert_eq!(*comments.update_count.lock().unwrap(), 0);
     }
 
     #[tokio::test]

--- a/apps/symphony/src/review/publisher.rs
+++ b/apps/symphony/src/review/publisher.rs
@@ -173,6 +173,7 @@ mod tests {
     use crate::review::domain::ReviewFindingsArtifactRecord;
     use crate::review::manifest::ReviewFindingsManifest;
     use crate::spec::domain::{SpecArtifact, SpecPublicationKind};
+    use crate::triage::domain::PublicationStatus;
     use crate::triage::publisher::TriageCommentPort;
     use crate::triage::runtime::SharedFactoryStore;
     use crate::triage::store::{
@@ -299,6 +300,16 @@ mod tests {
 
     async fn setup_preview_fixture(
         store: &SharedFactoryStore,
+    ) -> (
+        ReviewFindingsArtifactRecord,
+        crate::review::domain::ReviewPublicationIntent,
+    ) {
+        setup_review_fixture(store, "preview").await
+    }
+
+    async fn setup_review_fixture(
+        store: &SharedFactoryStore,
+        kind: &str,
     ) -> (
         ReviewFindingsArtifactRecord,
         crate::review::domain::ReviewPublicationIntent,
@@ -439,7 +450,7 @@ mod tests {
             .create_review_publication_intent(
                 &artifact.run_id,
                 &artifact.artifact_id,
-                "preview",
+                kind,
                 &serde_json::json!({"issue_number":42}),
             )
             .unwrap();
@@ -488,6 +499,132 @@ mod tests {
         assert_eq!(comments.comments.lock().unwrap().len(), 1);
         assert_eq!(*comments.create_count.lock().unwrap(), 1);
         assert_eq!(*comments.update_count.lock().unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn fresh_intent_round_trips_formal_identity_and_progressive_steps() {
+        let (_dir, store) = open_store();
+        let (_artifact, intent) = setup_preview_fixture(&store).await;
+
+        let fresh = store
+            .get_review_publication_intent(&intent.intent_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(fresh.review_id, None);
+        assert_eq!(fresh.review_url, None);
+        assert_eq!(fresh.route_state, None);
+
+        store
+            .bind_review_publication_review(
+                &intent.intent_id,
+                "review-17",
+                "https://example.test/reviews/17",
+                "symphony-bot",
+            )
+            .unwrap();
+        store
+            .set_review_publication_route_state(&intent.intent_id, "Human Review")
+            .unwrap();
+        store
+            .record_review_publication_step(
+                &intent.intent_id,
+                "review_created",
+                PublicationStatus::Pending,
+                &serde_json::json!({"review_id": "review-17"}),
+            )
+            .unwrap();
+        let pending = store
+            .get_review_publication_intent(&intent.intent_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(pending.status, PublicationStatus::Pending);
+        assert_eq!(pending.review_id.as_deref(), Some("review-17"));
+        assert_eq!(
+            pending.review_url.as_deref(),
+            Some("https://example.test/reviews/17")
+        );
+        assert_eq!(pending.route_state.as_deref(), Some("Human Review"));
+
+        store
+            .record_review_publication_step(
+                &intent.intent_id,
+                "findings_recorded",
+                PublicationStatus::Pending,
+                &serde_json::json!({"finding_count": 0}),
+            )
+            .unwrap();
+        store
+            .record_review_publication_step(
+                &intent.intent_id,
+                "route_applied",
+                PublicationStatus::Pending,
+                &serde_json::json!({"route_state": "Human Review"}),
+            )
+            .unwrap();
+        store
+            .record_review_publication_step(
+                &intent.intent_id,
+                "comment_final",
+                PublicationStatus::Pending,
+                &serde_json::json!({"comment_id": "701"}),
+            )
+            .unwrap();
+        let applied = store
+            .get_review_publication_intent(&intent.intent_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(applied.status, PublicationStatus::Applied);
+        assert_eq!(applied.completed_steps.len(), 4);
+    }
+
+    #[tokio::test]
+    async fn applied_formal_intent_stays_terminal_when_a_nonfinal_step_replays() {
+        let (_dir, store) = open_store();
+        let (_artifact, intent) = setup_review_fixture(&store, "formal").await;
+
+        store
+            .record_review_publication_step(
+                &intent.intent_id,
+                "comment_final",
+                PublicationStatus::Pending,
+                &serde_json::json!({"comment_id":"701"}),
+            )
+            .unwrap();
+        store
+            .record_review_publication_step(
+                &intent.intent_id,
+                "route_applied",
+                PublicationStatus::Pending,
+                &serde_json::json!({"route_state":"Human Review"}),
+            )
+            .unwrap();
+
+        let applied = store
+            .get_review_publication_intent(&intent.intent_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(applied.status, PublicationStatus::Applied);
+        assert_eq!(applied.completed_steps, vec!["comment_final"]);
+        assert_eq!(
+            applied.expected_projection,
+            serde_json::json!({"comment_id":"701"})
+        );
+    }
+
+    #[tokio::test]
+    async fn preview_completion_helper_rejects_formal_intents() {
+        let (_dir, store) = open_store();
+        let (_artifact, intent) = setup_review_fixture(&store, "formal").await;
+
+        assert!(store
+            .complete_review_publication(&intent.intent_id, REVIEW_PREVIEW_COMMENT_STEP)
+            .is_err());
+        let unchanged = store
+            .get_review_publication_intent(&intent.intent_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(unchanged.status, PublicationStatus::Pending);
+        assert!(unchanged.completed_steps.is_empty());
     }
 
     #[tokio::test]

--- a/apps/symphony/src/review/publisher.rs
+++ b/apps/symphony/src/review/publisher.rs
@@ -160,8 +160,6 @@ where
             && intent.review_url.is_some()
             && intent.publisher_login.is_some();
         if bound_identity {
-            let review_id = intent.review_id.as_deref().expect("bound review id");
-            let review_url = intent.review_url.as_deref().expect("bound review URL");
             let durable_publisher_login = intent
                 .publisher_login
                 .as_deref()
@@ -170,18 +168,6 @@ where
                 return Err(SymphonyError::TriageError(format!(
                     "formal review publisher identity conflict: durable login {durable_publisher_login} does not match authenticated login {publisher_login}"
                 )));
-            }
-            if !review_created {
-                store.record_review_publication_step(
-                    &intent.intent_id,
-                    REVIEW_CREATED_STEP,
-                    crate::triage::domain::PublicationStatus::Pending,
-                    &serde_json::json!({
-                        "review_id": review_id,
-                        "review_url": review_url,
-                        "publisher_login": durable_publisher_login,
-                    }),
-                )?;
             }
         }
 
@@ -278,6 +264,25 @@ where
                     live_head, artifact.reviewed_head_sha
                 )));
             }
+        }
+
+        if bound_identity && !review_created {
+            let review_id = intent.review_id.as_deref().expect("bound review id");
+            let review_url = intent.review_url.as_deref().expect("bound review URL");
+            let durable_publisher_login = intent
+                .publisher_login
+                .as_deref()
+                .expect("bound publisher login");
+            store.record_review_publication_step(
+                &intent.intent_id,
+                REVIEW_CREATED_STEP,
+                crate::triage::domain::PublicationStatus::Pending,
+                &serde_json::json!({
+                    "review_id": review_id,
+                    "review_url": review_url,
+                    "publisher_login": durable_publisher_login,
+                }),
+            )?;
         }
 
         if let Some(review) = review {
@@ -1480,10 +1485,7 @@ mod tests {
             .get_review_publication_intent(&intent.intent_id)
             .unwrap()
             .unwrap();
-        assert!(!persisted
-            .completed_steps
-            .iter()
-            .any(|step| step == FINDINGS_RECORDED_STEP));
+        assert!(persisted.completed_steps.is_empty());
         assert_eq!(persisted.retry_count, 0);
     }
 

--- a/apps/symphony/src/review/publisher.rs
+++ b/apps/symphony/src/review/publisher.rs
@@ -9,8 +9,10 @@ use crate::review::domain::{
 use crate::review::findings::{render_formal_review_body_with_records, render_preview_comment};
 use crate::triage::publisher::TriageCommentPort;
 use crate::triage::runtime::SharedFactoryStore;
+use uuid::Uuid;
 
 pub const REVIEW_PREVIEW_COMMENT_STEP: &str = "review_preview_comment";
+const REVIEW_PUBLICATION_LEASE_SECONDS: i64 = 900;
 pub const REVIEW_CREATED_STEP: &str = "review_created";
 pub const FINDINGS_RECORDED_STEP: &str = "findings_recorded";
 
@@ -23,6 +25,7 @@ pub trait ReviewPort: Send + Sync {
         number: u64,
         max_pages: u32,
     ) -> Result<Vec<GithubPullRequestReview>>;
+    async fn pull_request_head_sha(&self, number: u64) -> Result<String>;
     async fn create_pull_request_review(
         &self,
         number: u64,
@@ -53,6 +56,10 @@ impl ReviewPort for crate::github::client::GithubClient {
             .await
     }
 
+    async fn pull_request_head_sha(&self, number: u64) -> Result<String> {
+        Ok(self.get_pull_request(number).await?.head.sha)
+    }
+
     async fn create_pull_request_review(
         &self,
         number: u64,
@@ -70,6 +77,7 @@ impl ReviewPort for crate::github::client::GithubClient {
 #[derive(Clone)]
 pub struct ReviewPublisher<C> {
     comments: C,
+    owner_instance: String,
 }
 
 impl<C> ReviewPublisher<C>
@@ -77,7 +85,14 @@ where
     C: TriageCommentPort + Clone,
 {
     pub fn new(comments: C) -> Self {
-        Self { comments }
+        Self::with_owner(comments, format!("review-publisher-{}", Uuid::now_v7()))
+    }
+
+    pub fn with_owner(comments: C, owner_instance: impl Into<String>) -> Self {
+        Self {
+            comments,
+            owner_instance: owner_instance.into(),
+        }
     }
 
     pub async fn publish_formal<R>(
@@ -88,7 +103,7 @@ where
         artifact: &ReviewFindingsArtifactRecord,
         pull_request_number: u64,
         max_pages: u32,
-    ) -> Result<()>
+    ) -> Result<bool>
     where
         R: ReviewPort + ?Sized,
     {
@@ -103,7 +118,14 @@ where
             .iter()
             .any(|step| step == FINDINGS_RECORDED_STEP)
         {
-            return Ok(());
+            return Ok(true);
+        }
+        if !store.claim_review_publication(
+            &intent.intent_id,
+            &self.owner_instance,
+            REVIEW_PUBLICATION_LEASE_SECONDS,
+        )? {
+            return Ok(false);
         }
 
         let publisher_login = review_port.authenticated_login().await?;
@@ -202,6 +224,15 @@ where
             if let Some(existing) = owned {
                 Some(existing)
             } else {
+                let live_head = review_port
+                    .pull_request_head_sha(pull_request_number)
+                    .await?;
+                if live_head != artifact.reviewed_head_sha {
+                    return Err(SymphonyError::TriageError(format!(
+                        "formal review publication conflict: live head {} does not match expected {}",
+                        live_head, artifact.reviewed_head_sha
+                    )));
+                }
                 Some(
                     review_port
                         .create_pull_request_review(
@@ -248,7 +279,8 @@ where
                 "inline_comment_count": comments.len(),
             }),
         )?;
-        Ok(())
+        store.clear_review_publication_lease(&intent.intent_id, &self.owner_instance)?;
+        Ok(true)
     }
 
     pub async fn publish_preview(
@@ -551,6 +583,7 @@ mod tests {
 
     struct FakeReviews {
         login: String,
+        head_sha: Mutex<String>,
         reviews: Mutex<Vec<GithubPullRequestReview>>,
         review_payloads: Mutex<Vec<(String, Vec<GithubPullRequestReviewComment>)>>,
     }
@@ -559,6 +592,7 @@ mod tests {
         fn new(login: &str) -> Arc<Self> {
             Arc::new(Self {
                 login: login.to_string(),
+                head_sha: Mutex::new("head".to_string()),
                 reviews: Mutex::new(Vec::new()),
                 review_payloads: Mutex::new(Vec::new()),
             })
@@ -577,6 +611,10 @@ mod tests {
             _max_pages: u32,
         ) -> Result<Vec<GithubPullRequestReview>> {
             Ok(self.reviews.lock().unwrap().clone())
+        }
+
+        async fn pull_request_head_sha(&self, _number: u64) -> Result<String> {
+            Ok(self.head_sha.lock().unwrap().clone())
         }
 
         async fn create_pull_request_review(
@@ -1224,6 +1262,22 @@ mod tests {
             vec![REVIEW_CREATED_STEP, FINDINGS_RECORDED_STEP]
         );
         assert_eq!(persisted.review_id.as_deref(), Some("review-17"));
+        assert!(reviews.review_payloads.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn formal_publication_rejects_live_head_change_before_create() {
+        let (_temp, store) = open_store();
+        let reviews = FakeReviews::new("symphony-bot");
+        let publisher = ReviewPublisher::new(FakeComments::new("symphony-bot"));
+        let (artifact, intent) = setup_review_fixture(&store, "formal").await;
+        *reviews.head_sha.lock().unwrap() = "new-head".to_string();
+
+        let error = publisher
+            .publish_formal(&store, &reviews, &intent, &artifact, 42, 2)
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("live head"));
         assert!(reviews.review_payloads.lock().unwrap().is_empty());
     }
 

--- a/apps/symphony/src/review/publisher.rs
+++ b/apps/symphony/src/review/publisher.rs
@@ -212,8 +212,18 @@ where
             .and_then(|version| u32::try_from(version).ok());
         let finding_records =
             store.list_review_finding_records_for_artifact(&artifact.artifact_id)?;
+        let issue_number = intent
+            .desired_effects
+            .get("issue_number")
+            .and_then(serde_json::Value::as_u64)
+            .ok_or_else(|| {
+                SymphonyError::TriageError(format!(
+                    "formal review intent {} is missing issue_number",
+                    intent.intent_id
+                ))
+            })?;
         let body = render_formal_review_body_with_records(
-            pull_request_number,
+            issue_number,
             &intent.intent_id,
             &intent.run_id,
             artifact,
@@ -235,7 +245,7 @@ where
                 .as_deref()
                 .expect("bound publisher login");
             if !durable_publisher_login.eq_ignore_ascii_case(&publisher_login) {
-                return Err(SymphonyError::TriageError(format!(
+                return Err(SymphonyError::ReviewPublicationConflict(format!(
                     "formal review publisher identity conflict: durable login {durable_publisher_login} does not match authenticated login {publisher_login}"
                 )));
             }
@@ -260,18 +270,18 @@ where
                     .map(|user| user.login.as_str())
                     .unwrap_or_default();
                 if !author.eq_ignore_ascii_case(&publisher_login) {
-                    return Err(SymphonyError::TriageError(format!(
+                    return Err(SymphonyError::ReviewPublicationConflict(format!(
                         "formal review marker {marker} is owned by another GitHub login {author}"
                     )));
                 }
-                if candidate.commit_id != artifact.reviewed_head_sha {
-                    return Err(SymphonyError::TriageError(format!(
+                if candidate.commit_id.as_deref() != Some(artifact.reviewed_head_sha.as_str()) {
+                    return Err(SymphonyError::ReviewPublicationConflict(format!(
                         "formal review marker {marker} conflict: head {} does not match expected {}",
-                        candidate.commit_id, artifact.reviewed_head_sha
+                        candidate.commit_id.as_deref().unwrap_or("unknown"), artifact.reviewed_head_sha
                     )));
                 }
                 if owned.is_some() {
-                    return Err(SymphonyError::TriageError(format!(
+                    return Err(SymphonyError::ReviewPublicationConflict(format!(
                         "multiple formal reviews found for marker {marker}"
                     )));
                 }
@@ -284,7 +294,7 @@ where
                     .pull_request_head_sha(pull_request_number)
                     .await?;
                 if live_head != artifact.reviewed_head_sha {
-                    return Err(SymphonyError::TriageError(format!(
+                    return Err(SymphonyError::ReviewCycleReopened(format!(
                         "review cycle reopened before formal review creation: live head {} does not match expected {}",
                         live_head, artifact.reviewed_head_sha
                     )));
@@ -304,7 +314,7 @@ where
                             review_port.pull_request_head_sha(pull_request_number).await;
                         if let Ok(live_head) = live_head {
                             if live_head != artifact.reviewed_head_sha {
-                                return Err(SymphonyError::TriageError(format!(
+                                return Err(SymphonyError::ReviewCycleReopened(format!(
                                     "review cycle reopened during formal review creation: live head {} does not match expected {}",
                                     live_head, artifact.reviewed_head_sha
                                 )));
@@ -322,7 +332,7 @@ where
                 .pull_request_head_sha(pull_request_number)
                 .await?;
             if live_head != artifact.reviewed_head_sha {
-                return Err(SymphonyError::TriageError(format!(
+                return Err(SymphonyError::ReviewCycleReopened(format!(
                     "review cycle reopened while accepting formal review identity: live head {} does not match expected {}",
                     live_head, artifact.reviewed_head_sha
                 )));
@@ -805,7 +815,7 @@ mod tests {
                     login: self.login.clone(),
                 }),
                 body: Some(body.to_string()),
-                commit_id: commit_id.to_string(),
+                commit_id: Some(commit_id.to_string()),
                 state: "COMMENTED".to_string(),
                 html_url: Some("https://github.test/reviews/900".to_string()),
                 submitted_at: None,
@@ -1515,7 +1525,7 @@ mod tests {
                     login: "symphony-bot".to_string(),
                 }),
                 body: Some(marker),
-                commit_id: "stale-head".to_string(),
+                commit_id: Some("stale-head".to_string()),
                 state: "COMMENTED".to_string(),
                 html_url: Some("https://github.test/reviews/901".to_string()),
                 submitted_at: None,
@@ -1556,7 +1566,7 @@ mod tests {
                     login: "symphony-bot".to_string(),
                 }),
                 body: Some(marker),
-                commit_id: "head".to_string(),
+                commit_id: Some("head".to_string()),
                 state: "COMMENTED".to_string(),
                 html_url: Some("https://github.test/reviews/902".to_string()),
                 submitted_at: None,
@@ -1631,7 +1641,7 @@ mod tests {
                     login: "human".to_string(),
                 }),
                 body: Some(marker),
-                commit_id: "head".to_string(),
+                commit_id: Some("head".to_string()),
                 state: "COMMENTED".to_string(),
                 html_url: Some("https://github.test/reviews/901".to_string()),
                 submitted_at: None,

--- a/apps/symphony/src/review/publisher.rs
+++ b/apps/symphony/src/review/publisher.rs
@@ -1,15 +1,71 @@
 //! Idempotent marker-owned findings preview publication.
 
 use crate::error::{Result, SymphonyError};
+use crate::github::client::{GithubPullRequestReview, GithubPullRequestReviewComment};
 use crate::review::domain::{
     ReviewFindingsArtifactRecord, ReviewPublicationIntent, REVIEW_COMMENT_MARKER_PREFIX,
     REVIEW_COMMENT_MARKER_SUFFIX,
 };
-use crate::review::findings::render_preview_comment;
+use crate::review::findings::{render_formal_review_body, render_preview_comment};
 use crate::triage::publisher::TriageCommentPort;
 use crate::triage::runtime::SharedFactoryStore;
 
 pub const REVIEW_PREVIEW_COMMENT_STEP: &str = "review_preview_comment";
+pub const REVIEW_CREATED_STEP: &str = "review_created";
+pub const FINDINGS_RECORDED_STEP: &str = "findings_recorded";
+
+/// Forge operations required for atomic pull-request review publication.
+#[async_trait::async_trait]
+pub trait ReviewPort: Send + Sync {
+    async fn authenticated_login(&self) -> Result<String>;
+    async fn list_pull_request_reviews(
+        &self,
+        number: u64,
+        max_pages: u32,
+    ) -> Result<Vec<GithubPullRequestReview>>;
+    async fn create_pull_request_review(
+        &self,
+        number: u64,
+        commit_id: &str,
+        body: &str,
+        comments: &[GithubPullRequestReviewComment],
+    ) -> Result<GithubPullRequestReview>;
+}
+
+#[async_trait::async_trait]
+impl ReviewPort for crate::github::client::GithubClient {
+    async fn authenticated_login(&self) -> Result<String> {
+        let user = self.get_authenticated_user().await?;
+        if user.login.trim().is_empty() {
+            return Err(SymphonyError::GithubApiRequest(
+                "authenticated GitHub user login is empty".to_string(),
+            ));
+        }
+        Ok(user.login)
+    }
+
+    async fn list_pull_request_reviews(
+        &self,
+        number: u64,
+        max_pages: u32,
+    ) -> Result<Vec<GithubPullRequestReview>> {
+        crate::github::client::GithubClient::list_pull_request_reviews(self, number, max_pages)
+            .await
+    }
+
+    async fn create_pull_request_review(
+        &self,
+        number: u64,
+        commit_id: &str,
+        body: &str,
+        comments: &[GithubPullRequestReviewComment],
+    ) -> Result<GithubPullRequestReview> {
+        crate::github::client::GithubClient::create_pull_request_review(
+            self, number, commit_id, body, comments,
+        )
+        .await
+    }
+}
 
 #[derive(Clone)]
 pub struct ReviewPublisher<C> {
@@ -22,6 +78,161 @@ where
 {
     pub fn new(comments: C) -> Self {
         Self { comments }
+    }
+
+    pub async fn publish_formal<R>(
+        &self,
+        store: &SharedFactoryStore,
+        review_port: &R,
+        intent: &ReviewPublicationIntent,
+        artifact: &ReviewFindingsArtifactRecord,
+        pull_request_number: u64,
+        max_pages: u32,
+    ) -> Result<()>
+    where
+        R: ReviewPort + ?Sized,
+    {
+        if intent.kind != "automatic" && intent.kind != "formal" {
+            return Err(SymphonyError::TriageError(format!(
+                "formal review publisher cannot reconcile kind={}",
+                intent.kind
+            )));
+        }
+        if intent
+            .completed_steps
+            .iter()
+            .any(|step| step == FINDINGS_RECORDED_STEP)
+        {
+            return Ok(());
+        }
+
+        let publisher_login = review_port.authenticated_login().await?;
+        let marker = format!(
+            "{REVIEW_COMMENT_MARKER_PREFIX}{}{REVIEW_COMMENT_MARKER_SUFFIX}",
+            intent.intent_id
+        );
+        let body = render_formal_review_body(
+            pull_request_number,
+            &intent.intent_id,
+            &intent.run_id,
+            artifact,
+        );
+        let comments = render_review_comments(artifact);
+
+        let review_created = intent
+            .completed_steps
+            .iter()
+            .any(|step| step == REVIEW_CREATED_STEP);
+        let bound_identity = intent.review_id.is_some()
+            && intent.review_url.is_some()
+            && intent.publisher_login.is_some();
+        if bound_identity && !review_created {
+            let review_id = intent.review_id.as_deref().expect("bound review id");
+            let review_url = intent.review_url.as_deref().expect("bound review URL");
+            let publisher_login = intent
+                .publisher_login
+                .as_deref()
+                .expect("bound publisher login");
+            store.record_review_publication_step(
+                &intent.intent_id,
+                REVIEW_CREATED_STEP,
+                crate::triage::domain::PublicationStatus::Pending,
+                &serde_json::json!({
+                    "review_id": review_id,
+                    "review_url": review_url,
+                    "publisher_login": publisher_login,
+                }),
+            )?;
+        }
+
+        let review = if review_created || bound_identity {
+            None
+        } else if intent.review_id.is_some() {
+            None
+        } else {
+            let existing = review_port
+                .list_pull_request_reviews(pull_request_number, max_pages)
+                .await?;
+            let mut owned = None;
+            for candidate in existing.into_iter().filter(|review| {
+                review
+                    .body
+                    .as_deref()
+                    .is_some_and(|body| body.contains(&marker))
+            }) {
+                let author = candidate
+                    .user
+                    .as_ref()
+                    .map(|user| user.login.as_str())
+                    .unwrap_or_default();
+                if !author.eq_ignore_ascii_case(&publisher_login) {
+                    return Err(SymphonyError::TriageError(format!(
+                        "formal review marker {marker} is owned by another GitHub login {author}"
+                    )));
+                }
+                if candidate.commit_id != artifact.reviewed_head_sha {
+                    return Err(SymphonyError::TriageError(format!(
+                        "formal review marker {marker} conflict: head {} does not match expected {}",
+                        candidate.commit_id, artifact.reviewed_head_sha
+                    )));
+                }
+                if owned.is_some() {
+                    return Err(SymphonyError::TriageError(format!(
+                        "multiple formal reviews found for marker {marker}"
+                    )));
+                }
+                owned = Some(candidate);
+            }
+            if let Some(existing) = owned {
+                Some(existing)
+            } else {
+                Some(
+                    review_port
+                        .create_pull_request_review(
+                            pull_request_number,
+                            &artifact.reviewed_head_sha,
+                            &body,
+                            &comments,
+                        )
+                        .await?,
+                )
+            }
+        };
+
+        if let Some(review) = review {
+            let review_url = review.html_url.clone().unwrap_or_default();
+            store.bind_review_publication_review(
+                &intent.intent_id,
+                &review.id.to_string(),
+                &review_url,
+                &publisher_login,
+            )?;
+            store.record_review_publication_step(
+                &intent.intent_id,
+                REVIEW_CREATED_STEP,
+                crate::triage::domain::PublicationStatus::Pending,
+                &serde_json::json!({
+                    "review_id": review.id.to_string(),
+                    "review_url": review_url,
+                    "publisher_login": publisher_login,
+                }),
+            )?;
+        } else if !review_created && !bound_identity {
+            return Err(SymphonyError::TriageError(
+                "formal review has no forge identity to record".to_string(),
+            ));
+        }
+
+        store.record_review_publication_step(
+            &intent.intent_id,
+            FINDINGS_RECORDED_STEP,
+            crate::triage::domain::PublicationStatus::Pending,
+            &serde_json::json!({
+                "finding_count": artifact.finding_count,
+                "inline_comment_count": comments.len(),
+            }),
+        )?;
+        Ok(())
     }
 
     pub async fn publish_preview(
@@ -161,17 +372,58 @@ where
     }
 }
 
+fn render_review_comments(
+    artifact: &ReviewFindingsArtifactRecord,
+) -> Vec<GithubPullRequestReviewComment> {
+    artifact
+        .manifest
+        .findings
+        .iter()
+        .map(|finding| {
+            let end_line = finding.end_line.unwrap_or(finding.line);
+            let multiline = end_line > finding.line;
+            let severity = serde_json::to_string(&finding.severity)
+                .unwrap_or_else(|_| "\"unknown\"".to_string())
+                .trim_matches('"')
+                .to_string();
+            let category = serde_json::to_string(&finding.category)
+                .unwrap_or_else(|_| "\"unknown\"".to_string())
+                .trim_matches('"')
+                .to_string();
+            let mut body = format!(
+                "**{severity}** ({category})\n\n{}\n\n**Why:** {}\n\n**Suggested remediation:** {}",
+                finding.claim, finding.rationale, finding.remediation
+            );
+            if let Some(criterion) = finding.acceptance_criterion.as_deref() {
+                body.push_str(&format!("\n\n**Acceptance criterion:** {criterion}"));
+            }
+            GithubPullRequestReviewComment {
+                path: finding.path.clone(),
+                line: end_line,
+                side: "RIGHT".to_string(),
+                start_line: multiline.then_some(finding.line),
+                start_side: multiline.then_some("RIGHT".to_string()),
+                body,
+            }
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::github::client::{GithubIssueComment, GithubUser};
+    use crate::github::client::{
+        GithubIssueComment, GithubPullRequestReview, GithubPullRequestReviewComment, GithubUser,
+    };
     use crate::implementation::domain::{
         AcceptanceCriterionClaim, CriterionStatus, EvidenceKind, ExecutionProfile,
         ImplementationEvidence, ImplementationManifest, ImplementationPublicationKind,
         ManifestStatus,
     };
     use crate::review::domain::ReviewFindingsArtifactRecord;
-    use crate::review::manifest::ReviewFindingsManifest;
+    use crate::review::manifest::{
+        ReviewFinding, ReviewFindingCategory, ReviewFindingsManifest, ReviewSeverity,
+    };
     use crate::spec::domain::{SpecArtifact, SpecPublicationKind};
     use crate::triage::domain::PublicationStatus;
     use crate::triage::publisher::TriageCommentPort;
@@ -269,6 +521,63 @@ mod tests {
                     })?;
             comment.body = Some(body.to_string());
             Ok(comment.clone())
+        }
+    }
+
+    struct FakeReviews {
+        login: String,
+        reviews: Mutex<Vec<GithubPullRequestReview>>,
+        review_payloads: Mutex<Vec<(String, Vec<GithubPullRequestReviewComment>)>>,
+    }
+
+    impl FakeReviews {
+        fn new(login: &str) -> Arc<Self> {
+            Arc::new(Self {
+                login: login.to_string(),
+                reviews: Mutex::new(Vec::new()),
+                review_payloads: Mutex::new(Vec::new()),
+            })
+        }
+    }
+
+    #[async_trait]
+    impl ReviewPort for Arc<FakeReviews> {
+        async fn authenticated_login(&self) -> Result<String> {
+            Ok(self.login.clone())
+        }
+
+        async fn list_pull_request_reviews(
+            &self,
+            _number: u64,
+            _max_pages: u32,
+        ) -> Result<Vec<GithubPullRequestReview>> {
+            Ok(self.reviews.lock().unwrap().clone())
+        }
+
+        async fn create_pull_request_review(
+            &self,
+            _number: u64,
+            commit_id: &str,
+            body: &str,
+            comments: &[GithubPullRequestReviewComment],
+        ) -> Result<GithubPullRequestReview> {
+            self.review_payloads
+                .lock()
+                .unwrap()
+                .push((body.to_string(), comments.to_vec()));
+            let review = GithubPullRequestReview {
+                id: 900,
+                user: Some(GithubUser {
+                    login: self.login.clone(),
+                }),
+                body: Some(body.to_string()),
+                commit_id: commit_id.to_string(),
+                state: "COMMENTED".to_string(),
+                html_url: Some("https://github.test/reviews/900".to_string()),
+                submitted_at: None,
+            };
+            self.reviews.lock().unwrap().push(review.clone());
+            Ok(review)
         }
     }
 
@@ -625,6 +934,204 @@ mod tests {
             .unwrap();
         assert_eq!(unchanged.status, PublicationStatus::Pending);
         assert!(unchanged.completed_steps.is_empty());
+    }
+
+    #[tokio::test]
+    async fn formal_publication_sends_one_atomic_review_with_multiline_anchor() {
+        let (_dir, store) = open_store();
+        let comments = FakeComments::new("comment-bot");
+        let reviews = FakeReviews::new("symphony-bot");
+        let publisher = ReviewPublisher::new(comments.clone());
+        let (mut artifact, intent) = setup_review_fixture(&store, "automatic").await;
+        artifact.manifest.no_findings = false;
+        artifact.manifest.findings = vec![ReviewFinding {
+            finding_id: "f-1".to_string(),
+            severity: ReviewSeverity::Major,
+            category: ReviewFindingCategory::Correctness,
+            path: "src/lib.rs".to_string(),
+            line: 10,
+            end_line: Some(12),
+            claim: "The retry loses the error".to_string(),
+            rationale: "The error is discarded in the changed branch".to_string(),
+            remediation: "Return the original error".to_string(),
+            acceptance_criterion: None,
+            confidence: 0.9,
+        }];
+        artifact.finding_count = 1;
+
+        publisher
+            .publish_formal(&store, &reviews, &intent, &artifact, 42, 2)
+            .await
+            .unwrap();
+
+        let payloads = reviews.review_payloads.lock().unwrap();
+        assert_eq!(payloads.len(), 1);
+        assert!(payloads[0].0.contains("<!-- symphony:review:"));
+        assert!(payloads[0].0.contains("formal review"));
+        assert!(payloads[0].0.contains("Issue `#42`"));
+        assert!(payloads[0].0.contains(&artifact.spec_artifact_id));
+        assert!(payloads[0].0.contains("version `1`"));
+        assert!(payloads[0].0.contains(&artifact.run_id));
+        assert!(payloads[0]
+            .0
+            .contains("reviewed head `head` against base `base`"));
+        assert_eq!(payloads[0].1.len(), 1);
+        assert_eq!(payloads[0].1[0].line, 12);
+        assert_eq!(payloads[0].1[0].start_line, Some(10));
+        assert_eq!(payloads[0].1[0].start_side.as_deref(), Some("RIGHT"));
+        let persisted = store
+            .get_review_publication_intent(&intent.intent_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(persisted.status, PublicationStatus::Pending);
+        assert_eq!(persisted.review_id.as_deref(), Some("900"));
+        assert_eq!(persisted.publisher_login.as_deref(), Some("symphony-bot"));
+        assert_eq!(
+            persisted.completed_steps,
+            vec![REVIEW_CREATED_STEP, FINDINGS_RECORDED_STEP]
+        );
+    }
+
+    #[tokio::test]
+    async fn formal_publication_adopts_owned_marker_without_duplicate_create() {
+        let (_dir, store) = open_store();
+        let comments = FakeComments::new("comment-bot");
+        let reviews = FakeReviews::new("symphony-bot");
+        let publisher = ReviewPublisher::new(comments.clone());
+        let (artifact, intent) = setup_review_fixture(&store, "formal").await;
+
+        publisher
+            .publish_formal(&store, &reviews, &intent, &artifact, 42, 2)
+            .await
+            .unwrap();
+        publisher
+            .publish_formal(&store, &reviews, &intent, &artifact, 42, 2)
+            .await
+            .unwrap();
+
+        assert_eq!(reviews.review_payloads.lock().unwrap().len(), 1);
+        let persisted = store
+            .get_review_publication_intent(&intent.intent_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(persisted.status, PublicationStatus::Pending);
+        assert_eq!(
+            persisted.completed_steps,
+            vec![REVIEW_CREATED_STEP, FINDINGS_RECORDED_STEP]
+        );
+    }
+
+    #[tokio::test]
+    async fn formal_publication_recovers_bound_identity_before_recorded_step() {
+        let (_dir, store) = open_store();
+        let comments = FakeComments::new("symphony-bot");
+        let reviews = FakeReviews::new("symphony-bot");
+        let publisher = ReviewPublisher::new(comments);
+        let (artifact, intent) = setup_review_fixture(&store, "formal").await;
+        store
+            .bind_review_publication_review(
+                &intent.intent_id,
+                "review-17",
+                "https://github.test/reviews/17",
+                "symphony-bot",
+            )
+            .unwrap();
+        let bound = store
+            .get_review_publication_intent(&intent.intent_id)
+            .unwrap()
+            .unwrap();
+
+        publisher
+            .publish_formal(&store, &reviews, &bound, &artifact, 42, 2)
+            .await
+            .unwrap();
+
+        let persisted = store
+            .get_review_publication_intent(&intent.intent_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            persisted.completed_steps,
+            vec![REVIEW_CREATED_STEP, FINDINGS_RECORDED_STEP]
+        );
+        assert_eq!(persisted.review_id.as_deref(), Some("review-17"));
+        assert!(reviews.review_payloads.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn formal_publication_rejects_marker_with_stale_head() {
+        let (_dir, store) = open_store();
+        let comments = FakeComments::new("symphony-bot");
+        let reviews = FakeReviews::new("symphony-bot");
+        let publisher = ReviewPublisher::new(comments);
+        let (artifact, intent) = setup_review_fixture(&store, "formal").await;
+        let marker = format!(
+            "{REVIEW_COMMENT_MARKER_PREFIX}{}{REVIEW_COMMENT_MARKER_SUFFIX}",
+            intent.intent_id
+        );
+        reviews
+            .reviews
+            .lock()
+            .unwrap()
+            .push(GithubPullRequestReview {
+                id: 901,
+                user: Some(GithubUser {
+                    login: "symphony-bot".to_string(),
+                }),
+                body: Some(marker),
+                commit_id: "stale-head".to_string(),
+                state: "COMMENTED".to_string(),
+                html_url: Some("https://github.test/reviews/901".to_string()),
+                submitted_at: None,
+            });
+
+        let error = publisher
+            .publish_formal(&store, &reviews, &intent, &artifact, 42, 2)
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("conflict"));
+        assert!(reviews.review_payloads.lock().unwrap().is_empty());
+        assert!(store
+            .get_review_publication_intent(&intent.intent_id)
+            .unwrap()
+            .unwrap()
+            .completed_steps
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn formal_publication_rejects_foreign_marker_owner() {
+        let (_dir, store) = open_store();
+        let comments = FakeComments::new("symphony-bot");
+        let reviews = FakeReviews::new("symphony-bot");
+        let publisher = ReviewPublisher::new(comments.clone());
+        let (artifact, intent) = setup_review_fixture(&store, "automatic").await;
+        let marker = format!(
+            "{REVIEW_COMMENT_MARKER_PREFIX}{}{REVIEW_COMMENT_MARKER_SUFFIX}",
+            intent.intent_id
+        );
+        reviews
+            .reviews
+            .lock()
+            .unwrap()
+            .push(GithubPullRequestReview {
+                id: 901,
+                user: Some(GithubUser {
+                    login: "human".to_string(),
+                }),
+                body: Some(marker),
+                commit_id: "head".to_string(),
+                state: "COMMENTED".to_string(),
+                html_url: Some("https://github.test/reviews/901".to_string()),
+                submitted_at: None,
+            });
+
+        let error = publisher
+            .publish_formal(&store, &reviews, &intent, &artifact, 42, 2)
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("another GitHub login"));
+        assert!(reviews.review_payloads.lock().unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/apps/symphony/src/review/publisher.rs
+++ b/apps/symphony/src/review/publisher.rs
@@ -228,21 +228,42 @@ where
                     .pull_request_head_sha(pull_request_number)
                     .await?;
                 if live_head != artifact.reviewed_head_sha {
+                    store
+                        .clear_review_publication_lease(&intent.intent_id, &self.owner_instance)?;
                     return Err(SymphonyError::TriageError(format!(
-                        "formal review publication conflict: live head {} does not match expected {}",
+                        "review cycle reopened before formal review creation: live head {} does not match expected {}",
                         live_head, artifact.reviewed_head_sha
                     )));
                 }
-                Some(
-                    review_port
-                        .create_pull_request_review(
-                            pull_request_number,
-                            &artifact.reviewed_head_sha,
-                            &body,
-                            &comments,
-                        )
-                        .await?,
-                )
+                let created = match review_port
+                    .create_pull_request_review(
+                        pull_request_number,
+                        &artifact.reviewed_head_sha,
+                        &body,
+                        &comments,
+                    )
+                    .await
+                {
+                    Ok(review) => review,
+                    Err(error) => {
+                        let live_head =
+                            review_port.pull_request_head_sha(pull_request_number).await;
+                        if let Ok(live_head) = live_head {
+                            if live_head != artifact.reviewed_head_sha {
+                                store.clear_review_publication_lease(
+                                    &intent.intent_id,
+                                    &self.owner_instance,
+                                )?;
+                                return Err(SymphonyError::TriageError(format!(
+                                    "review cycle reopened during formal review creation: live head {} does not match expected {}",
+                                    live_head, artifact.reviewed_head_sha
+                                )));
+                            }
+                        }
+                        return Err(error);
+                    }
+                };
+                Some(created)
             }
         };
 
@@ -584,6 +605,7 @@ mod tests {
     struct FakeReviews {
         login: String,
         head_sha: Mutex<String>,
+        change_head_on_create: Mutex<bool>,
         reviews: Mutex<Vec<GithubPullRequestReview>>,
         review_payloads: Mutex<Vec<(String, Vec<GithubPullRequestReviewComment>)>>,
     }
@@ -593,6 +615,7 @@ mod tests {
             Arc::new(Self {
                 login: login.to_string(),
                 head_sha: Mutex::new("head".to_string()),
+                change_head_on_create: Mutex::new(false),
                 reviews: Mutex::new(Vec::new()),
                 review_payloads: Mutex::new(Vec::new()),
             })
@@ -624,6 +647,13 @@ mod tests {
             body: &str,
             comments: &[GithubPullRequestReviewComment],
         ) -> Result<GithubPullRequestReview> {
+            if *self.change_head_on_create.lock().unwrap() {
+                *self.head_sha.lock().unwrap() = "new-head".to_string();
+                return Err(SymphonyError::GithubApiStatus {
+                    status: 422,
+                    message: "head changed during create".to_string(),
+                });
+            }
             self.review_payloads
                 .lock()
                 .unwrap()
@@ -1278,6 +1308,22 @@ mod tests {
             .await
             .unwrap_err();
         assert!(error.to_string().contains("live head"));
+        assert!(reviews.review_payloads.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn formal_publication_waits_when_head_changes_during_create() {
+        let (_temp, store) = open_store();
+        let reviews = FakeReviews::new("symphony-bot");
+        *reviews.change_head_on_create.lock().unwrap() = true;
+        let publisher = ReviewPublisher::new(FakeComments::new("symphony-bot"));
+        let (artifact, intent) = setup_review_fixture(&store, "formal").await;
+
+        let error = publisher
+            .publish_formal(&store, &reviews, &intent, &artifact, 42, 2)
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("review cycle reopened"));
         assert!(reviews.review_payloads.lock().unwrap().is_empty());
     }
 

--- a/apps/symphony/src/triage/migrations/007_review_publication.sql
+++ b/apps/symphony/src/triage/migrations/007_review_publication.sql
@@ -1,0 +1,6 @@
+-- A4 PR2: durable formal review identity and routing projection.
+-- Additive only; existing preview publication rows remain valid.
+
+ALTER TABLE review_publication_intents ADD COLUMN review_id TEXT;
+ALTER TABLE review_publication_intents ADD COLUMN review_url TEXT;
+ALTER TABLE review_publication_intents ADD COLUMN route_state TEXT;

--- a/apps/symphony/src/triage/migrations/008_review_publication_lease.sql
+++ b/apps/symphony/src/triage/migrations/008_review_publication_lease.sql
@@ -1,0 +1,5 @@
+-- A4 PR2: durable cross-process publication lease.
+-- Additive only; lease ownership expires after a coordinator crash.
+
+ALTER TABLE review_publication_intents ADD COLUMN lease_owner TEXT;
+ALTER TABLE review_publication_intents ADD COLUMN lease_expires_at TEXT;

--- a/apps/symphony/src/triage/runtime.rs
+++ b/apps/symphony/src/triage/runtime.rs
@@ -617,10 +617,21 @@ impl SharedFactoryStore {
         self.with_store(|store| store.list_review_publications_for_run(run_id))
     }
 
+    #[cfg(test)]
     pub fn complete_review_publication(&self, intent_id: &str, step: &str) -> Result<()> {
         self.with_store_mut(|store| store.complete_review_publication(intent_id, step))
     }
 
+    pub fn complete_review_publication_owned(
+        &self,
+        intent_id: &str,
+        owner: &str,
+        step: &str,
+    ) -> Result<bool> {
+        self.with_store_mut(|store| store.complete_review_publication_owned(intent_id, owner, step))
+    }
+
+    #[cfg(test)]
     pub fn record_review_publication_step(
         &self,
         intent_id: &str,
@@ -633,6 +644,26 @@ impl SharedFactoryStore {
         })
     }
 
+    pub fn record_review_publication_step_owned(
+        &self,
+        intent_id: &str,
+        owner: &str,
+        step: &str,
+        status: PublicationStatus,
+        expected_projection: &serde_json::Value,
+    ) -> Result<bool> {
+        self.with_store_mut(|store| {
+            store.record_review_publication_step_owned(
+                intent_id,
+                owner,
+                step,
+                status,
+                expected_projection,
+            )
+        })
+    }
+
+    #[cfg(test)]
     pub fn bind_review_publication_review(
         &self,
         intent_id: &str,
@@ -645,6 +676,26 @@ impl SharedFactoryStore {
         })
     }
 
+    pub fn bind_review_publication_review_owned(
+        &self,
+        intent_id: &str,
+        owner: &str,
+        review_id: &str,
+        review_url: &str,
+        publisher_login: &str,
+    ) -> Result<bool> {
+        self.with_store_mut(|store| {
+            store.bind_review_publication_review_owned(
+                intent_id,
+                owner,
+                review_id,
+                review_url,
+                publisher_login,
+            )
+        })
+    }
+
+    #[cfg(test)]
     pub fn set_review_publication_route_state(
         &self,
         intent_id: &str,
@@ -655,6 +706,18 @@ impl SharedFactoryStore {
         })
     }
 
+    pub fn set_review_publication_route_state_owned(
+        &self,
+        intent_id: &str,
+        owner: &str,
+        route_state: &str,
+    ) -> Result<bool> {
+        self.with_store_mut(|store| {
+            store.set_review_publication_route_state_owned(intent_id, owner, route_state)
+        })
+    }
+
+    #[cfg(test)]
     pub fn bind_review_publication_comment(
         &self,
         intent_id: &str,
@@ -666,14 +729,52 @@ impl SharedFactoryStore {
         })
     }
 
+    pub fn bind_review_publication_comment_owned(
+        &self,
+        intent_id: &str,
+        owner: &str,
+        comment_id: &str,
+        publisher_login: &str,
+    ) -> Result<bool> {
+        self.with_store_mut(|store| {
+            store.bind_review_publication_comment_owned(
+                intent_id,
+                owner,
+                comment_id,
+                publisher_login,
+            )
+        })
+    }
+
+    #[cfg(test)]
     pub fn clear_review_publication_comment(&self, intent_id: &str) -> Result<()> {
         self.with_store_mut(|store| store.clear_review_publication_comment(intent_id))
+    }
+
+    pub fn clear_review_publication_comment_owned(
+        &self,
+        intent_id: &str,
+        owner: &str,
+    ) -> Result<bool> {
+        self.with_store_mut(|store| store.clear_review_publication_comment_owned(intent_id, owner))
     }
 
     pub fn clear_review_publication_lease(&self, intent_id: &str, owner: &str) -> Result<()> {
         self.with_store_mut(|store| store.clear_review_publication_lease(intent_id, owner))
     }
 
+    pub fn renew_review_publication_lease(
+        &self,
+        intent_id: &str,
+        owner: &str,
+        lease_seconds: i64,
+    ) -> Result<bool> {
+        self.with_store_mut(|store| {
+            store.renew_review_publication_lease(intent_id, owner, lease_seconds)
+        })
+    }
+
+    #[cfg(test)]
     pub fn set_review_publication_error(
         &self,
         intent_id: &str,
@@ -683,6 +784,30 @@ impl SharedFactoryStore {
         self.with_store_mut(|store| store.set_review_publication_error(intent_id, status, error))
     }
 
+    pub fn set_review_publication_error_owned(
+        &self,
+        intent_id: &str,
+        owner: &str,
+        status: PublicationStatus,
+        error: FactoryError,
+    ) -> Result<bool> {
+        self.with_store_mut(|store| {
+            store.set_review_publication_error_owned(intent_id, owner, status, error)
+        })
+    }
+
+    pub fn supersede_review_publication_owned(
+        &self,
+        intent_id: &str,
+        owner: &str,
+        error: FactoryError,
+    ) -> Result<bool> {
+        self.with_store_mut(|store| {
+            store.supersede_review_publication_owned(intent_id, owner, error)
+        })
+    }
+
+    #[cfg(test)]
     pub fn supersede_review_publication(
         &self,
         intent_id: &str,

--- a/apps/symphony/src/triage/runtime.rs
+++ b/apps/symphony/src/triage/runtime.rs
@@ -13,8 +13,8 @@ use crate::event_stream::EventHub;
 use crate::github::client::GithubClient;
 use crate::github::projects_v2::ProjectsV2Client;
 use crate::http_server::{
-    attach_implementation_http_response, attach_review_http_response, attach_spec_http_response,
-    factory_run_http_response, factory_run_metrics_http_response,
+    attach_implementation_http_response, attach_review_http_response_with_attempts,
+    attach_spec_http_response, factory_run_http_response, factory_run_metrics_http_response,
     implementation_run_metrics_http_response, review_run_metrics_http_response,
     spec_run_metrics_http_response, FactoryArtifactHttpResponse, FactoryRunHttpResponse,
     FactoryRunMetricsHttpResponse, FactoryRunQuery, ImplementationRunMetricsHttpResponse,
@@ -502,6 +502,26 @@ impl SharedFactoryStore {
         self.with_store(|store| store.list_a4_eligible_review_runs(max_attempts))
     }
 
+    pub fn review_artifact_exists_for_head(&self, run_id: &str, head_sha: &str) -> Result<bool> {
+        self.with_store(|store| store.review_artifact_exists_for_head(run_id, head_sha))
+    }
+
+    pub fn count_review_attempt_failures_for_head(
+        &self,
+        run_id: &str,
+        head_sha: &str,
+    ) -> Result<u32> {
+        self.with_store(|store| store.count_review_attempt_failures_for_head(run_id, head_sha))
+    }
+
+    pub fn get_orphaned_review_artifact_for_head(
+        &self,
+        run_id: &str,
+        head_sha: &str,
+    ) -> Result<Option<crate::review::domain::ReviewFindingsArtifactRecord>> {
+        self.with_store(|store| store.get_orphaned_review_artifact_for_head(run_id, head_sha))
+    }
+
     pub fn store_review_attempt_inputs(
         &self,
         request: crate::triage::store::StoreReviewAttemptRequest,
@@ -511,6 +531,14 @@ impl SharedFactoryStore {
 
     pub fn update_review_attempt(&self, request: UpdateReviewAttemptRequest<'_>) -> Result<()> {
         self.with_store_mut(|store| store.update_review_attempt(request))
+    }
+
+    pub fn interrupt_review_attempt(
+        &self,
+        stage_run_id: &str,
+        owner_instance: &str,
+    ) -> Result<bool> {
+        self.with_store_mut(|store| store.interrupt_attempt(stage_run_id, owner_instance))
     }
 
     pub fn store_review_artifact(
@@ -525,6 +553,13 @@ impl SharedFactoryStore {
         artifact_id: &str,
     ) -> Result<Option<crate::review::domain::ReviewFindingsArtifactRecord>> {
         self.with_store(|store| store.get_review_artifact(artifact_id))
+    }
+
+    pub fn list_review_finding_records_for_artifact(
+        &self,
+        artifact_id: &str,
+    ) -> Result<Vec<crate::review::domain::ReviewFindingRecord>> {
+        self.with_store(|store| store.list_review_finding_records_for_artifact(artifact_id))
     }
 
     pub fn create_review_publication_intent(
@@ -545,11 +580,32 @@ impl SharedFactoryStore {
         self.with_store(|store| store.list_pending_review_publications())
     }
 
+    pub fn list_blocked_review_publications(
+        &self,
+    ) -> Result<Vec<crate::review::domain::ReviewPublicationIntent>> {
+        self.with_store(|store| store.list_blocked_review_publications())
+    }
+
+    pub fn reset_blocked_review_publication(
+        &self,
+        intent_id: &str,
+        operator: &str,
+    ) -> Result<crate::review::domain::ReviewPublicationIntent> {
+        self.with_store_mut(|store| store.reset_blocked_review_publication(intent_id, operator))
+    }
+
     pub fn get_review_publication_intent(
         &self,
         intent_id: &str,
     ) -> Result<Option<crate::review::domain::ReviewPublicationIntent>> {
         self.with_store(|store| store.get_review_publication_intent(intent_id))
+    }
+
+    pub fn list_review_publications_for_run(
+        &self,
+        run_id: &str,
+    ) -> Result<Vec<crate::review::domain::ReviewPublicationIntent>> {
+        self.with_store(|store| store.list_review_publications_for_run(run_id))
     }
 
     pub fn complete_review_publication(&self, intent_id: &str, step: &str) -> Result<()> {
@@ -707,10 +763,11 @@ impl SharedFactoryStore {
                 .list_review_publications_for_run(&run.run_id)?
                 .into_iter()
                 .next();
-            attach_review_http_response(
+            attach_review_http_response_with_attempts(
                 &mut response,
                 review_artifact,
                 review_publication.as_ref(),
+                &attempts,
             );
             Ok(Some(response))
         })
@@ -973,28 +1030,67 @@ impl FactoryRunQuery for SharedFactoryStore {
     fn blocked_publications(
         &self,
     ) -> std::result::Result<Vec<crate::http_server::BlockedPublicationHttpResponse>, String> {
-        self.list_blocked_implementation_publications()
+        let mut intents = self
+            .list_blocked_implementation_publications()
             .map(|intents| {
                 intents
                     .into_iter()
-                    .map(
-                        |intent| crate::http_server::BlockedPublicationHttpResponse {
-                            intent_id: intent.intent_id,
-                            run_id: intent.run_id,
-                            kind: intent.kind.as_str().to_string(),
-                            retry_count: intent.retry_count,
-                            last_step: intent.completed_steps.last().cloned(),
-                            error_code: intent.last_error.as_ref().map(|error| error.code.clone()),
-                            error_remediation: intent
-                                .last_error
-                                .as_ref()
-                                .map(|error| error.remediation.clone()),
-                            updated_at: intent.updated_at,
-                        },
-                    )
-                    .collect()
+                    .map(|intent| {
+                        (
+                            intent.created_at,
+                            crate::http_server::BlockedPublicationHttpResponse {
+                                intent_id: intent.intent_id,
+                                run_id: intent.run_id,
+                                kind: intent.kind.as_str().to_string(),
+                                retry_count: intent.retry_count,
+                                last_step: intent.completed_steps.last().cloned(),
+                                error_code: intent
+                                    .last_error
+                                    .as_ref()
+                                    .map(|error| error.code.clone()),
+                                error_remediation: intent
+                                    .last_error
+                                    .as_ref()
+                                    .map(|error| error.remediation.clone()),
+                                updated_at: intent.updated_at,
+                            },
+                        )
+                    })
+                    .collect::<Vec<_>>()
             })
-            .map_err(|err| err.to_string())
+            .map_err(|err| err.to_string())?;
+        let review_intents = self
+            .list_blocked_review_publications()
+            .map(|intents| {
+                intents
+                    .into_iter()
+                    .map(|intent| {
+                        (
+                            intent.created_at,
+                            crate::http_server::BlockedPublicationHttpResponse {
+                                intent_id: intent.intent_id,
+                                run_id: intent.run_id,
+                                kind: intent.kind,
+                                retry_count: intent.retry_count,
+                                last_step: intent.completed_steps.last().cloned(),
+                                error_code: intent
+                                    .last_error
+                                    .as_ref()
+                                    .map(|error| error.code.clone()),
+                                error_remediation: intent
+                                    .last_error
+                                    .as_ref()
+                                    .map(|error| error.remediation.clone()),
+                                updated_at: intent.updated_at,
+                            },
+                        )
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .map_err(|err| err.to_string())?;
+        intents.extend(review_intents);
+        intents.sort_by_key(|(created_at, _)| *created_at);
+        Ok(intents.into_iter().map(|(_, intent)| intent).collect())
     }
 
     fn reset_blocked_publication(
@@ -1002,16 +1098,45 @@ impl FactoryRunQuery for SharedFactoryStore {
         intent_id: &str,
         operator: &str,
     ) -> std::result::Result<crate::http_server::BlockedPublicationResetHttpResponse, String> {
-        self.reset_blocked_implementation_publication(intent_id, operator)
-            .map(
-                |intent| crate::http_server::BlockedPublicationResetHttpResponse {
-                    intent_id: intent.intent_id,
-                    run_id: intent.run_id,
-                    status: intent.status.as_str().to_string(),
-                    completed_steps: intent.completed_steps,
-                },
-            )
-            .map_err(|err| err.to_string())
+        // Intent ids are globally unique, so locating the durable record selects
+        // the publication family without changing the HTTP contract.
+        if self
+            .get_implementation_publication_intent(intent_id)
+            .map_err(|err| err.to_string())?
+            .is_some()
+        {
+            return self
+                .reset_blocked_implementation_publication(intent_id, operator)
+                .map(
+                    |intent| crate::http_server::BlockedPublicationResetHttpResponse {
+                        intent_id: intent.intent_id,
+                        run_id: intent.run_id,
+                        status: intent.status.as_str().to_string(),
+                        completed_steps: intent.completed_steps,
+                    },
+                )
+                .map_err(|err| err.to_string());
+        }
+        if self
+            .get_review_publication_intent(intent_id)
+            .map_err(|err| err.to_string())?
+            .is_some()
+        {
+            return self
+                .reset_blocked_review_publication(intent_id, operator)
+                .map(
+                    |intent| crate::http_server::BlockedPublicationResetHttpResponse {
+                        intent_id: intent.intent_id,
+                        run_id: intent.run_id,
+                        status: intent.status.as_str().to_string(),
+                        completed_steps: intent.completed_steps,
+                    },
+                )
+                .map_err(|err| err.to_string());
+        }
+        Err(format!(
+            "implementation publication intent {intent_id} not found"
+        ))
     }
 
     fn get_artifact(
@@ -1643,6 +1768,7 @@ impl TriageRuntime {
                             attempts_failed = summary.attempts_failed,
                             waiting = summary.waiting,
                             preview_published = summary.preview_published,
+                            automatic_published = summary.automatic_published,
                             blocked = summary.blocked,
                             "review poll completed"
                         );
@@ -1659,5 +1785,58 @@ impl TriageRuntime {
         }
         self.reconcile_factory_sessions();
         Ok(triage)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::http_server::FactoryRunQuery;
+    use rusqlite::params;
+
+    #[test]
+    fn factory_query_lists_and_resets_review_blocked_publications() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("factory.db");
+        let store = SharedFactoryStore::open(&path, 5_000).unwrap();
+        let mut db = store.inner.lock().unwrap();
+        db.connection_for_test()
+            .execute_batch("PRAGMA foreign_keys = OFF")
+            .unwrap();
+        let now = chrono::Utc::now().to_rfc3339();
+        let error = serde_json::json!({
+            "code": "review_publication_retry_exhausted",
+            "component": "review_publication",
+            "remediation": "restore forge access",
+            "retryable": false
+        })
+        .to_string();
+        db.connection_for_test()
+            .execute(
+                "INSERT INTO review_publication_intents (
+                    intent_id, run_id, artifact_id, kind, status,
+                    completed_steps_json, retry_count, last_error_json,
+                    desired_effects_json, observed_baseline_json,
+                    expected_projection_json, created_at, updated_at
+                 ) VALUES ('review-blocked', 'run-review', 'artifact-review',
+                    'formal', 'blocked', '[\"review_created\"]', 3, ?1,
+                    '{}', '{}', '{}', ?2, ?2)",
+                params![error, now],
+            )
+            .unwrap();
+        drop(db);
+
+        let blocked = FactoryRunQuery::blocked_publications(&store).unwrap();
+        assert_eq!(blocked.len(), 1);
+        assert_eq!(blocked[0].kind, "formal");
+        assert_eq!(blocked[0].last_step.as_deref(), Some("review_created"));
+
+        let reset =
+            FactoryRunQuery::reset_blocked_publication(&store, "review-blocked", "ada").unwrap();
+        assert_eq!(reset.status, "pending");
+        assert_eq!(reset.completed_steps, vec!["review_created"]);
+        assert!(FactoryRunQuery::blocked_publications(&store)
+            .unwrap()
+            .is_empty());
     }
 }

--- a/apps/symphony/src/triage/runtime.rs
+++ b/apps/symphony/src/triage/runtime.rs
@@ -1280,9 +1280,7 @@ impl FactoryRunQuery for SharedFactoryStore {
                 )
                 .map_err(|err| err.to_string());
         }
-        Err(format!(
-            "implementation publication intent {intent_id} not found"
-        ))
+        Err(format!("publication intent {intent_id} not found"))
     }
 
     fn get_artifact(

--- a/apps/symphony/src/triage/runtime.rs
+++ b/apps/symphony/src/triage/runtime.rs
@@ -556,6 +556,40 @@ impl SharedFactoryStore {
         self.with_store_mut(|store| store.complete_review_publication(intent_id, step))
     }
 
+    pub fn record_review_publication_step(
+        &self,
+        intent_id: &str,
+        step: &str,
+        status: PublicationStatus,
+        expected_projection: &serde_json::Value,
+    ) -> Result<()> {
+        self.with_store_mut(|store| {
+            store.record_review_publication_step(intent_id, step, status, expected_projection)
+        })
+    }
+
+    pub fn bind_review_publication_review(
+        &self,
+        intent_id: &str,
+        review_id: &str,
+        review_url: &str,
+        publisher_login: &str,
+    ) -> Result<()> {
+        self.with_store_mut(|store| {
+            store.bind_review_publication_review(intent_id, review_id, review_url, publisher_login)
+        })
+    }
+
+    pub fn set_review_publication_route_state(
+        &self,
+        intent_id: &str,
+        route_state: &str,
+    ) -> Result<()> {
+        self.with_store_mut(|store| {
+            store.set_review_publication_route_state(intent_id, route_state)
+        })
+    }
+
     pub fn bind_review_publication_comment(
         &self,
         intent_id: &str,

--- a/apps/symphony/src/triage/runtime.rs
+++ b/apps/symphony/src/triage/runtime.rs
@@ -683,7 +683,11 @@ impl SharedFactoryStore {
         self.with_store_mut(|store| store.set_review_publication_error(intent_id, status, error))
     }
 
-    pub fn supersede_review_publication(&self, intent_id: &str, error: FactoryError) -> Result<()> {
+    pub fn supersede_review_publication(
+        &self,
+        intent_id: &str,
+        error: FactoryError,
+    ) -> Result<bool> {
         self.with_store_mut(|store| store.supersede_review_publication(intent_id, error))
     }
 

--- a/apps/symphony/src/triage/runtime.rs
+++ b/apps/symphony/src/triage/runtime.rs
@@ -574,6 +574,15 @@ impl SharedFactoryStore {
         })
     }
 
+    pub fn claim_review_publication(
+        &self,
+        intent_id: &str,
+        owner: &str,
+        lease_seconds: i64,
+    ) -> Result<bool> {
+        self.with_store_mut(|store| store.claim_review_publication(intent_id, owner, lease_seconds))
+    }
+
     pub fn list_pending_review_publications(
         &self,
     ) -> Result<Vec<crate::review::domain::ReviewPublicationIntent>> {
@@ -659,6 +668,10 @@ impl SharedFactoryStore {
 
     pub fn clear_review_publication_comment(&self, intent_id: &str) -> Result<()> {
         self.with_store_mut(|store| store.clear_review_publication_comment(intent_id))
+    }
+
+    pub fn clear_review_publication_lease(&self, intent_id: &str, owner: &str) -> Result<()> {
+        self.with_store_mut(|store| store.clear_review_publication_lease(intent_id, owner))
     }
 
     pub fn set_review_publication_error(
@@ -1824,17 +1837,38 @@ mod tests {
                 params![error, now],
             )
             .unwrap();
+        db.connection_for_test()
+            .execute(
+                "INSERT INTO review_publication_intents (
+                    intent_id, run_id, artifact_id, kind, status,
+                    completed_steps_json, retry_count, last_error_json,
+                    desired_effects_json, observed_baseline_json,
+                    expected_projection_json, created_at, updated_at
+                 ) VALUES ('review-conflict', 'run-review', 'artifact-conflict',
+                    'formal', 'conflict', '[\"review_created\"]', 2, ?1,
+                    '{}', '{}', '{}', ?2, ?2)",
+                params![error, now],
+            )
+            .unwrap();
         drop(db);
 
         let blocked = FactoryRunQuery::blocked_publications(&store).unwrap();
-        assert_eq!(blocked.len(), 1);
-        assert_eq!(blocked[0].kind, "formal");
-        assert_eq!(blocked[0].last_step.as_deref(), Some("review_created"));
+        assert_eq!(blocked.len(), 2);
+        assert!(blocked
+            .iter()
+            .any(|intent| intent.intent_id == "review-blocked"));
+        assert!(blocked
+            .iter()
+            .any(|intent| intent.intent_id == "review-conflict"));
 
         let reset =
             FactoryRunQuery::reset_blocked_publication(&store, "review-blocked", "ada").unwrap();
         assert_eq!(reset.status, "pending");
         assert_eq!(reset.completed_steps, vec!["review_created"]);
+
+        let conflict_reset =
+            FactoryRunQuery::reset_blocked_publication(&store, "review-conflict", "ada").unwrap();
+        assert_eq!(conflict_reset.status, "pending");
         assert!(FactoryRunQuery::blocked_publications(&store)
             .unwrap()
             .is_empty());

--- a/apps/symphony/src/triage/runtime.rs
+++ b/apps/symphony/src/triage/runtime.rs
@@ -683,6 +683,10 @@ impl SharedFactoryStore {
         self.with_store_mut(|store| store.set_review_publication_error(intent_id, status, error))
     }
 
+    pub fn supersede_review_publication(&self, intent_id: &str, error: FactoryError) -> Result<()> {
+        self.with_store_mut(|store| store.supersede_review_publication(intent_id, error))
+    }
+
     pub fn review_metrics(&self) -> Result<crate::review::domain::ReviewMetricsAggregate> {
         self.with_store(|store| store.review_metrics())
     }

--- a/apps/symphony/src/triage/store.rs
+++ b/apps/symphony/src/triage/store.rs
@@ -4504,6 +4504,36 @@ impl SqliteFactoryStore {
         Ok(())
     }
 
+    /// Terminalize a publication intent whose artifact head was superseded by
+    /// a newer review cycle without charging the publication retry budget.
+    pub fn supersede_review_publication(
+        &mut self,
+        intent_id: &str,
+        error: FactoryError,
+    ) -> Result<()> {
+        let changed = self
+            .conn
+            .execute(
+                "UPDATE review_publication_intents SET status = ?1,
+                 last_error_json = ?2, lease_owner = NULL, lease_expires_at = NULL,
+                 updated_at = ?3
+                 WHERE intent_id = ?4",
+                params![
+                    PublicationStatus::Conflict.as_str(),
+                    bounded_json(&error)?,
+                    ts(Self::now()),
+                    intent_id,
+                ],
+            )
+            .map_err(storage_error)?;
+        if changed == 0 {
+            return Err(SymphonyError::StorageError(format!(
+                "review intent {intent_id} not found"
+            )));
+        }
+        Ok(())
+    }
+
     pub fn review_metrics(&self) -> Result<ReviewMetricsAggregate> {
         use crate::triage::domain::{TriageMetricsDuration, TriageMetricsTokenTotals};
         use std::collections::BTreeMap;
@@ -7058,6 +7088,56 @@ mod tests {
             .reset_blocked_review_publication("review-blocked", "operator")
             .unwrap_err();
         assert!(err.to_string().contains("not blocked"));
+    }
+
+    #[test]
+    fn superseding_review_publication_preserves_retry_budget() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("state.db");
+        let mut store = store(&path);
+        let now = Utc::now().to_rfc3339();
+        store
+            .conn
+            .execute_batch("PRAGMA foreign_keys = OFF")
+            .unwrap();
+        store
+            .conn
+            .execute(
+                "INSERT INTO review_publication_intents (
+                    intent_id, run_id, artifact_id, kind, status,
+                    completed_steps_json, retry_count, desired_effects_json,
+                    observed_baseline_json, expected_projection_json,
+                    created_at, updated_at
+                 ) VALUES ('review-superseded', 'run-review', 'artifact-review',
+                    'automatic', 'pending', '[]', 0, '{}', '{}', '{}', ?1, ?1)",
+                params![now],
+            )
+            .unwrap();
+
+        store
+            .supersede_review_publication(
+                "review-superseded",
+                FactoryError::new(
+                    "review_publication_superseded",
+                    "review_publisher",
+                    "new head opened a review cycle",
+                    false,
+                    None,
+                ),
+            )
+            .unwrap();
+
+        let intent = store
+            .get_review_publication_intent("review-superseded")
+            .unwrap()
+            .unwrap();
+        assert_eq!(intent.status, PublicationStatus::Conflict);
+        assert_eq!(intent.retry_count, 0);
+        assert_eq!(
+            intent.last_error.unwrap().code,
+            "review_publication_superseded"
+        );
+        assert!(store.list_pending_review_publications().unwrap().is_empty());
     }
 
     #[test]

--- a/apps/symphony/src/triage/store.rs
+++ b/apps/symphony/src/triage/store.rs
@@ -38,7 +38,7 @@ use std::time::Duration as StdDuration;
 use uuid::Uuid;
 
 /// Embedded migrations, applied in order while the exclusive store lock is held.
-const MIGRATIONS: [&str; 7] = [
+const MIGRATIONS: [&str; 8] = [
     include_str!("migrations/001_init.sql"),
     include_str!("migrations/002_route_observations.sql"),
     include_str!("migrations/003_spec_stage.sql"),
@@ -46,6 +46,7 @@ const MIGRATIONS: [&str; 7] = [
     include_str!("migrations/005_implementation_draft_pr.sql"),
     include_str!("migrations/006_review_stage.sql"),
     include_str!("migrations/007_review_publication.sql"),
+    include_str!("migrations/008_review_publication_lease.sql"),
 ];
 
 #[derive(Debug, Clone)]
@@ -508,7 +509,7 @@ impl SqliteFactoryStore {
         conn.busy_timeout(StdDuration::from_millis(busy_timeout_ms))
             .map_err(storage_error)?;
         for (index, migration) in MIGRATIONS.iter().enumerate() {
-            if index == 6 {
+            if index >= 6 {
                 apply_review_publication_migration(&conn, migration).map_err(storage_error)?;
             } else {
                 conn.execute_batch(migration).map_err(storage_error)?;
@@ -3624,6 +3625,7 @@ impl SqliteFactoryStore {
                  JOIN spec_run_state s ON s.run_id = r.run_id
                     AND s.approved_artifact_id IS NOT NULL
                  WHERE s.decision = 'approved'
+                   AND d.draft = 1
                    AND NOT EXISTS (
                      SELECT 1 FROM stage_runs sr
                      WHERE sr.run_id = r.run_id AND sr.stage = ?1
@@ -4120,6 +4122,46 @@ impl SqliteFactoryStore {
             })
     }
 
+    /// Claim a pending formal publication before any forge side effect.
+    ///
+    /// The conditional update is the cross-process compare-and-set. An
+    /// expired lease is reclaimable after a coordinator crash; an active lease
+    /// belongs exclusively to its current publisher.
+    pub fn claim_review_publication(
+        &mut self,
+        intent_id: &str,
+        owner: &str,
+        lease_seconds: i64,
+    ) -> Result<bool> {
+        let now = Self::now();
+        let now_s = ts(now);
+        let expires_s = ts(now + Duration::seconds(lease_seconds.max(1)));
+        let changed = self
+            .conn
+            .execute(
+                "UPDATE review_publication_intents
+                 SET lease_owner = ?1, lease_expires_at = ?2, updated_at = ?3
+                 WHERE intent_id = ?4 AND status = 'pending'
+                   AND (lease_owner IS NULL OR lease_expires_at IS NULL
+                        OR lease_expires_at <= ?3)",
+                params![owner, expires_s, now_s, intent_id],
+            )
+            .map_err(storage_error)?;
+        Ok(changed == 1)
+    }
+
+    pub fn clear_review_publication_lease(&mut self, intent_id: &str, owner: &str) -> Result<()> {
+        self.conn
+            .execute(
+                "UPDATE review_publication_intents
+                 SET lease_owner = NULL, lease_expires_at = NULL, updated_at = ?1
+                 WHERE intent_id = ?2 AND lease_owner = ?3",
+                params![ts(Self::now()), intent_id, owner],
+            )
+            .map_err(storage_error)?;
+        Ok(())
+    }
+
     pub fn get_review_publication_intent(
         &self,
         intent_id: &str,
@@ -4159,7 +4201,7 @@ impl SqliteFactoryStore {
             .map_err(storage_error)
     }
 
-    /// List review publication intents terminalized as `blocked`, oldest first.
+    /// List review publication intents terminalized as `blocked` or `conflict`, oldest first.
     pub fn list_blocked_review_publications(&self) -> Result<Vec<ReviewPublicationIntent>> {
         let mut stmt = self
             .conn
@@ -4169,7 +4211,8 @@ impl SqliteFactoryStore {
                     publisher_login, review_id, review_url, route_state,
                     desired_effects_json, observed_baseline_json,
                     expected_projection_json, created_at, updated_at
-                 FROM review_publication_intents WHERE status = 'blocked'
+                 FROM review_publication_intents
+                 WHERE status IN ('blocked', 'conflict')
                  ORDER BY created_at ASC",
             )
             .map_err(storage_error)?;
@@ -4180,8 +4223,8 @@ impl SqliteFactoryStore {
             .map_err(storage_error)
     }
 
-    /// Return a blocked review publication intent to pending for operator
-    /// recovery. Completed steps and forge identities are preserved.
+    /// Return a blocked or conflict review publication intent to pending for
+    /// operator recovery. Completed steps and forge identities are preserved.
     pub fn reset_blocked_review_publication(
         &mut self,
         intent_id: &str,
@@ -4192,10 +4235,13 @@ impl SqliteFactoryStore {
                 "review publication intent {intent_id} not found"
             )));
         };
-        if intent.status != PublicationStatus::Blocked {
+        if !matches!(
+            intent.status,
+            PublicationStatus::Blocked | PublicationStatus::Conflict
+        ) {
             return Err(SymphonyError::TriageError(format!(
                 "review publication intent {intent_id} is {}, not blocked; \
-                 only a blocked intent can be reset",
+                 only a blocked or conflict intent can be reset",
                 intent.status.as_str()
             )));
         }
@@ -4211,14 +4257,10 @@ impl SqliteFactoryStore {
         let changed = tx
             .execute(
                 "UPDATE review_publication_intents
-                 SET status = ?1, last_error_json = NULL, retry_count = 0, updated_at = ?2
-                 WHERE intent_id = ?3 AND status = ?4",
-                params![
-                    PublicationStatus::Pending.as_str(),
-                    ts(now),
-                    intent_id,
-                    PublicationStatus::Blocked.as_str(),
-                ],
+                 SET status = ?1, last_error_json = NULL, retry_count = 0,
+                     lease_owner = NULL, lease_expires_at = NULL, updated_at = ?2
+                 WHERE intent_id = ?3 AND status IN ('blocked', 'conflict')",
+                params![PublicationStatus::Pending.as_str(), ts(now), intent_id],
             )
             .map_err(storage_error)?;
         if changed == 0 {
@@ -4388,7 +4430,10 @@ impl SqliteFactoryStore {
             .execute(
                 "UPDATE review_publication_intents
                  SET completed_steps_json = ?1, status = ?2, last_error_json = NULL,
-                     expected_projection_json = ?3, updated_at = ?4
+                     expected_projection_json = ?3,
+                     lease_owner = CASE WHEN ?6 = 'applied' THEN NULL ELSE lease_owner END,
+                     lease_expires_at = CASE WHEN ?6 = 'applied' THEN NULL ELSE lease_expires_at END,
+                     updated_at = ?4
                  WHERE intent_id = ?5",
                 params![
                     bounded_json(&steps)?,
@@ -4396,6 +4441,7 @@ impl SqliteFactoryStore {
                     bounded_json(expected_projection)?,
                     ts(Self::now()),
                     intent_id,
+                    next_status.as_str(),
                 ],
             )
             .map_err(storage_error)?;
@@ -4440,7 +4486,8 @@ impl SqliteFactoryStore {
             .execute(
                 "UPDATE review_publication_intents SET status = ?1,
                     last_error_json = ?2, retry_count = retry_count + 1,
-                    updated_at = ?3 WHERE intent_id = ?4",
+                    lease_owner = NULL, lease_expires_at = NULL, updated_at = ?3
+                    WHERE intent_id = ?4",
                 params![
                     status.as_str(),
                     bounded_json(&error)?,
@@ -5982,6 +6029,48 @@ mod tests {
                 params![now],
             )
             .unwrap();
+        // A published non-draft PR artifact for the same run must not enter the
+        // A4 queue, which only reviews draft PRs.
+        store
+            .conn
+            .execute(
+                "INSERT INTO implementation_artifacts (
+                    artifact_id, run_id, stage_run_id, approved_artifact_id,
+                    approved_version, issue_revision, configuration_revision,
+                    schema_version, manifest_json, base_commit, approved_spec_path,
+                    validation_cycles, execution_profile, received_at, bytes_len
+                 ) VALUES ('non-draft-implementation', 'run-review',
+                    'implementation-stage-non-draft', 'spec-artifact', 1, 'issue-rev',
+                    'config-rev-non-draft', 1, '{}', 'base', 'spec.md', 1, 'default', ?1, 1)",
+                params![now],
+            )
+            .unwrap();
+        store
+            .conn
+            .execute(
+                "INSERT INTO implementation_publication_intents (
+                    intent_id, run_id, artifact_id, kind, status,
+                    completed_steps_json, desired_effects_json, observed_baseline_json,
+                    expected_projection_json, created_at, updated_at
+                 ) VALUES ('non-draft-implementation-intent', 'run-review',
+                    'non-draft-implementation', 'draft_pr', 'applied', '[]', '{}', '{}',
+                    '{}', ?1, ?1)",
+                params![now],
+            )
+            .unwrap();
+        store
+            .conn
+            .execute(
+                "INSERT INTO implementation_draft_pr_artifacts (
+                    artifact_id, run_id, implementation_artifact_id, intent_id,
+                    number, url, draft, head, base, head_sha, marker, created_at
+                 ) VALUES ('non-draft-artifact', 'run-review', 'non-draft-implementation',
+                    'non-draft-implementation-intent', 43,
+                    'https://github.com/owner/repo/pull/43', 0, 'feature', 'main',
+                    'new-head', 'marker-non-draft', ?1)",
+                params![now],
+            )
+            .unwrap();
         for (attempt_id, stage_run_id, status) in [
             ("failed-1", "stage-failed-1", "failed"),
             ("blocked-1", "stage-blocked-1", "blocked"),
@@ -6003,6 +6092,8 @@ mod tests {
 
         let candidates = store.list_a4_eligible_review_runs(2).unwrap();
         assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].draft_pr_artifact_id, "draft-artifact");
+        assert!(candidates[0].draft);
         assert_eq!(candidates[0].head_sha, "old-head");
         assert_eq!(
             store
@@ -6898,12 +6989,41 @@ mod tests {
                 ],
             )
             .unwrap();
+        store
+            .conn
+            .execute(
+                "INSERT INTO review_publication_intents (
+                    intent_id, run_id, artifact_id, kind, status,
+                    completed_steps_json, retry_count, last_error_json,
+                    desired_effects_json, observed_baseline_json,
+                    expected_projection_json, created_at, updated_at
+                 ) VALUES ('review-conflict', 'run-review', 'artifact-conflict',
+                    'formal', 'conflict', '[\"review_created\"]', 2,
+                    ?1, '{}', '{}', '{}', ?2, ?2)",
+                params![
+                    serde_json::json!({
+                        "code": "review_publication_conflict",
+                        "component": "review_publication",
+                        "remediation": "reconcile the forge review",
+                        "retryable": false
+                    })
+                    .to_string(),
+                    now,
+                ],
+            )
+            .unwrap();
 
         let blocked = store.list_blocked_review_publications().unwrap();
-        assert_eq!(blocked.len(), 1);
-        assert_eq!(blocked[0].intent_id, "review-blocked");
-        assert_eq!(blocked[0].completed_steps, ["review_created"]);
-        assert_eq!(blocked[0].retry_count, 4);
+        assert_eq!(blocked.len(), 2);
+        let blocked_intent = blocked
+            .iter()
+            .find(|intent| intent.intent_id == "review-blocked")
+            .unwrap();
+        assert_eq!(blocked_intent.completed_steps, ["review_created"]);
+        assert_eq!(blocked_intent.retry_count, 4);
+        assert!(blocked.iter().any(|intent| {
+            intent.intent_id == "review-conflict" && intent.status == PublicationStatus::Conflict
+        }));
 
         let reset = store
             .reset_blocked_review_publication("review-blocked", "operator")
@@ -6924,12 +7044,58 @@ mod tests {
             .unwrap();
         assert_eq!(event_type, "review_publication_reset");
         assert!(payload.contains("\"operator\":\"operator\""));
+        let remaining = store.list_blocked_review_publications().unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].intent_id, "review-conflict");
+
+        let conflict_reset = store
+            .reset_blocked_review_publication("review-conflict", "operator")
+            .unwrap();
+        assert_eq!(conflict_reset.status, PublicationStatus::Pending);
         assert!(store.list_blocked_review_publications().unwrap().is_empty());
 
         let err = store
             .reset_blocked_review_publication("review-blocked", "operator")
             .unwrap_err();
         assert!(err.to_string().contains("not blocked"));
+    }
+
+    #[test]
+    fn review_publication_claim_is_single_owner_until_released_or_expired() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("state.db");
+        let mut store = store(&path);
+        let now = Utc::now().to_rfc3339();
+        store
+            .conn
+            .execute_batch("PRAGMA foreign_keys = OFF")
+            .unwrap();
+        store
+            .conn
+            .execute(
+                "INSERT INTO review_publication_intents (
+                    intent_id, run_id, artifact_id, kind, status,
+                    completed_steps_json, desired_effects_json,
+                    observed_baseline_json, expected_projection_json,
+                    created_at, updated_at
+                 ) VALUES ('review-lease', 'run-review', 'artifact-review',
+                    'formal', 'pending', '[]', '{}', '{}', '{}', ?1, ?1)",
+                params![now],
+            )
+            .unwrap();
+
+        assert!(store
+            .claim_review_publication("review-lease", "owner-a", 900)
+            .unwrap());
+        assert!(!store
+            .claim_review_publication("review-lease", "owner-b", 900)
+            .unwrap());
+        store
+            .clear_review_publication_lease("review-lease", "owner-a")
+            .unwrap();
+        assert!(store
+            .claim_review_publication("review-lease", "owner-b", 900)
+            .unwrap());
     }
 
     #[test]

--- a/apps/symphony/src/triage/store.rs
+++ b/apps/symphony/src/triage/store.rs
@@ -4510,28 +4510,44 @@ impl SqliteFactoryStore {
         &mut self,
         intent_id: &str,
         error: FactoryError,
-    ) -> Result<()> {
+    ) -> Result<bool> {
+        let now = Self::now();
+        let now_s = ts(now);
         let changed = self
             .conn
             .execute(
                 "UPDATE review_publication_intents SET status = ?1,
                  last_error_json = ?2, lease_owner = NULL, lease_expires_at = NULL,
                  updated_at = ?3
-                 WHERE intent_id = ?4",
+                 WHERE intent_id = ?4 AND status = ?5
+                   AND (lease_owner IS NULL OR lease_expires_at IS NULL OR lease_expires_at < ?3)",
                 params![
                     PublicationStatus::Conflict.as_str(),
                     bounded_json(&error)?,
-                    ts(Self::now()),
+                    now_s,
                     intent_id,
+                    PublicationStatus::Pending.as_str(),
                 ],
             )
             .map_err(storage_error)?;
-        if changed == 0 {
+        if changed > 0 {
+            return Ok(true);
+        }
+        let exists: Option<String> = self
+            .conn
+            .query_row(
+                "SELECT status FROM review_publication_intents WHERE intent_id = ?1",
+                params![intent_id],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(storage_error)?;
+        if exists.is_none() {
             return Err(SymphonyError::StorageError(format!(
                 "review intent {intent_id} not found"
             )));
         }
-        Ok(())
+        Ok(false)
     }
 
     pub fn review_metrics(&self) -> Result<ReviewMetricsAggregate> {
@@ -7114,7 +7130,7 @@ mod tests {
             )
             .unwrap();
 
-        store
+        assert!(store
             .supersede_review_publication(
                 "review-superseded",
                 FactoryError::new(
@@ -7125,7 +7141,19 @@ mod tests {
                     None,
                 ),
             )
-            .unwrap();
+            .unwrap());
+        assert!(!store
+            .supersede_review_publication(
+                "review-superseded",
+                FactoryError::new(
+                    "review_publication_superseded_again",
+                    "review_publisher",
+                    "a stale caller must not overwrite terminal state",
+                    false,
+                    None,
+                ),
+            )
+            .unwrap());
 
         let intent = store
             .get_review_publication_intent("review-superseded")

--- a/apps/symphony/src/triage/store.rs
+++ b/apps/symphony/src/triage/store.rs
@@ -8,9 +8,10 @@ use crate::implementation::domain::{
     ValidationCycleRecord, IMPLEMENTATION_STAGE_NAME,
 };
 use crate::review::domain::{
-    ReviewAttemptRecord, ReviewFindingsArtifactRecord, ReviewMetricsAggregate,
+    ReviewAttemptRecord, ReviewFindingRecord, ReviewFindingsArtifactRecord, ReviewMetricsAggregate,
     ReviewPublicationIntent, REVIEW_STAGE_NAME,
 };
+use crate::review::findings::finding_identity_key;
 use crate::review::manifest::ReviewFindingsManifest;
 use crate::spec::artifact::validate_spec;
 use crate::spec::domain::{
@@ -30,6 +31,7 @@ use crate::triage::storage_path::lock_path_for_storage;
 use chrono::{DateTime, Duration, Utc};
 use fs2::FileExt;
 use rusqlite::{params, Connection, OptionalExtension};
+use std::collections::HashSet;
 use std::fs::{File, OpenOptions};
 use std::path::Path;
 use std::time::Duration as StdDuration;
@@ -475,6 +477,11 @@ pub struct SqliteFactoryStore {
 }
 
 impl SqliteFactoryStore {
+    #[cfg(test)]
+    pub(crate) fn connection_for_test(&mut self) -> &mut Connection {
+        &mut self.conn
+    }
+
     pub fn acquire_lock_and_migrate(
         path: &Path,
         busy_timeout_ms: u64,
@@ -3599,7 +3606,7 @@ impl SqliteFactoryStore {
     /// publication facts and applies the single-owner/head-cycle guards.
     pub fn list_a4_eligible_review_runs(
         &self,
-        max_attempts: u32,
+        _max_attempts: u32,
     ) -> Result<Vec<A4EligibleReviewRun>> {
         let mut stmt = self
             .conn
@@ -3618,25 +3625,15 @@ impl SqliteFactoryStore {
                     AND s.approved_artifact_id IS NOT NULL
                  WHERE s.decision = 'approved'
                    AND NOT EXISTS (
-                     SELECT 1 FROM review_findings_artifacts a
-                     WHERE a.run_id = r.run_id AND a.reviewed_head_sha = d.head_sha
-                   )
-                   AND NOT EXISTS (
                      SELECT 1 FROM stage_runs sr
                      WHERE sr.run_id = r.run_id AND sr.stage = ?1
                        AND sr.status IN ('pending', 'running')
                    )
-                   AND (
-                     SELECT COUNT(*) FROM review_attempts ra
-                     WHERE ra.run_id = r.run_id
-                       AND ra.reviewed_head_sha = d.head_sha
-                       AND ra.status IN ('failed', 'blocked', 'interrupted')
-                   ) < ?2
                  ORDER BY r.updated_at ASC, d.created_at ASC",
             )
             .map_err(storage_error)?;
         let rows = stmt
-            .query_map(params![REVIEW_STAGE_NAME, max_attempts.max(1)], |row| {
+            .query_map(params![REVIEW_STAGE_NAME], |row| {
                 let draft: i64 = row.get(10)?;
                 Ok(A4EligibleReviewRun {
                     run_id: row.get(0)?,
@@ -3657,6 +3654,24 @@ impl SqliteFactoryStore {
             })
             .map_err(storage_error)?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(storage_error)
+    }
+
+    /// Count review attempts that consume the retry budget for one live PR
+    /// head. Interrupted attempts remain recoverable work and do not count.
+    pub fn count_review_attempt_failures_for_head(
+        &self,
+        run_id: &str,
+        reviewed_head_sha: &str,
+    ) -> Result<u32> {
+        self.conn
+            .query_row(
+                "SELECT COUNT(*) FROM review_attempts
+                 WHERE run_id = ?1 AND reviewed_head_sha = ?2
+                   AND status IN ('failed', 'blocked')",
+                params![run_id, reviewed_head_sha],
+                |row| row.get(0),
+            )
             .map_err(storage_error)
     }
 
@@ -3788,6 +3803,25 @@ impl SqliteFactoryStore {
                 request.stage_run_id
             )));
         }
+        let prior_identity_keys = {
+            let mut stmt = tx
+                .prepare(
+                    "SELECT identity_key FROM review_finding_records
+                     WHERE run_id = ?1 AND lifecycle_state != 'resolved'",
+                )
+                .map_err(storage_error)?;
+            let rows = stmt
+                .query_map(params![stage.run_id], |row| row.get::<_, String>(0))
+                .map_err(storage_error)?;
+            rows.collect::<std::result::Result<HashSet<_>, _>>()
+                .map_err(storage_error)?
+        };
+        let current_identity_keys = request
+            .manifest
+            .findings
+            .iter()
+            .map(finding_identity_key)
+            .collect::<HashSet<_>>();
         let artifact_id = new_id();
         tx.execute(
             "INSERT INTO review_findings_artifacts (
@@ -3833,13 +3867,12 @@ impl SqliteFactoryStore {
                     "maintainability"
                 }
             };
-            let identity_key = format!(
-                "{}:{}:{}:{}",
-                finding.path,
-                finding.line,
-                finding.end_line.unwrap_or(finding.line),
-                finding.claim.trim()
-            );
+            let identity_key = finding_identity_key(finding);
+            let lifecycle_state = if prior_identity_keys.contains(&identity_key) {
+                "persisting"
+            } else {
+                "new"
+            };
             tx.execute(
                 "INSERT INTO review_finding_records (
                     finding_record_id, run_id, artifact_id, finding_id, identity_key,
@@ -3847,7 +3880,7 @@ impl SqliteFactoryStore {
                     claim, rationale, remediation, acceptance_criterion, confidence,
                     lifecycle_state, created_at, updated_at
                  ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12,
-                    ?13, ?14, ?15, ?16, 'new', ?17, ?17)",
+                    ?13, ?14, ?15, ?16, ?17, ?18, ?18)",
                 params![
                     new_id(),
                     stage.run_id,
@@ -3865,10 +3898,37 @@ impl SqliteFactoryStore {
                     finding.remediation,
                     finding.acceptance_criterion,
                     finding.confidence,
+                    lifecycle_state,
                     now_s,
                 ],
             )
             .map_err(storage_error)?;
+        }
+        let mut prior_stmt = tx
+            .prepare(
+                "SELECT finding_record_id, identity_key FROM review_finding_records
+                 WHERE run_id = ?1 AND artifact_id != ?2
+                   AND lifecycle_state != 'resolved'",
+            )
+            .map_err(storage_error)?;
+        let prior_rows = prior_stmt
+            .query_map(params![stage.run_id, artifact_id], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .map_err(storage_error)?;
+        let prior_records = prior_rows
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(storage_error)?;
+        drop(prior_stmt);
+        for (finding_record_id, identity_key) in prior_records {
+            if !current_identity_keys.contains(&identity_key) {
+                tx.execute(
+                    "UPDATE review_finding_records SET lifecycle_state = 'resolved',
+                        updated_at = ?1 WHERE finding_record_id = ?2",
+                    params![now_s, finding_record_id],
+                )
+                .map_err(storage_error)?;
+            }
         }
         let validation_result = bounded_json(&serde_json::json!({
             "accepted": true,
@@ -3926,6 +3986,46 @@ impl SqliteFactoryStore {
         Ok(record)
     }
 
+    pub fn review_artifact_exists_for_head(&self, run_id: &str, head_sha: &str) -> Result<bool> {
+        self.conn
+            .query_row(
+                "SELECT EXISTS(
+                    SELECT 1 FROM review_findings_artifacts
+                    WHERE run_id = ?1 AND reviewed_head_sha = ?2
+                )",
+                params![run_id, head_sha],
+                |row| row.get(0),
+            )
+            .map_err(storage_error)
+    }
+
+    /// Find a completed artifact whose publication intent was never persisted.
+    pub fn get_orphaned_review_artifact_for_head(
+        &self,
+        run_id: &str,
+        head_sha: &str,
+    ) -> Result<Option<ReviewFindingsArtifactRecord>> {
+        self.conn
+            .query_row(
+                "SELECT a.artifact_id, a.run_id, a.stage_run_id, a.attempt_id,
+                    a.draft_pr_artifact_id, a.implementation_artifact_id, a.spec_artifact_id,
+                    a.schema_version, a.reviewed_head_sha, a.base_sha, a.manifest_json,
+                    a.no_findings, a.finding_count, a.received_at, a.bytes_len
+                 FROM review_findings_artifacts a
+                 WHERE a.run_id = ?1 AND a.reviewed_head_sha = ?2
+                   AND NOT EXISTS (
+                       SELECT 1 FROM review_publication_intents i
+                       WHERE i.artifact_id = a.artifact_id
+                   )
+                 ORDER BY a.received_at DESC
+                 LIMIT 1",
+                params![run_id, head_sha],
+                review_artifact_from_row,
+            )
+            .optional()
+            .map_err(storage_error)
+    }
+
     pub fn get_review_artifact(
         &self,
         artifact_id: &str,
@@ -3941,6 +4041,28 @@ impl SqliteFactoryStore {
                 review_artifact_from_row,
             )
             .optional()
+            .map_err(storage_error)
+    }
+
+    pub fn list_review_finding_records_for_artifact(
+        &self,
+        artifact_id: &str,
+    ) -> Result<Vec<ReviewFindingRecord>> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT finding_record_id, run_id, artifact_id, finding_id, identity_key,
+                    reviewed_head_sha, severity, category, path, line, end_line,
+                    claim, rationale, remediation, acceptance_criterion, confidence,
+                    lifecycle_state, created_at, updated_at
+                 FROM review_finding_records
+                 WHERE artifact_id = ?1 ORDER BY created_at, finding_record_id",
+            )
+            .map_err(storage_error)?;
+        let rows = stmt
+            .query_map(params![artifact_id], review_finding_record_from_row)
+            .map_err(storage_error)?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
             .map_err(storage_error)
     }
 
@@ -4035,6 +4157,99 @@ impl SqliteFactoryStore {
             .map_err(storage_error)?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
             .map_err(storage_error)
+    }
+
+    /// List review publication intents terminalized as `blocked`, oldest first.
+    pub fn list_blocked_review_publications(&self) -> Result<Vec<ReviewPublicationIntent>> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT intent_id, run_id, artifact_id, kind, status,
+                    completed_steps_json, retry_count, last_error_json, comment_id,
+                    publisher_login, review_id, review_url, route_state,
+                    desired_effects_json, observed_baseline_json,
+                    expected_projection_json, created_at, updated_at
+                 FROM review_publication_intents WHERE status = 'blocked'
+                 ORDER BY created_at ASC",
+            )
+            .map_err(storage_error)?;
+        let rows = stmt
+            .query_map([], review_publication_from_row)
+            .map_err(storage_error)?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(storage_error)
+    }
+
+    /// Return a blocked review publication intent to pending for operator
+    /// recovery. Completed steps and forge identities are preserved.
+    pub fn reset_blocked_review_publication(
+        &mut self,
+        intent_id: &str,
+        operator: &str,
+    ) -> Result<ReviewPublicationIntent> {
+        let Some(intent) = self.get_review_publication_intent(intent_id)? else {
+            return Err(SymphonyError::StorageError(format!(
+                "review publication intent {intent_id} not found"
+            )));
+        };
+        if intent.status != PublicationStatus::Blocked {
+            return Err(SymphonyError::TriageError(format!(
+                "review publication intent {intent_id} is {}, not blocked; \
+                 only a blocked intent can be reset",
+                intent.status.as_str()
+            )));
+        }
+
+        let payload = bounded_json(&serde_json::json!({
+            "intent_id": intent.intent_id,
+            "operator": operator,
+            "cleared_error": intent.last_error,
+            "completed_steps": intent.completed_steps,
+        }))?;
+        let now = Self::now();
+        let tx = self.conn.transaction().map_err(storage_error)?;
+        let changed = tx
+            .execute(
+                "UPDATE review_publication_intents
+                 SET status = ?1, last_error_json = NULL, retry_count = 0, updated_at = ?2
+                 WHERE intent_id = ?3 AND status = ?4",
+                params![
+                    PublicationStatus::Pending.as_str(),
+                    ts(now),
+                    intent_id,
+                    PublicationStatus::Blocked.as_str(),
+                ],
+            )
+            .map_err(storage_error)?;
+        if changed == 0 {
+            return Err(SymphonyError::TriageError(format!(
+                "review publication intent {intent_id} changed status concurrently; \
+                 re-run list-blocked and retry"
+            )));
+        }
+        tx.execute(
+            "INSERT INTO factory_events (
+                event_id, run_id, stage_run_id, event_type, timestamp, payload_json
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                new_id(),
+                Some(intent.run_id.as_str()),
+                None::<String>,
+                "review_publication_reset",
+                ts(now),
+                payload,
+            ],
+        )
+        .map_err(storage_error)?;
+        tx.commit().map_err(storage_error)?;
+
+        Ok(ReviewPublicationIntent {
+            status: PublicationStatus::Pending,
+            retry_count: 0,
+            last_error: None,
+            updated_at: now,
+            ..intent
+        })
     }
 
     pub fn list_review_publications_for_run(
@@ -4274,6 +4489,15 @@ impl SqliteFactoryStore {
             .query_row(
                 "SELECT COUNT(*) FROM review_publication_intents
                  WHERE kind = 'preview' AND status = 'applied'",
+                [],
+                |row| row.get(0),
+            )
+            .map_err(storage_error)?;
+        metrics.automatic_publications = self
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM review_publication_intents
+                 WHERE kind = 'automatic' AND status = 'applied'",
                 [],
                 |row| row.get(0),
             )
@@ -4647,6 +4871,34 @@ fn review_attempt_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<ReviewAt
         last_error: optional_from_json(row.get::<_, Option<String>>(14)?)?,
         created_at: parse_ts_row(row.get::<_, String>(15)?)?,
         updated_at: parse_ts_row(row.get::<_, String>(16)?)?,
+    })
+}
+
+fn review_finding_record_from_row(
+    row: &rusqlite::Row<'_>,
+) -> rusqlite::Result<ReviewFindingRecord> {
+    let severity: String = row.get(6)?;
+    let category: String = row.get(7)?;
+    Ok(ReviewFindingRecord {
+        finding_record_id: row.get(0)?,
+        run_id: row.get(1)?,
+        artifact_id: row.get(2)?,
+        finding_id: row.get(3)?,
+        identity_key: row.get(4)?,
+        reviewed_head_sha: row.get(5)?,
+        severity: serde_json::from_value(serde_json::Value::String(severity)).map_err(row_error)?,
+        category: serde_json::from_value(serde_json::Value::String(category)).map_err(row_error)?,
+        path: row.get(8)?,
+        line: row.get(9)?,
+        end_line: row.get(10)?,
+        claim: row.get(11)?,
+        rationale: row.get(12)?,
+        remediation: row.get(13)?,
+        acceptance_criterion: row.get(14)?,
+        confidence: row.get(15)?,
+        lifecycle_state: row.get(16)?,
+        created_at: parse_ts_row(row.get::<_, String>(17)?)?,
+        updated_at: parse_ts_row(row.get::<_, String>(18)?)?,
     })
 }
 
@@ -5313,6 +5565,9 @@ fn row_error<E: ToString>(err: E) -> rusqlite::Error {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::review::manifest::{
+        ReviewFinding, ReviewFindingCategory, ReviewFindingsManifest, ReviewSeverity,
+    };
     use crate::triage::domain::{
         EvidenceKind, RiskClass, TriageEvidence, TriageRoute, TRIAGE_SCHEMA_VERSION,
     };
@@ -5356,6 +5611,412 @@ mod tests {
 
     fn store(path: &Path) -> SqliteFactoryStore {
         SqliteFactoryStore::acquire_lock_and_migrate(path, 5_000).unwrap()
+    }
+
+    fn review_finding(finding_id: &str, path: &str, line: u32, claim: &str) -> ReviewFinding {
+        ReviewFinding {
+            finding_id: finding_id.to_string(),
+            severity: ReviewSeverity::Major,
+            category: ReviewFindingCategory::Correctness,
+            path: path.to_string(),
+            line,
+            end_line: None,
+            claim: claim.to_string(),
+            rationale: "A rationale".to_string(),
+            remediation: "A remediation".to_string(),
+            acceptance_criterion: None,
+            confidence: 0.9,
+        }
+    }
+
+    fn review_manifest(head: &str, findings: Vec<ReviewFinding>) -> ReviewFindingsManifest {
+        ReviewFindingsManifest {
+            schema_version: 1,
+            reviewed_head_sha: head.to_string(),
+            base_sha: "base".to_string(),
+            spec_conformance_summary: "Conforms".to_string(),
+            no_findings: findings.is_empty(),
+            findings,
+        }
+    }
+
+    #[test]
+    fn review_metrics_count_applied_publication_kinds_separately() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("state.db");
+        let mut store = store(&path);
+        store
+            .conn
+            .execute_batch("PRAGMA foreign_keys = OFF")
+            .unwrap();
+
+        let preview = store
+            .create_review_publication_intent(
+                "run-preview",
+                "artifact-preview",
+                "preview",
+                &serde_json::json!({}),
+            )
+            .unwrap();
+        store
+            .complete_review_publication(&preview.intent_id, "comment_final")
+            .unwrap();
+
+        let automatic = store
+            .create_review_publication_intent(
+                "run-automatic",
+                "artifact-automatic",
+                "automatic",
+                &serde_json::json!({}),
+            )
+            .unwrap();
+        store
+            .record_review_publication_step(
+                &automatic.intent_id,
+                "comment_final",
+                PublicationStatus::Applied,
+                &serde_json::json!({}),
+            )
+            .unwrap();
+
+        let pending_automatic = store
+            .create_review_publication_intent(
+                "run-pending",
+                "artifact-pending",
+                "automatic",
+                &serde_json::json!({}),
+            )
+            .unwrap();
+
+        let metrics = store.review_metrics().unwrap();
+        assert_eq!(metrics.preview_publications, 1);
+        assert_eq!(metrics.automatic_publications, 1);
+        assert_eq!(
+            store
+                .get_review_publication_intent(&pending_automatic.intent_id)
+                .unwrap()
+                .unwrap()
+                .status,
+            PublicationStatus::Pending
+        );
+    }
+
+    #[test]
+    fn classifies_re_review_findings_by_prior_identity() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("state.db");
+        let mut store = store(&path);
+        let first_stage = store
+            .claim_stage_attempt(REVIEW_STAGE_NAME, claim_request("rev-1", "cfg"))
+            .unwrap();
+        // This test isolates review lifecycle behavior; linked A2/A3 artifacts
+        // are represented by placeholder IDs because those stages are out of scope.
+        store
+            .conn
+            .execute_batch("PRAGMA foreign_keys = OFF")
+            .unwrap();
+        store
+            .store_review_attempt_inputs(StoreReviewAttemptRequest {
+                attempt_id: "attempt-1".to_string(),
+                stage_run_id: first_stage.stage_run_id.clone(),
+                draft_pr_artifact_id: "draft".to_string(),
+                implementation_artifact_id: "implementation".to_string(),
+                spec_artifact_id: "spec".to_string(),
+                pr_number: 42,
+                reviewed_head_sha: "head-1".to_string(),
+                base_sha: "base".to_string(),
+            })
+            .unwrap();
+        let first = store
+            .store_review_artifact(StoreReviewArtifactRequest {
+                stage_run_id: first_stage.stage_run_id,
+                attempt_id: "attempt-1".to_string(),
+                draft_pr_artifact_id: "draft".to_string(),
+                implementation_artifact_id: "implementation".to_string(),
+                spec_artifact_id: "spec".to_string(),
+                reviewed_head_sha: "head-1".to_string(),
+                base_sha: "base".to_string(),
+                manifest: review_manifest(
+                    "head-1",
+                    vec![
+                        review_finding("old-a", "src/a.rs", 10, "persist me"),
+                        review_finding("old-c", "src/c.rs", 30, "resolve me"),
+                    ],
+                ),
+                bytes_len: 1,
+                usage: StageUsage::default(),
+            })
+            .unwrap();
+        let second_stage = store
+            .claim_stage_attempt(REVIEW_STAGE_NAME, claim_request("rev-2", "cfg"))
+            .unwrap();
+        store
+            .store_review_attempt_inputs(StoreReviewAttemptRequest {
+                attempt_id: "attempt-2".to_string(),
+                stage_run_id: second_stage.stage_run_id.clone(),
+                draft_pr_artifact_id: "draft".to_string(),
+                implementation_artifact_id: "implementation".to_string(),
+                spec_artifact_id: "spec".to_string(),
+                pr_number: 42,
+                reviewed_head_sha: "head-2".to_string(),
+                base_sha: "base".to_string(),
+            })
+            .unwrap();
+        let second = store
+            .store_review_artifact(StoreReviewArtifactRequest {
+                stage_run_id: second_stage.stage_run_id,
+                attempt_id: "attempt-2".to_string(),
+                draft_pr_artifact_id: "draft".to_string(),
+                implementation_artifact_id: "implementation".to_string(),
+                spec_artifact_id: "spec".to_string(),
+                reviewed_head_sha: "head-2".to_string(),
+                base_sha: "base".to_string(),
+                manifest: review_manifest(
+                    "head-2",
+                    vec![
+                        review_finding("new-a", "src/a.rs", 99, "persist me"),
+                        review_finding("new-b", "src/b.rs", 20, "new finding"),
+                    ],
+                ),
+                bytes_len: 1,
+                usage: StageUsage::default(),
+            })
+            .unwrap();
+
+        let first_records_before_third = store
+            .list_review_finding_records_for_artifact(&first.artifact_id)
+            .unwrap();
+        let second_records_before_third = store
+            .list_review_finding_records_for_artifact(&second.artifact_id)
+            .unwrap();
+        assert_eq!(
+            first_records_before_third
+                .iter()
+                .find(|record| record.finding_id == "old-a")
+                .unwrap()
+                .lifecycle_state,
+            "new"
+        );
+        assert_eq!(
+            first_records_before_third
+                .iter()
+                .find(|record| record.finding_id == "old-c")
+                .unwrap()
+                .lifecycle_state,
+            "resolved"
+        );
+        assert_eq!(
+            second_records_before_third
+                .iter()
+                .find(|record| record.finding_id == "new-a")
+                .unwrap()
+                .lifecycle_state,
+            "persisting"
+        );
+        assert_eq!(
+            second_records_before_third
+                .iter()
+                .find(|record| record.finding_id == "new-b")
+                .unwrap()
+                .lifecycle_state,
+            "new"
+        );
+
+        let third_stage = store
+            .claim_stage_attempt(REVIEW_STAGE_NAME, claim_request("rev-3", "cfg"))
+            .unwrap();
+        store
+            .store_review_attempt_inputs(StoreReviewAttemptRequest {
+                attempt_id: "attempt-3".to_string(),
+                stage_run_id: third_stage.stage_run_id.clone(),
+                draft_pr_artifact_id: "draft".to_string(),
+                implementation_artifact_id: "implementation".to_string(),
+                spec_artifact_id: "spec".to_string(),
+                pr_number: 42,
+                reviewed_head_sha: "head-3".to_string(),
+                base_sha: "base".to_string(),
+            })
+            .unwrap();
+        let third = store
+            .store_review_artifact(StoreReviewArtifactRequest {
+                stage_run_id: third_stage.stage_run_id,
+                attempt_id: "attempt-3".to_string(),
+                draft_pr_artifact_id: "draft".to_string(),
+                implementation_artifact_id: "implementation".to_string(),
+                spec_artifact_id: "spec".to_string(),
+                reviewed_head_sha: "head-3".to_string(),
+                base_sha: "base".to_string(),
+                manifest: review_manifest(
+                    "head-3",
+                    vec![review_finding("new-c", "src/c.rs", 30, "resolve me")],
+                ),
+                bytes_len: 1,
+                usage: StageUsage::default(),
+            })
+            .unwrap();
+
+        let third_records = store
+            .list_review_finding_records_for_artifact(&third.artifact_id)
+            .unwrap();
+        assert_eq!(
+            third_records
+                .iter()
+                .find(|record| record.finding_id == "new-c")
+                .unwrap()
+                .lifecycle_state,
+            "new",
+            "a finding reappearing after resolution starts a new lifecycle",
+        );
+    }
+
+    #[test]
+    fn interrupted_review_attempt_does_not_consume_retry_budget() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("state.db");
+        let store = store(&path);
+        store
+            .conn
+            .execute_batch("PRAGMA foreign_keys = OFF")
+            .unwrap();
+        let now = Utc::now().to_rfc3339();
+        for (attempt_id, stage_run_id, status) in [
+            ("attempt-interrupted", "stage-interrupted", "interrupted"),
+            ("attempt-failed", "stage-failed", "failed"),
+            ("attempt-blocked", "stage-blocked", "blocked"),
+        ] {
+            store
+                .conn
+                .execute(
+                    "INSERT INTO review_attempts (
+                        attempt_id, run_id, stage_run_id, draft_pr_artifact_id,
+                        implementation_artifact_id, spec_artifact_id, pr_number,
+                        reviewed_head_sha, base_sha, status, created_at, updated_at
+                     ) VALUES (?1, 'run-review', ?2, 'draft', 'implementation', 'spec',
+                        42, 'head-1', 'base-1', ?3, ?4, ?4)",
+                    params![attempt_id, stage_run_id, status, now],
+                )
+                .unwrap();
+        }
+
+        // A worker-head reopen is waiting work for the same cycle. Only actual
+        // failed or blocked review attempts consume the retry ceiling.
+        let counted: u32 = store
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM review_attempts
+                 WHERE run_id = 'run-review' AND reviewed_head_sha = 'head-1'
+                   AND status IN ('failed', 'blocked')",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(counted, 2);
+    }
+
+    #[test]
+    fn changed_live_head_keeps_review_candidate_eligible_after_old_head_exhaustion() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("state.db");
+        let store = store(&path);
+        store
+            .conn
+            .execute_batch("PRAGMA foreign_keys = OFF")
+            .unwrap();
+        let now = Utc::now().to_rfc3339();
+        store
+            .conn
+            .execute(
+                "INSERT INTO factory_runs (
+                    run_id, forge_host, repository, issue_id, issue_identifier,
+                    issue_revision, status, current_stage, created_at, updated_at
+                 ) VALUES ('run-review', 'github.com', 'owner/repo', '123', '#123',
+                    'issue-rev', 'running', 'review', ?1, ?1)",
+                params![now],
+            )
+            .unwrap();
+        store
+            .conn
+            .execute(
+                "INSERT INTO spec_run_state (
+                    run_id, approved_artifact_id, approved_version, decision, updated_at
+                 ) VALUES ('run-review', 'spec-artifact', 1, 'approved', ?1)",
+                params![now],
+            )
+            .unwrap();
+        store
+            .conn
+            .execute(
+                "INSERT INTO implementation_artifacts (
+                    artifact_id, run_id, stage_run_id, approved_artifact_id,
+                    approved_version, issue_revision, configuration_revision,
+                    schema_version, manifest_json, base_commit, approved_spec_path,
+                    validation_cycles, execution_profile, received_at, bytes_len
+                 ) VALUES ('implementation-artifact', 'run-review', 'implementation-stage',
+                    'spec-artifact', 1, 'issue-rev', 'config-rev', 1, '{}', 'base',
+                    'spec.md', 1, 'default', ?1, 1)",
+                params![now],
+            )
+            .unwrap();
+        store
+            .conn
+            .execute(
+                "INSERT INTO implementation_publication_intents (
+                    intent_id, run_id, artifact_id, kind, status,
+                    completed_steps_json, desired_effects_json, observed_baseline_json,
+                    expected_projection_json, created_at, updated_at
+                 ) VALUES ('implementation-intent', 'run-review',
+                    'implementation-artifact', 'draft_pr', 'applied', '[]', '{}', '{}',
+                    '{}', ?1, ?1)",
+                params![now],
+            )
+            .unwrap();
+        store
+            .conn
+            .execute(
+                "INSERT INTO implementation_draft_pr_artifacts (
+                    artifact_id, run_id, implementation_artifact_id, intent_id,
+                    number, url, draft, head, base, head_sha, marker, created_at
+                 ) VALUES ('draft-artifact', 'run-review', 'implementation-artifact',
+                    'implementation-intent', 42, 'https://github.com/owner/repo/pull/42',
+                    1, 'feature', 'main', 'old-head', 'marker', ?1)",
+                params![now],
+            )
+            .unwrap();
+        for (attempt_id, stage_run_id, status) in [
+            ("failed-1", "stage-failed-1", "failed"),
+            ("blocked-1", "stage-blocked-1", "blocked"),
+        ] {
+            store
+                .conn
+                .execute(
+                    "INSERT INTO review_attempts (
+                        attempt_id, run_id, stage_run_id, draft_pr_artifact_id,
+                        implementation_artifact_id, spec_artifact_id, pr_number,
+                        reviewed_head_sha, base_sha, status, created_at, updated_at
+                     ) VALUES (?1, 'run-review', ?2, 'draft-artifact',
+                        'implementation-artifact', 'spec-artifact', 42,
+                        'old-head', 'base', ?3, ?4, ?4)",
+                    params![attempt_id, stage_run_id, status, now],
+                )
+                .unwrap();
+        }
+
+        let candidates = store.list_a4_eligible_review_runs(2).unwrap();
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].head_sha, "old-head");
+        assert_eq!(
+            store
+                .count_review_attempt_failures_for_head("run-review", "old-head")
+                .unwrap(),
+            2
+        );
+        assert_eq!(
+            store
+                .count_review_attempt_failures_for_head("run-review", "new-head")
+                .unwrap(),
+            0,
+            "the live/new head starts with a fresh retry budget"
+        );
     }
 
     #[test]
@@ -6205,6 +6866,73 @@ mod tests {
     }
 
     #[test]
+    fn blocked_review_publication_can_be_listed_and_reset_atomically() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("state.db");
+        let mut store = store(&path);
+        let now = Utc::now().to_rfc3339();
+        store
+            .conn
+            .execute_batch("PRAGMA foreign_keys = OFF")
+            .unwrap();
+        store
+            .conn
+            .execute(
+                "INSERT INTO review_publication_intents (
+                    intent_id, run_id, artifact_id, kind, status,
+                    completed_steps_json, retry_count, last_error_json,
+                    desired_effects_json, observed_baseline_json,
+                    expected_projection_json, created_at, updated_at
+                 ) VALUES ('review-blocked', 'run-review', 'artifact-review',
+                    'formal', 'blocked', '[\"review_created\"]', 4,
+                    ?1, '{}', '{}', '{}', ?2, ?2)",
+                params![
+                    serde_json::json!({
+                        "code": "review_publication_retry_exhausted",
+                        "component": "review_publication",
+                        "remediation": "retry after restoring forge access",
+                        "retryable": false
+                    })
+                    .to_string(),
+                    now,
+                ],
+            )
+            .unwrap();
+
+        let blocked = store.list_blocked_review_publications().unwrap();
+        assert_eq!(blocked.len(), 1);
+        assert_eq!(blocked[0].intent_id, "review-blocked");
+        assert_eq!(blocked[0].completed_steps, ["review_created"]);
+        assert_eq!(blocked[0].retry_count, 4);
+
+        let reset = store
+            .reset_blocked_review_publication("review-blocked", "operator")
+            .unwrap();
+        assert_eq!(reset.status, PublicationStatus::Pending);
+        assert_eq!(reset.retry_count, 0);
+        assert!(reset.last_error.is_none());
+        assert_eq!(reset.completed_steps, ["review_created"]);
+
+        let (event_type, payload): (String, String) = store
+            .conn
+            .query_row(
+                "SELECT event_type, payload_json FROM factory_events
+                 WHERE event_type = 'review_publication_reset'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(event_type, "review_publication_reset");
+        assert!(payload.contains("\"operator\":\"operator\""));
+        assert!(store.list_blocked_review_publications().unwrap().is_empty());
+
+        let err = store
+            .reset_blocked_review_publication("review-blocked", "operator")
+            .unwrap_err();
+        assert!(err.to_string().contains("not blocked"));
+    }
+
+    #[test]
     fn migration_004_creates_implementation_tables() {
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("state.db");
@@ -6363,6 +7091,24 @@ mod tests {
                 ],
             )
             .unwrap();
+
+        let orphan = store
+            .get_orphaned_review_artifact_for_head(&run_id, "head-sha")
+            .unwrap()
+            .expect("artifact without an intent is recoverable");
+        assert_eq!(orphan.artifact_id, "review-artifact");
+        store
+            .create_review_publication_intent(
+                &run_id,
+                &orphan.artifact_id,
+                "preview",
+                &serde_json::json!({"issue_number": 123}),
+            )
+            .unwrap();
+        assert!(store
+            .get_orphaned_review_artifact_for_head(&run_id, "head-sha")
+            .unwrap()
+            .is_none());
 
         let update = store.conn.execute(
             "UPDATE review_findings_artifacts SET manifest_json = '{}' WHERE artifact_id = 'review-artifact'",

--- a/apps/symphony/src/triage/store.rs
+++ b/apps/symphony/src/triage/store.rs
@@ -508,12 +508,8 @@ impl SqliteFactoryStore {
         let conn = Connection::open(path).map_err(storage_error)?;
         conn.busy_timeout(StdDuration::from_millis(busy_timeout_ms))
             .map_err(storage_error)?;
-        for (index, migration) in MIGRATIONS.iter().enumerate() {
-            if index >= 6 {
-                apply_review_publication_migration(&conn, migration).map_err(storage_error)?;
-            } else {
-                conn.execute_batch(migration).map_err(storage_error)?;
-            }
+        for migration in MIGRATIONS {
+            apply_migration(&conn, migration).map_err(storage_error)?;
         }
 
         Ok(Self {
@@ -3660,7 +3656,8 @@ impl SqliteFactoryStore {
     }
 
     /// Count review attempts that consume the retry budget for one live PR
-    /// head. Interrupted attempts remain recoverable work and do not count.
+    /// head. Interrupted attempts count as failed work so repeated crashes
+    /// cannot reclaim the same head indefinitely.
     pub fn count_review_attempt_failures_for_head(
         &self,
         run_id: &str,
@@ -3670,7 +3667,7 @@ impl SqliteFactoryStore {
             .query_row(
                 "SELECT COUNT(*) FROM review_attempts
                  WHERE run_id = ?1 AND reviewed_head_sha = ?2
-                   AND status IN ('failed', 'blocked')",
+                   AND status IN ('failed', 'blocked', 'interrupted')",
                 params![run_id, reviewed_head_sha],
                 |row| row.get(0),
             )
@@ -4094,6 +4091,19 @@ impl SqliteFactoryStore {
         kind: &str,
         desired_effects: &serde_json::Value,
     ) -> Result<ReviewPublicationIntent> {
+        if let Some(existing) = self
+            .list_review_publications_for_run(run_id)?
+            .into_iter()
+            .find(|intent| {
+                intent.artifact_id == artifact_id
+                    && !matches!(
+                        intent.status,
+                        PublicationStatus::Blocked | PublicationStatus::Conflict
+                    )
+            })
+        {
+            return Ok(existing);
+        }
         let intent_id = new_id();
         let now_s = ts(Self::now());
         self.conn
@@ -5323,26 +5333,35 @@ fn review_artifact_from_row(
     })
 }
 
-fn apply_review_publication_migration(conn: &Connection, migration: &str) -> rusqlite::Result<()> {
-    let migration = migration
+fn apply_migration(conn: &Connection, migration: &str) -> rusqlite::Result<()> {
+    let statements = migration
         .lines()
         .filter(|line| !line.trim_start().starts_with("--"))
         .collect::<Vec<_>>()
         .join("\n");
-    for statement in migration
+    if !statements.to_ascii_uppercase().contains("ALTER TABLE") {
+        return conn.execute_batch(migration);
+    }
+    for statement in statements
         .split(';')
         .map(str::trim)
         .filter(|s| !s.is_empty())
     {
-        let column = statement
-            .split_whitespace()
-            .nth(5)
-            .ok_or_else(|| rusqlite::Error::InvalidQuery)?;
+        let tokens: Vec<&str> = statement.split_whitespace().collect();
+        let is_add_column = tokens.len() >= 6
+            && tokens[0].eq_ignore_ascii_case("ALTER")
+            && tokens[1].eq_ignore_ascii_case("TABLE")
+            && tokens[3].eq_ignore_ascii_case("ADD")
+            && tokens[4].eq_ignore_ascii_case("COLUMN");
+        if !is_add_column {
+            conn.execute_batch(statement)?;
+            continue;
+        }
+        let table = tokens[2].trim_matches('`').trim_matches('"');
+        let column = tokens[5].trim_matches('`').trim_matches('"');
         let exists: bool = conn.query_row(
-            "SELECT EXISTS(
-                SELECT 1 FROM pragma_table_info('review_publication_intents') WHERE name = ?1
-            )",
-            params![column],
+            "SELECT EXISTS(SELECT 1 FROM pragma_table_info(?1) WHERE name = ?2)",
+            params![table, column],
             |row| row.get(0),
         )?;
         if !exists {
@@ -6296,19 +6315,12 @@ mod tests {
                 .unwrap();
         }
 
-        // A worker-head reopen is waiting work for the same cycle. Only actual
-        // failed or blocked review attempts consume the retry ceiling.
-        let counted: u32 = store
-            .conn
-            .query_row(
-                "SELECT COUNT(*) FROM review_attempts
-                 WHERE run_id = 'run-review' AND reviewed_head_sha = 'head-1'
-                   AND status IN ('failed', 'blocked')",
-                [],
-                |row| row.get(0),
-            )
+        // Interrupted attempts consume the retry ceiling as well, preventing
+        // repeated worker crashes from reclaiming the same head indefinitely.
+        let counted = store
+            .count_review_attempt_failures_for_head("run-review", "head-1")
             .unwrap();
-        assert_eq!(counted, 2);
+        assert_eq!(counted, 3);
     }
 
     #[test]

--- a/apps/symphony/src/triage/store.rs
+++ b/apps/symphony/src/triage/store.rs
@@ -4142,7 +4142,7 @@ impl SqliteFactoryStore {
                 "UPDATE review_publication_intents
                  SET lease_owner = ?1, lease_expires_at = ?2, updated_at = ?3
                  WHERE intent_id = ?4 AND status = 'pending'
-                   AND (lease_owner IS NULL OR lease_expires_at IS NULL
+                   AND (lease_owner = ?1 OR lease_owner IS NULL OR lease_expires_at IS NULL
                         OR lease_expires_at <= ?3)",
                 params![owner, expires_s, now_s, intent_id],
             )
@@ -4160,6 +4160,28 @@ impl SqliteFactoryStore {
             )
             .map_err(storage_error)?;
         Ok(())
+    }
+
+    pub fn renew_review_publication_lease(
+        &mut self,
+        intent_id: &str,
+        owner: &str,
+        lease_seconds: i64,
+    ) -> Result<bool> {
+        let now = Self::now();
+        let now_s = ts(now);
+        let expires_s = ts(now + Duration::seconds(lease_seconds.max(1)));
+        let changed = self
+            .conn
+            .execute(
+                "UPDATE review_publication_intents
+                 SET lease_expires_at = ?1, updated_at = ?2
+                 WHERE intent_id = ?3 AND status = 'pending'
+                   AND lease_owner = ?4 AND lease_expires_at > ?2",
+                params![expires_s, now_s, intent_id, owner],
+            )
+            .map_err(storage_error)?;
+        Ok(changed == 1)
     }
 
     pub fn get_review_publication_intent(
@@ -4224,7 +4246,8 @@ impl SqliteFactoryStore {
     }
 
     /// Return a blocked or conflict review publication intent to pending for
-    /// operator recovery. Completed steps and forge identities are preserved.
+    /// explicit operator recovery. This is the human-controlled recovery
+    /// command; completed steps and forge identities are preserved.
     pub fn reset_blocked_review_publication(
         &mut self,
         intent_id: &str,
@@ -4317,6 +4340,7 @@ impl SqliteFactoryStore {
             .map_err(storage_error)
     }
 
+    #[cfg(test)]
     pub fn bind_review_publication_comment(
         &mut self,
         intent_id: &str,
@@ -4326,26 +4350,69 @@ impl SqliteFactoryStore {
         self.conn
             .execute(
                 "UPDATE review_publication_intents SET comment_id = ?1,
-                    publisher_login = ?2, updated_at = ?3 WHERE intent_id = ?4",
+                    publisher_login = ?2, updated_at = ?3
+                 WHERE intent_id = ?4 AND status = 'pending' AND lease_owner IS NULL",
                 params![comment_id, publisher_login, ts(Self::now()), intent_id],
             )
             .map_err(storage_error)?;
         Ok(())
     }
 
+    #[cfg(test)]
     pub fn clear_review_publication_comment(&mut self, intent_id: &str) -> Result<()> {
         self.conn
             .execute(
                 "UPDATE review_publication_intents
                  SET comment_id = NULL, publisher_login = NULL, updated_at = ?1
-                 WHERE intent_id = ?2",
+                 WHERE intent_id = ?2 AND status = 'pending' AND lease_owner IS NULL",
                 params![ts(Self::now()), intent_id],
             )
             .map_err(storage_error)?;
         Ok(())
     }
 
-    /// Bind the identity returned by the forge for a formal review.
+    pub fn bind_review_publication_comment_owned(
+        &mut self,
+        intent_id: &str,
+        owner: &str,
+        comment_id: &str,
+        publisher_login: &str,
+    ) -> Result<bool> {
+        let now_s = ts(Self::now());
+        let changed = self
+            .conn
+            .execute(
+                "UPDATE review_publication_intents SET comment_id = ?1,
+                    publisher_login = ?2, updated_at = ?3
+                 WHERE intent_id = ?4 AND status = 'pending' AND lease_owner = ?5
+                   AND lease_expires_at > ?3",
+                params![comment_id, publisher_login, now_s, intent_id, owner],
+            )
+            .map_err(storage_error)?;
+        Ok(changed == 1)
+    }
+
+    pub fn clear_review_publication_comment_owned(
+        &mut self,
+        intent_id: &str,
+        owner: &str,
+    ) -> Result<bool> {
+        let now_s = ts(Self::now());
+        let changed = self
+            .conn
+            .execute(
+                "UPDATE review_publication_intents
+                 SET comment_id = NULL, publisher_login = NULL, updated_at = ?1
+                 WHERE intent_id = ?2 AND status = 'pending' AND lease_owner = ?3
+                   AND lease_expires_at > ?1",
+                params![now_s, intent_id, owner],
+            )
+            .map_err(storage_error)?;
+        Ok(changed == 1)
+    }
+
+    /// Test-only compatibility helper for constructing durable publication rows.
+    #[cfg(test)]
     pub fn bind_review_publication_review(
         &mut self,
         intent_id: &str,
@@ -4358,7 +4425,8 @@ impl SqliteFactoryStore {
             .execute(
                 "UPDATE review_publication_intents
                  SET review_id = ?1, review_url = ?2, publisher_login = ?3,
-                     updated_at = ?4 WHERE intent_id = ?5",
+                     updated_at = ?4
+                 WHERE intent_id = ?5 AND status = 'pending' AND lease_owner IS NULL",
                 params![
                     review_id,
                     review_url,
@@ -4376,29 +4444,80 @@ impl SqliteFactoryStore {
         Ok(())
     }
 
+    pub fn bind_review_publication_review_owned(
+        &mut self,
+        intent_id: &str,
+        owner: &str,
+        review_id: &str,
+        review_url: &str,
+        publisher_login: &str,
+    ) -> Result<bool> {
+        let changed = self
+            .conn
+            .execute(
+                "UPDATE review_publication_intents
+                 SET review_id = ?1, review_url = ?2, publisher_login = ?3,
+                     updated_at = ?4
+                 WHERE intent_id = ?5 AND status = 'pending' AND lease_owner = ?6
+                   AND lease_expires_at > ?7",
+                params![
+                    review_id,
+                    review_url,
+                    publisher_login,
+                    ts(Self::now()),
+                    intent_id,
+                    owner,
+                    ts(Self::now()),
+                ],
+            )
+            .map_err(storage_error)?;
+        Ok(changed == 1)
+    }
+
+    #[cfg(test)]
     pub fn set_review_publication_route_state(
         &mut self,
         intent_id: &str,
         route_state: &str,
     ) -> Result<()> {
+        self.conn
+            .execute(
+                "UPDATE review_publication_intents
+                 SET route_state = ?1, updated_at = ?2
+                 WHERE intent_id = ?3 AND status = 'pending' AND lease_owner IS NULL",
+                params![route_state, ts(Self::now()), intent_id],
+            )
+            .map_err(storage_error)?;
+        Ok(())
+    }
+
+    pub fn set_review_publication_route_state_owned(
+        &mut self,
+        intent_id: &str,
+        owner: &str,
+        route_state: &str,
+    ) -> Result<bool> {
         let changed = self
             .conn
             .execute(
                 "UPDATE review_publication_intents
-                 SET route_state = ?1, updated_at = ?2 WHERE intent_id = ?3",
-                params![route_state, ts(Self::now()), intent_id],
+                 SET route_state = ?1, updated_at = ?2
+                 WHERE intent_id = ?3 AND status = 'pending' AND lease_owner = ?4
+                   AND lease_expires_at > ?5",
+                params![
+                    route_state,
+                    ts(Self::now()),
+                    intent_id,
+                    owner,
+                    ts(Self::now()),
+                ],
             )
             .map_err(storage_error)?;
-        if changed == 0 {
-            return Err(SymphonyError::StorageError(format!(
-                "review intent {intent_id} not found"
-            )));
-        }
-        Ok(())
+        Ok(changed == 1)
     }
 
-    /// Record one formal publication step. Only `comment_final` terminalizes
-    /// the intent, allowing restart to resume at the first incomplete step.
+    /// Test-only compatibility helper for constructing durable publication rows.
+    #[cfg(test)]
     pub fn record_review_publication_step(
         &mut self,
         intent_id: &str,
@@ -4406,13 +4525,48 @@ impl SqliteFactoryStore {
         status: PublicationStatus,
         expected_projection: &serde_json::Value,
     ) -> Result<()> {
+        self.record_review_publication_step_inner(
+            intent_id,
+            step,
+            status,
+            expected_projection,
+            None,
+        )
+        .map(|_| ())
+    }
+
+    pub fn record_review_publication_step_owned(
+        &mut self,
+        intent_id: &str,
+        owner: &str,
+        step: &str,
+        status: PublicationStatus,
+        expected_projection: &serde_json::Value,
+    ) -> Result<bool> {
+        self.record_review_publication_step_inner(
+            intent_id,
+            step,
+            status,
+            expected_projection,
+            Some(owner),
+        )
+    }
+
+    fn record_review_publication_step_inner(
+        &mut self,
+        intent_id: &str,
+        step: &str,
+        status: PublicationStatus,
+        expected_projection: &serde_json::Value,
+        owner: Option<&str>,
+    ) -> Result<bool> {
         let intent = self
             .get_review_publication_intent(intent_id)?
             .ok_or_else(|| {
                 SymphonyError::StorageError(format!("review intent {intent_id} not found"))
             })?;
-        if intent.status == PublicationStatus::Applied {
-            return Ok(());
+        if intent.status != PublicationStatus::Pending {
+            return Ok(false);
         }
         let mut steps = intent.completed_steps;
         let trimmed = step.trim();
@@ -4426,29 +4580,77 @@ impl SqliteFactoryStore {
         } else {
             status
         };
-        self.conn
-            .execute(
-                "UPDATE review_publication_intents
-                 SET completed_steps_json = ?1, status = ?2, last_error_json = NULL,
-                     expected_projection_json = ?3,
-                     lease_owner = CASE WHEN ?6 = 'applied' THEN NULL ELSE lease_owner END,
-                     lease_expires_at = CASE WHEN ?6 = 'applied' THEN NULL ELSE lease_expires_at END,
-                     updated_at = ?4
-                 WHERE intent_id = ?5",
-                params![
-                    bounded_json(&steps)?,
-                    next_status.as_str(),
-                    bounded_json(expected_projection)?,
-                    ts(Self::now()),
-                    intent_id,
-                    next_status.as_str(),
-                ],
-            )
-            .map_err(storage_error)?;
-        Ok(())
+        let steps_json = bounded_json(&steps)?;
+        let projection_json = bounded_json(expected_projection)?;
+        let now_s = ts(Self::now());
+        let changed = if let Some(owner) = owner {
+            self.conn
+                .execute(
+                    "UPDATE review_publication_intents
+                     SET completed_steps_json = ?1, status = ?2, last_error_json = NULL,
+                         expected_projection_json = ?3,
+                         lease_owner = CASE WHEN ?6 = 'applied' THEN NULL ELSE lease_owner END,
+                         lease_expires_at = CASE WHEN ?6 = 'applied' THEN NULL ELSE lease_expires_at END,
+                         updated_at = ?4
+                     WHERE intent_id = ?5 AND status = 'pending' AND lease_owner = ?7
+                       AND lease_expires_at > ?8",
+                    params![
+                        steps_json,
+                        next_status.as_str(),
+                        projection_json,
+                        now_s,
+                        intent_id,
+                        next_status.as_str(),
+                        owner,
+                        now_s,
+                    ],
+                )
+                .map_err(storage_error)?
+        } else {
+            self.conn
+                .execute(
+                    "UPDATE review_publication_intents
+                     SET completed_steps_json = ?1, status = ?2, last_error_json = NULL,
+                         expected_projection_json = ?3,
+                         lease_owner = CASE WHEN ?6 = 'applied' THEN NULL ELSE lease_owner END,
+                         lease_expires_at = CASE WHEN ?6 = 'applied' THEN NULL ELSE lease_expires_at END,
+                         updated_at = ?4
+                     WHERE intent_id = ?5 AND status = 'pending' AND lease_owner IS NULL",
+                    params![
+                        steps_json,
+                        next_status.as_str(),
+                        projection_json,
+                        now_s,
+                        intent_id,
+                        next_status.as_str(),
+                    ],
+                )
+                .map_err(storage_error)?
+        };
+        Ok(changed == 1)
     }
 
+    #[cfg(test)]
     pub fn complete_review_publication(&mut self, intent_id: &str, step: &str) -> Result<()> {
+        self.complete_review_publication_inner(intent_id, step, None)
+            .map(|_| ())
+    }
+
+    pub fn complete_review_publication_owned(
+        &mut self,
+        intent_id: &str,
+        owner: &str,
+        step: &str,
+    ) -> Result<bool> {
+        self.complete_review_publication_inner(intent_id, step, Some(owner))
+    }
+
+    fn complete_review_publication_inner(
+        &mut self,
+        intent_id: &str,
+        step: &str,
+        owner: Option<&str>,
+    ) -> Result<bool> {
         let intent = self
             .get_review_publication_intent(intent_id)?
             .ok_or_else(|| {
@@ -4460,21 +4662,39 @@ impl SqliteFactoryStore {
                 intent.kind
             )));
         }
+        if intent.status != PublicationStatus::Pending {
+            return Ok(false);
+        }
         let mut steps = intent.completed_steps;
         if !steps.iter().any(|existing| existing == step) {
             steps.push(step.to_string());
         }
-        self.conn
-            .execute(
-                "UPDATE review_publication_intents SET status = 'applied',
-                    completed_steps_json = ?1, last_error_json = NULL, updated_at = ?2
-                 WHERE intent_id = ?3",
-                params![bounded_json(&steps)?, ts(Self::now()), intent_id],
-            )
-            .map_err(storage_error)?;
-        Ok(())
+        let now_s = ts(Self::now());
+        let changed = if let Some(owner) = owner {
+            self.conn
+                .execute(
+                    "UPDATE review_publication_intents SET status = 'applied',
+                        completed_steps_json = ?1, last_error_json = NULL,
+                        lease_owner = NULL, lease_expires_at = NULL, updated_at = ?2
+                     WHERE intent_id = ?3 AND status = 'pending' AND lease_owner = ?4
+                       AND lease_expires_at > ?5",
+                    params![bounded_json(&steps)?, now_s, intent_id, owner, now_s],
+                )
+                .map_err(storage_error)?
+        } else {
+            self.conn
+                .execute(
+                    "UPDATE review_publication_intents SET status = 'applied',
+                        completed_steps_json = ?1, last_error_json = NULL, updated_at = ?2
+                     WHERE intent_id = ?3 AND status = 'pending' AND lease_owner IS NULL",
+                    params![bounded_json(&steps)?, now_s, intent_id],
+                )
+                .map_err(storage_error)?
+        };
+        Ok(changed == 1)
     }
 
+    #[cfg(test)]
     pub fn set_review_publication_error(
         &mut self,
         intent_id: &str,
@@ -4487,7 +4707,7 @@ impl SqliteFactoryStore {
                 "UPDATE review_publication_intents SET status = ?1,
                     last_error_json = ?2, retry_count = retry_count + 1,
                     lease_owner = NULL, lease_expires_at = NULL, updated_at = ?3
-                    WHERE intent_id = ?4",
+                    WHERE intent_id = ?4 AND status = 'pending' AND lease_owner IS NULL",
                 params![
                     status.as_str(),
                     bounded_json(&error)?,
@@ -4497,15 +4717,100 @@ impl SqliteFactoryStore {
             )
             .map_err(storage_error)?;
         if changed == 0 {
-            return Err(SymphonyError::StorageError(format!(
-                "review intent {intent_id} not found"
-            )));
+            let exists: Option<String> = self
+                .conn
+                .query_row(
+                    "SELECT status FROM review_publication_intents WHERE intent_id = ?1",
+                    params![intent_id],
+                    |row| row.get(0),
+                )
+                .optional()
+                .map_err(storage_error)?;
+            if exists.is_none() {
+                return Err(SymphonyError::StorageError(format!(
+                    "review intent {intent_id} not found"
+                )));
+            }
         }
         Ok(())
     }
 
+    pub fn set_review_publication_error_owned(
+        &mut self,
+        intent_id: &str,
+        owner: &str,
+        status: PublicationStatus,
+        error: FactoryError,
+    ) -> Result<bool> {
+        let now_s = ts(Self::now());
+        let changed = self
+            .conn
+            .execute(
+                "UPDATE review_publication_intents SET status = ?1,
+                    last_error_json = ?2, retry_count = retry_count + 1,
+                    lease_owner = NULL, lease_expires_at = NULL, updated_at = ?3
+                 WHERE intent_id = ?4 AND status = 'pending' AND lease_owner = ?5
+                   AND lease_expires_at > ?3",
+                params![
+                    status.as_str(),
+                    bounded_json(&error)?,
+                    now_s,
+                    intent_id,
+                    owner,
+                ],
+            )
+            .map_err(storage_error)?;
+        Ok(changed == 1)
+    }
+
     /// Terminalize a publication intent whose artifact head was superseded by
     /// a newer review cycle without charging the publication retry budget.
+    pub fn supersede_review_publication_owned(
+        &mut self,
+        intent_id: &str,
+        owner: &str,
+        error: FactoryError,
+    ) -> Result<bool> {
+        let now_s = ts(Self::now());
+        let changed = self
+            .conn
+            .execute(
+                "UPDATE review_publication_intents SET status = ?1,
+                 last_error_json = ?2, lease_owner = NULL, lease_expires_at = NULL,
+                 updated_at = ?3
+                 WHERE intent_id = ?4 AND status = ?5 AND lease_owner = ?6
+                   AND lease_expires_at > ?3",
+                params![
+                    PublicationStatus::Conflict.as_str(),
+                    bounded_json(&error)?,
+                    now_s,
+                    intent_id,
+                    PublicationStatus::Pending.as_str(),
+                    owner,
+                ],
+            )
+            .map_err(storage_error)?;
+        if changed > 0 {
+            return Ok(true);
+        }
+        let exists: Option<String> = self
+            .conn
+            .query_row(
+                "SELECT status FROM review_publication_intents WHERE intent_id = ?1",
+                params![intent_id],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(storage_error)?;
+        if exists.is_none() {
+            return Err(SymphonyError::StorageError(format!(
+                "review intent {intent_id} not found"
+            )));
+        }
+        Ok(false)
+    }
+
+    #[cfg(test)]
     pub fn supersede_review_publication(
         &mut self,
         intent_id: &str,
@@ -4520,7 +4825,7 @@ impl SqliteFactoryStore {
                  last_error_json = ?2, lease_owner = NULL, lease_expires_at = NULL,
                  updated_at = ?3
                  WHERE intent_id = ?4 AND status = ?5
-                   AND (lease_owner IS NULL OR lease_expires_at IS NULL OR lease_expires_at < ?3)",
+                   AND (lease_owner IS NULL OR lease_expires_at IS NULL OR lease_expires_at <= ?3)",
                 params![
                     PublicationStatus::Conflict.as_str(),
                     bounded_json(&error)?,
@@ -7125,8 +7430,32 @@ mod tests {
                     observed_baseline_json, expected_projection_json,
                     created_at, updated_at
                  ) VALUES ('review-superseded', 'run-review', 'artifact-review',
-                    'automatic', 'pending', '[]', 0, '{}', '{}', '{}', ?1, ?1)",
+                    'automatic', 'pending', '[]', 4, '{}', '{}', '{}', ?1, ?1)",
                 params![now],
+            )
+            .unwrap();
+
+        assert!(store
+            .claim_review_publication("review-superseded", "owner-a", 900)
+            .unwrap());
+        assert!(!store
+            .supersede_review_publication(
+                "review-superseded",
+                FactoryError::new(
+                    "review_publication_superseded_active",
+                    "review_publisher",
+                    "an active publisher lease must win",
+                    false,
+                    None,
+                ),
+            )
+            .unwrap());
+        store
+            .conn
+            .execute(
+                "UPDATE review_publication_intents SET lease_expires_at = ?1
+                 WHERE intent_id = 'review-superseded'",
+                params![ts(Utc::now() - Duration::seconds(1))],
             )
             .unwrap();
 
@@ -7160,12 +7489,246 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(intent.status, PublicationStatus::Conflict);
-        assert_eq!(intent.retry_count, 0);
+        assert_eq!(intent.retry_count, 4);
         assert_eq!(
             intent.last_error.unwrap().code,
             "review_publication_superseded"
         );
         assert!(store.list_pending_review_publications().unwrap().is_empty());
+    }
+
+    #[test]
+    fn terminal_review_publications_ignore_stale_writers() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("state.db");
+        let mut store = store(&path);
+        let now = Utc::now().to_rfc3339();
+        store
+            .conn
+            .execute_batch("PRAGMA foreign_keys = OFF")
+            .unwrap();
+        for (intent_id, status, retry_count) in [
+            ("review-applied", "applied", 2),
+            ("review-conflict", "conflict", 3),
+            ("review-blocked", "blocked", 4),
+        ] {
+            store
+                .conn
+                .execute(
+                    &format!(
+                        "INSERT INTO review_publication_intents (
+                            intent_id, run_id, artifact_id, kind, status,
+                            completed_steps_json, retry_count, desired_effects_json,
+                            observed_baseline_json, expected_projection_json,
+                            created_at, updated_at
+                         ) VALUES ('{intent_id}', 'run-review', 'artifact-{intent_id}',
+                            'formal', '{status}', '[]', {retry_count}, '{{}}', '{{}}', '{{}}', ?1, ?1)"
+                    ),
+                    params![now],
+                )
+                .unwrap();
+        }
+
+        for intent_id in ["review-applied", "review-conflict", "review-blocked"] {
+            store
+                .record_review_publication_step(
+                    intent_id,
+                    "comment_final",
+                    PublicationStatus::Pending,
+                    &serde_json::json!({"stale": true}),
+                )
+                .unwrap();
+            store
+                .set_review_publication_route_state(intent_id, "Human Review")
+                .unwrap();
+            store
+                .set_review_publication_error(
+                    intent_id,
+                    PublicationStatus::Blocked,
+                    FactoryError::new(
+                        "stale_writer",
+                        "review_publisher",
+                        "must not overwrite terminal state",
+                        false,
+                        None,
+                    ),
+                )
+                .unwrap();
+        }
+
+        for (intent_id, status, retry_count) in [
+            ("review-applied", PublicationStatus::Applied, 2),
+            ("review-conflict", PublicationStatus::Conflict, 3),
+            ("review-blocked", PublicationStatus::Blocked, 4),
+        ] {
+            let intent = store
+                .get_review_publication_intent(intent_id)
+                .unwrap()
+                .unwrap();
+            assert_eq!(intent.status, status);
+            assert_eq!(intent.retry_count, retry_count);
+            assert!(intent.completed_steps.is_empty());
+            assert!(intent.route_state.is_none());
+        }
+    }
+
+    #[test]
+    fn owned_publication_mutations_require_an_active_lease() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("state.db");
+        let mut store = store(&path);
+        let now = Utc::now().to_rfc3339();
+        store
+            .conn
+            .execute_batch("PRAGMA foreign_keys = OFF")
+            .unwrap();
+        store
+            .conn
+            .execute(
+                "INSERT INTO review_publication_intents (
+                    intent_id, run_id, artifact_id, kind, status,
+                    completed_steps_json, retry_count, desired_effects_json,
+                    observed_baseline_json, expected_projection_json,
+                    created_at, updated_at
+                 ) VALUES ('review-owned', 'run-review', 'artifact-review',
+                    'formal', 'pending', '[]', 2, '{}', '{}', '{}', ?1, ?1)",
+                params![now],
+            )
+            .unwrap();
+
+        assert!(store
+            .claim_review_publication("review-owned", "owner-a", 900)
+            .unwrap());
+        store
+            .conn
+            .execute(
+                "UPDATE review_publication_intents SET lease_expires_at = ?1
+                 WHERE intent_id = 'review-owned'",
+                params![ts(Utc::now() - Duration::seconds(1))],
+            )
+            .unwrap();
+
+        assert!(
+            !store
+                .bind_review_publication_comment_owned(
+                    "review-owned",
+                    "owner-a",
+                    "701",
+                    "symphony-bot",
+                )
+                .unwrap()
+        );
+        assert!(!store
+            .clear_review_publication_comment_owned("review-owned", "owner-a")
+            .unwrap());
+        assert!(!store
+            .bind_review_publication_review_owned(
+                "review-owned",
+                "owner-a",
+                "review-1",
+                "https://example.test/review-1",
+                "symphony-bot",
+            )
+            .unwrap());
+        assert!(!store
+            .set_review_publication_route_state_owned("review-owned", "owner-a", "Human Review")
+            .unwrap());
+        assert!(!store
+            .record_review_publication_step_owned(
+                "review-owned",
+                "owner-a",
+                "review_created",
+                PublicationStatus::Pending,
+                &serde_json::json!({"stale": true}),
+            )
+            .unwrap());
+        assert!(!store
+            .set_review_publication_error_owned(
+                "review-owned",
+                "owner-a",
+                PublicationStatus::Blocked,
+                FactoryError::new(
+                    "stale_writer",
+                    "review_publisher",
+                    "expired lease must not write",
+                    false,
+                    None,
+                ),
+            )
+            .unwrap());
+
+        assert!(store
+            .claim_review_publication("review-owned", "owner-b", 900)
+            .unwrap());
+        store
+            .set_review_publication_route_state("review-owned", "Human Review")
+            .unwrap();
+        store
+            .record_review_publication_step(
+                "review-owned",
+                "route_applied",
+                PublicationStatus::Pending,
+                &serde_json::json!({"stale": true}),
+            )
+            .unwrap();
+        store
+            .set_review_publication_error(
+                "review-owned",
+                PublicationStatus::Blocked,
+                FactoryError::new(
+                    "stale_writer",
+                    "review_publisher",
+                    "unowned writer must not bypass owner-b",
+                    false,
+                    None,
+                ),
+            )
+            .unwrap();
+        let pending = store
+            .get_review_publication_intent("review-owned")
+            .unwrap()
+            .unwrap();
+        assert_eq!(pending.status, PublicationStatus::Pending);
+        assert!(pending.completed_steps.is_empty());
+        assert!(pending.route_state.is_none());
+        assert_eq!(pending.retry_count, 2);
+
+        assert!(store
+            .bind_review_publication_review_owned(
+                "review-owned",
+                "owner-b",
+                "review-1",
+                "https://example.test/review-1",
+                "symphony-bot",
+            )
+            .unwrap());
+        assert!(store
+            .record_review_publication_step_owned(
+                "review-owned",
+                "owner-b",
+                "review_created",
+                PublicationStatus::Pending,
+                &serde_json::json!({"review_id": "review-1"}),
+            )
+            .unwrap());
+        assert!(store
+            .record_review_publication_step_owned(
+                "review-owned",
+                "owner-b",
+                "comment_final",
+                PublicationStatus::Pending,
+                &serde_json::json!({"review_id": "review-1"}),
+            )
+            .unwrap());
+
+        let applied = store
+            .get_review_publication_intent("review-owned")
+            .unwrap()
+            .unwrap();
+        assert_eq!(applied.status, PublicationStatus::Applied);
+        assert_eq!(applied.retry_count, 2);
+        assert_eq!(applied.completed_steps, ["review_created", "comment_final"]);
+        assert_eq!(applied.route_state, None);
     }
 
     #[test]
@@ -7196,6 +7759,18 @@ mod tests {
             .claim_review_publication("review-lease", "owner-a", 900)
             .unwrap());
         assert!(!store
+            .supersede_review_publication(
+                "review-lease",
+                FactoryError::new(
+                    "review_publication_superseded",
+                    "review_publisher",
+                    "active lease must win",
+                    false,
+                    None,
+                ),
+            )
+            .unwrap());
+        assert!(!store
             .claim_review_publication("review-lease", "owner-b", 900)
             .unwrap());
         store
@@ -7203,6 +7778,33 @@ mod tests {
             .unwrap();
         assert!(store
             .claim_review_publication("review-lease", "owner-b", 900)
+            .unwrap());
+        assert!(!store
+            .supersede_review_publication(
+                "review-lease",
+                FactoryError::new(
+                    "review_publication_superseded",
+                    "review_publisher",
+                    "active lease must still win",
+                    false,
+                    None,
+                ),
+            )
+            .unwrap());
+        store
+            .clear_review_publication_lease("review-lease", "owner-b")
+            .unwrap();
+        assert!(store
+            .supersede_review_publication(
+                "review-lease",
+                FactoryError::new(
+                    "review_publication_superseded",
+                    "review_publisher",
+                    "released lease can be superseded",
+                    false,
+                    None,
+                ),
+            )
             .unwrap());
     }
 

--- a/apps/symphony/src/triage/store.rs
+++ b/apps/symphony/src/triage/store.rs
@@ -36,13 +36,14 @@ use std::time::Duration as StdDuration;
 use uuid::Uuid;
 
 /// Embedded migrations, applied in order while the exclusive store lock is held.
-const MIGRATIONS: [&str; 6] = [
+const MIGRATIONS: [&str; 7] = [
     include_str!("migrations/001_init.sql"),
     include_str!("migrations/002_route_observations.sql"),
     include_str!("migrations/003_spec_stage.sql"),
     include_str!("migrations/004_implementation_stage.sql"),
     include_str!("migrations/005_implementation_draft_pr.sql"),
     include_str!("migrations/006_review_stage.sql"),
+    include_str!("migrations/007_review_publication.sql"),
 ];
 
 #[derive(Debug, Clone)]
@@ -499,8 +500,12 @@ impl SqliteFactoryStore {
         let conn = Connection::open(path).map_err(storage_error)?;
         conn.busy_timeout(StdDuration::from_millis(busy_timeout_ms))
             .map_err(storage_error)?;
-        for migration in MIGRATIONS {
-            conn.execute_batch(migration).map_err(storage_error)?;
+        for (index, migration) in MIGRATIONS.iter().enumerate() {
+            if index == 6 {
+                apply_review_publication_migration(&conn, migration).map_err(storage_error)?;
+            } else {
+                conn.execute_batch(migration).map_err(storage_error)?;
+            }
         }
 
         Ok(Self {
@@ -4001,7 +4006,8 @@ impl SqliteFactoryStore {
             .query_row(
                 "SELECT intent_id, run_id, artifact_id, kind, status,
                     completed_steps_json, retry_count, last_error_json, comment_id,
-                    publisher_login, desired_effects_json, observed_baseline_json,
+                    publisher_login, review_id, review_url, route_state,
+                    desired_effects_json, observed_baseline_json,
                     expected_projection_json, created_at, updated_at
                  FROM review_publication_intents WHERE intent_id = ?1",
                 params![intent_id],
@@ -4017,7 +4023,8 @@ impl SqliteFactoryStore {
             .prepare(
                 "SELECT intent_id, run_id, artifact_id, kind, status,
                     completed_steps_json, retry_count, last_error_json, comment_id,
-                    publisher_login, desired_effects_json, observed_baseline_json,
+                    publisher_login, review_id, review_url, route_state,
+                    desired_effects_json, observed_baseline_json,
                     expected_projection_json, created_at, updated_at
                  FROM review_publication_intents WHERE status = 'pending'
                  ORDER BY created_at ASC",
@@ -4039,7 +4046,8 @@ impl SqliteFactoryStore {
             .prepare(
                 "SELECT intent_id, run_id, artifact_id, kind, status,
                     completed_steps_json, retry_count, last_error_json, comment_id,
-                    publisher_login, desired_effects_json, observed_baseline_json,
+                    publisher_login, review_id, review_url, route_state,
+                    desired_effects_json, observed_baseline_json,
                     expected_projection_json, created_at, updated_at
                  FROM review_publication_intents WHERE run_id = ?1
                  ORDER BY created_at DESC",
@@ -4080,12 +4088,117 @@ impl SqliteFactoryStore {
         Ok(())
     }
 
+    /// Bind the identity returned by the forge for a formal review.
+    pub fn bind_review_publication_review(
+        &mut self,
+        intent_id: &str,
+        review_id: &str,
+        review_url: &str,
+        publisher_login: &str,
+    ) -> Result<()> {
+        let changed = self
+            .conn
+            .execute(
+                "UPDATE review_publication_intents
+                 SET review_id = ?1, review_url = ?2, publisher_login = ?3,
+                     updated_at = ?4 WHERE intent_id = ?5",
+                params![
+                    review_id,
+                    review_url,
+                    publisher_login,
+                    ts(Self::now()),
+                    intent_id
+                ],
+            )
+            .map_err(storage_error)?;
+        if changed == 0 {
+            return Err(SymphonyError::StorageError(format!(
+                "review intent {intent_id} not found"
+            )));
+        }
+        Ok(())
+    }
+
+    pub fn set_review_publication_route_state(
+        &mut self,
+        intent_id: &str,
+        route_state: &str,
+    ) -> Result<()> {
+        let changed = self
+            .conn
+            .execute(
+                "UPDATE review_publication_intents
+                 SET route_state = ?1, updated_at = ?2 WHERE intent_id = ?3",
+                params![route_state, ts(Self::now()), intent_id],
+            )
+            .map_err(storage_error)?;
+        if changed == 0 {
+            return Err(SymphonyError::StorageError(format!(
+                "review intent {intent_id} not found"
+            )));
+        }
+        Ok(())
+    }
+
+    /// Record one formal publication step. Only `comment_final` terminalizes
+    /// the intent, allowing restart to resume at the first incomplete step.
+    pub fn record_review_publication_step(
+        &mut self,
+        intent_id: &str,
+        step: &str,
+        status: PublicationStatus,
+        expected_projection: &serde_json::Value,
+    ) -> Result<()> {
+        let intent = self
+            .get_review_publication_intent(intent_id)?
+            .ok_or_else(|| {
+                SymphonyError::StorageError(format!("review intent {intent_id} not found"))
+            })?;
+        if intent.status == PublicationStatus::Applied {
+            return Ok(());
+        }
+        let mut steps = intent.completed_steps;
+        let trimmed = step.trim();
+        if !trimmed.is_empty() && !steps.iter().any(|existing| existing == trimmed) {
+            steps.push(trimmed.to_string());
+        }
+        let next_status = if trimmed == "comment_final" {
+            PublicationStatus::Applied
+        } else if status == PublicationStatus::Applied {
+            PublicationStatus::Pending
+        } else {
+            status
+        };
+        self.conn
+            .execute(
+                "UPDATE review_publication_intents
+                 SET completed_steps_json = ?1, status = ?2, last_error_json = NULL,
+                     expected_projection_json = ?3, updated_at = ?4
+                 WHERE intent_id = ?5",
+                params![
+                    bounded_json(&steps)?,
+                    next_status.as_str(),
+                    bounded_json(expected_projection)?,
+                    ts(Self::now()),
+                    intent_id,
+                ],
+            )
+            .map_err(storage_error)?;
+        Ok(())
+    }
+
     pub fn complete_review_publication(&mut self, intent_id: &str, step: &str) -> Result<()> {
         let intent = self
             .get_review_publication_intent(intent_id)?
             .ok_or_else(|| {
                 SymphonyError::StorageError(format!("review intent {intent_id} not found"))
             })?;
+        if intent.kind != "preview" {
+            return Err(SymphonyError::TriageError(format!(
+                "review publication helper only supports preview intents, got kind={}",
+                intent.kind
+            )));
+        }
         let mut steps = intent.completed_steps;
         if !steps.iter().any(|existing| existing == step) {
             steps.push(step.to_string());
@@ -4560,6 +4673,35 @@ fn review_artifact_from_row(
     })
 }
 
+fn apply_review_publication_migration(conn: &Connection, migration: &str) -> rusqlite::Result<()> {
+    let migration = migration
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("--"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    for statement in migration
+        .split(';')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        let column = statement
+            .split_whitespace()
+            .nth(5)
+            .ok_or_else(|| rusqlite::Error::InvalidQuery)?;
+        let exists: bool = conn.query_row(
+            "SELECT EXISTS(
+                SELECT 1 FROM pragma_table_info('review_publication_intents') WHERE name = ?1
+            )",
+            params![column],
+            |row| row.get(0),
+        )?;
+        if !exists {
+            conn.execute_batch(statement)?;
+        }
+    }
+    Ok(())
+}
+
 fn review_publication_from_row(
     row: &rusqlite::Row<'_>,
 ) -> rusqlite::Result<ReviewPublicationIntent> {
@@ -4575,11 +4717,14 @@ fn review_publication_from_row(
         last_error: optional_from_json(row.get::<_, Option<String>>(7)?)?,
         comment_id: row.get(8)?,
         publisher_login: row.get(9)?,
-        desired_effects: serde_json::from_str(&row.get::<_, String>(10)?).map_err(row_error)?,
-        observed_baseline: serde_json::from_str(&row.get::<_, String>(11)?).map_err(row_error)?,
-        expected_projection: serde_json::from_str(&row.get::<_, String>(12)?).map_err(row_error)?,
-        created_at: parse_ts_row(row.get::<_, String>(13)?)?,
-        updated_at: parse_ts_row(row.get::<_, String>(14)?)?,
+        review_id: row.get(10)?,
+        review_url: row.get(11)?,
+        route_state: row.get(12)?,
+        desired_effects: serde_json::from_str(&row.get::<_, String>(13)?).map_err(row_error)?,
+        observed_baseline: serde_json::from_str(&row.get::<_, String>(14)?).map_err(row_error)?,
+        expected_projection: serde_json::from_str(&row.get::<_, String>(15)?).map_err(row_error)?,
+        created_at: parse_ts_row(row.get::<_, String>(16)?)?,
+        updated_at: parse_ts_row(row.get::<_, String>(17)?)?,
     })
 }
 
@@ -6074,6 +6219,30 @@ mod tests {
             )
             .unwrap();
         assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn reopening_store_reapplies_review_publication_migration_idempotently() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("state.db");
+        let first = store(&path);
+        drop(first);
+
+        let reopened = store(&path);
+        for column in ["review_id", "review_url", "route_state"] {
+            let exists: bool = reopened
+                .conn
+                .query_row(
+                    "SELECT EXISTS(
+                        SELECT 1 FROM pragma_table_info('review_publication_intents')
+                        WHERE name = ?1
+                    )",
+                    params![column],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            assert!(exists, "missing review publication column {column}");
+        }
     }
 
     #[test]

--- a/apps/symphony/tests/github_client_tests.rs
+++ b/apps/symphony/tests/github_client_tests.rs
@@ -428,6 +428,72 @@ async fn test_list_pull_request_reviews_returns_author_marker_and_commit() {
 }
 
 #[tokio::test]
+async fn test_probe_pull_request_review_permission_accepts_unprocessable_entity() {
+    let mut server = Server::new_async().await;
+    let client = test_client(&server);
+
+    let mock = server
+        .mock("POST", "/repos/kata-sh/kata-mono/pulls/11/reviews")
+        .match_body(Matcher::PartialJson(json!({ "event": "INVALID" })))
+        .with_status(422)
+        .with_body("invalid review event")
+        .create_async()
+        .await;
+
+    client
+        .probe_pull_request_review_permission(11)
+        .await
+        .expect("HTTP 422 proves review endpoint authorization");
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn test_probe_pull_request_review_permission_rejects_forbidden() {
+    let mut server = Server::new_async().await;
+    let client = test_client(&server);
+
+    let mock = server
+        .mock("POST", "/repos/kata-sh/kata-mono/pulls/11/reviews")
+        .with_status(403)
+        .with_body("forbidden")
+        .create_async()
+        .await;
+
+    let error = client
+        .probe_pull_request_review_permission(11)
+        .await
+        .expect_err("HTTP 403 must fail the permission probe");
+    mock.assert_async().await;
+    assert!(matches!(
+        error,
+        SymphonyError::GithubApiStatus { status: 403, .. }
+    ));
+}
+
+#[tokio::test]
+async fn test_probe_pull_request_review_permission_rejects_unexpected_success() {
+    let mut server = Server::new_async().await;
+    let client = test_client(&server);
+
+    let mock = server
+        .mock("POST", "/repos/kata-sh/kata-mono/pulls/11/reviews")
+        .with_status(201)
+        .with_body("created")
+        .create_async()
+        .await;
+
+    let error = client
+        .probe_pull_request_review_permission(11)
+        .await
+        .expect_err("successful review creation must fail the invalid-event probe");
+    mock.assert_async().await;
+    assert!(matches!(
+        error,
+        SymphonyError::GithubApiStatus { status: 201, .. }
+    ));
+}
+
+#[tokio::test]
 async fn test_create_pull_request_review_serializes_multiline_anchors_and_omits_single_line_fields()
 {
     let mut server = Server::new_async().await;

--- a/apps/symphony/tests/github_client_tests.rs
+++ b/apps/symphony/tests/github_client_tests.rs
@@ -4,7 +4,7 @@ use chrono::Utc;
 use mockito::{Matcher, Server, ServerGuard};
 use serde_json::json;
 use symphony::error::SymphonyError;
-use symphony::github::client::GithubClient;
+use symphony::github::client::{GithubClient, GithubPullRequestReviewComment};
 
 fn test_client(server: &ServerGuard) -> GithubClient {
     GithubClient::with_base_url(
@@ -384,6 +384,129 @@ async fn test_list_pull_requests_filters_head_base_state() {
     assert!(prs[0].draft);
     assert_eq!(prs[0].head.ref_name, "symphony/42");
     assert_eq!(prs[0].head.sha, "abc123");
+}
+
+#[tokio::test]
+async fn test_list_pull_request_reviews_returns_author_marker_and_commit() {
+    let mut server = Server::new_async().await;
+    let client = test_client(&server);
+
+    let mock = server
+        .mock("GET", "/repos/kata-sh/kata-mono/pulls/11/reviews")
+        .match_query(Matcher::UrlEncoded("per_page".into(), "100".into()))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!([{
+                "id": 73,
+                "user": { "login": "symphony-bot" },
+                "body": "<!-- symphony:review:intent-7 -->\\nSummary",
+                "commit_id": "head-sha",
+                "state": "COMMENTED",
+                "html_url": "https://github.com/kata-sh/kata-mono/pull/11#pullrequestreview-73",
+                "submitted_at": "2026-07-30T10:00:00Z"
+            }])
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let reviews = client
+        .list_pull_request_reviews(11, 2)
+        .await
+        .expect("list_pull_request_reviews");
+    mock.assert_async().await;
+    assert_eq!(reviews.len(), 1);
+    assert_eq!(reviews[0].id, 73);
+    assert_eq!(reviews[0].user.as_ref().unwrap().login, "symphony-bot");
+    assert!(reviews[0]
+        .body
+        .as_deref()
+        .unwrap()
+        .contains("<!-- symphony:review:intent-7 -->"));
+    assert_eq!(reviews[0].commit_id, "head-sha");
+}
+
+#[tokio::test]
+async fn test_create_pull_request_review_serializes_multiline_anchors_and_omits_single_line_fields()
+{
+    let mut server = Server::new_async().await;
+    let client = test_client(&server);
+
+    let mock = server
+        .mock("POST", "/repos/kata-sh/kata-mono/pulls/11/reviews")
+        .match_header("content-type", Matcher::Regex("application/json".into()))
+        .match_body(Matcher::Json(json!({
+            "commit_id": "head-sha",
+            "body": "<!-- symphony:review:intent-7 -->\\nSummary",
+            "event": "COMMENT",
+            "comments": [
+                {
+                    "path": "src/lib.rs",
+                    "line": 27,
+                    "side": "RIGHT",
+                    "start_line": 24,
+                    "start_side": "RIGHT",
+                    "body": "Handle this error before publishing."
+                },
+                {
+                    "path": "src/main.rs",
+                    "line": 10,
+                    "side": "RIGHT",
+                    "body": "Handle this error before publishing."
+                }
+            ]
+        })))
+        .with_status(201)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "id": 73,
+                "user": { "login": "symphony-bot" },
+                "body": "<!-- symphony:review:intent-7 -->\\nSummary",
+                "commit_id": "head-sha",
+                "state": "COMMENTED",
+                "html_url": "https://github.com/kata-sh/kata-mono/pull/11#pullrequestreview-73"
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+
+    let review = client
+        .create_pull_request_review(
+            11,
+            "head-sha",
+            "<!-- symphony:review:intent-7 -->\\nSummary",
+            &[
+                GithubPullRequestReviewComment {
+                    path: "src/lib.rs".to_string(),
+                    line: 27,
+                    side: "RIGHT".to_string(),
+                    start_line: Some(24),
+                    start_side: Some("RIGHT".to_string()),
+                    body: "Handle this error before publishing.".to_string(),
+                },
+                GithubPullRequestReviewComment {
+                    path: "src/main.rs".to_string(),
+                    line: 10,
+                    side: "RIGHT".to_string(),
+                    start_line: None,
+                    start_side: None,
+                    body: "Handle this error before publishing.".to_string(),
+                },
+            ],
+        )
+        .await
+        .expect("create_pull_request_review");
+    mock.assert_async().await;
+    assert_eq!(review.id, 73);
+    assert_eq!(review.commit_id, "head-sha");
+    assert_eq!(review.user.as_ref().unwrap().login, "symphony-bot");
+    assert_eq!(
+        review.html_url.as_deref(),
+        Some("https://github.com/kata-sh/kata-mono/pull/11#pullrequestreview-73")
+    );
 }
 
 #[tokio::test]

--- a/apps/symphony/tests/github_client_tests.rs
+++ b/apps/symphony/tests/github_client_tests.rs
@@ -424,7 +424,7 @@ async fn test_list_pull_request_reviews_returns_author_marker_and_commit() {
         .as_deref()
         .unwrap()
         .contains("<!-- symphony:review:intent-7 -->"));
-    assert_eq!(reviews[0].commit_id, "head-sha");
+    assert_eq!(reviews[0].commit_id.as_deref(), Some("head-sha"));
 }
 
 #[tokio::test]
@@ -567,7 +567,7 @@ async fn test_create_pull_request_review_serializes_multiline_anchors_and_omits_
         .expect("create_pull_request_review");
     mock.assert_async().await;
     assert_eq!(review.id, 73);
-    assert_eq!(review.commit_id, "head-sha");
+    assert_eq!(review.commit_id.as_deref(), Some("head-sha"));
     assert_eq!(review.user.as_ref().unwrap().login, "symphony-bot");
     assert_eq!(
         review.html_url.as_deref(),

--- a/apps/symphony/tests/http_server_tests.rs
+++ b/apps/symphony/tests/http_server_tests.rs
@@ -1457,12 +1457,37 @@ fn sample_blocked_publication() -> symphony::http_server::BlockedPublicationHttp
     }
 }
 
+fn sample_blocked_review_publication() -> symphony::http_server::BlockedPublicationHttpResponse {
+    symphony::http_server::BlockedPublicationHttpResponse {
+        intent_id: "review-intent-blocked-1".to_string(),
+        run_id: "run-review-7".to_string(),
+        kind: "formal".to_string(),
+        retry_count: 3,
+        last_step: Some("review_created".to_string()),
+        error_code: Some("review_publication_retry_exhausted".to_string()),
+        error_remediation: Some("Restore forge access and retry.".to_string()),
+        updated_at: Utc
+            .with_ymd_and_hms(2026, 7, 30, 9, 16, 0)
+            .single()
+            .expect("timestamp"),
+    }
+}
+
 fn sample_publication_reset() -> symphony::http_server::BlockedPublicationResetHttpResponse {
     symphony::http_server::BlockedPublicationResetHttpResponse {
         intent_id: "intent-blocked-1".to_string(),
         run_id: "run-7".to_string(),
         status: "pending".to_string(),
         completed_steps: vec!["comment_pending".to_string()],
+    }
+}
+
+fn sample_review_publication_reset() -> symphony::http_server::BlockedPublicationResetHttpResponse {
+    symphony::http_server::BlockedPublicationResetHttpResponse {
+        intent_id: "review-intent-blocked-1".to_string(),
+        run_id: "run-review-7".to_string(),
+        status: "pending".to_string(),
+        completed_steps: vec!["review_created".to_string()],
     }
 }
 
@@ -1714,6 +1739,7 @@ async fn test_factory_run_metrics_stage_validation() {
             },
             blocked_publications: 1,
             preview_publications: 1,
+            automatic_publications: 2,
             findings: 0,
             no_findings: 1,
         }),
@@ -1746,6 +1772,8 @@ async fn test_factory_run_metrics_stage_validation() {
     let review_payload = body_json(review).await;
     assert_eq!(review_payload["stage"], "review");
     assert_eq!(review_payload["blocked_publications"], 1);
+    assert_eq!(review_payload["preview_publications"], 1);
+    assert_eq!(review_payload["automatic_publications"], 2);
     assert_eq!(review_payload["no_findings"], 1);
 
     let missing_stage = app
@@ -1876,7 +1904,10 @@ async fn unused_base_url() -> String {
 #[tokio::test]
 async fn test_blocked_publications_route_returns_the_blocked_set() {
     let app = router_with_factory_query(FakeFactoryRunQuery {
-        blocked_publications: Some(vec![sample_blocked_publication()]),
+        blocked_publications: Some(vec![
+            sample_blocked_publication(),
+            sample_blocked_review_publication(),
+        ]),
         ..Default::default()
     });
 
@@ -1898,6 +1929,11 @@ async fn test_blocked_publications_route_returns_the_blocked_set() {
     assert_eq!(
         payload["blocked"][0]["error_code"],
         "publication_retry_exhausted"
+    );
+    assert_eq!(payload["blocked"][1]["kind"], "formal");
+    assert_eq!(
+        payload["blocked"][1]["intent_id"],
+        "review-intent-blocked-1"
     );
 }
 
@@ -1950,6 +1986,39 @@ async fn test_publication_reset_route_records_the_operator() {
     assert_eq!(
         operators.lock().expect("operators lock").as_slice(),
         [("intent-blocked-1".to_string(), "ada".to_string())]
+    );
+}
+
+#[tokio::test]
+async fn test_review_publication_reset_route_preserves_review_steps() {
+    let operators = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let app = router_with_factory_query(FakeFactoryRunQuery {
+        resets: BTreeMap::from([(
+            "review-intent-blocked-1".to_string(),
+            Ok(sample_review_publication_reset()),
+        )]),
+        reset_operators: Arc::clone(&operators),
+        ..Default::default()
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/api/v1/publications/review-intent-blocked-1/reset?operator=ada")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload = body_json(response).await;
+    assert_eq!(payload["intent_id"], "review-intent-blocked-1");
+    assert_eq!(payload["completed_steps"][0], "review_created");
+    assert_eq!(
+        operators.lock().expect("operators lock").as_slice(),
+        [("review-intent-blocked-1".to_string(), "ada".to_string())]
     );
 }
 

--- a/apps/symphony/tests/review_config_tests.rs
+++ b/apps/symphony/tests/review_config_tests.rs
@@ -59,8 +59,10 @@ fn review_defaults_validate_and_explicit_routes_parse() {
         serde_yaml::Value::String("Human Review".to_string());
     raw["review"]["changes_requested_route"]["state"] =
         serde_yaml::Value::String("Rework".to_string());
+    raw["review"]["permission_probe_pull_request"] = serde_yaml::Value::Number(17.into());
 
     let config = from_workflow(&raw).expect("explicit review settings should parse");
+    assert_eq!(config.review.permission_probe_pull_request, Some(17));
     assert!(config.review.enabled);
     assert_eq!(config.review.max_attempts, 4);
     assert_eq!(
@@ -151,6 +153,15 @@ fn review_prompt_and_trigger_state_must_be_non_empty() {
     let mut trigger = review_config();
     trigger.review.trigger_state = "  ".to_string();
     assert!(review_error(trigger).contains("review.trigger_state must be non-empty"));
+}
+
+#[test]
+fn review_permission_probe_pull_request_rejects_zero() {
+    let mut raw = raw_review_workflow();
+    raw["review"]["permission_probe_pull_request"] = serde_yaml::Value::Number(0.into());
+    let config = from_workflow(&raw).expect("zero probe PR should parse before validation");
+    let message = review_error(config);
+    assert!(message.contains("review.permission_probe_pull_request must be greater than 0"));
 }
 
 #[test]

--- a/apps/symphony/tests/review_config_tests.rs
+++ b/apps/symphony/tests/review_config_tests.rs
@@ -3,6 +3,7 @@
 use symphony::config::{from_workflow, validate};
 use symphony::domain::AgentBackend;
 use symphony::error::SymphonyError;
+use symphony::review::manifest::ReviewSeverity;
 
 const REVIEW_WORKFLOW: &str = r#"
 tracker:
@@ -71,6 +72,54 @@ fn review_defaults_validate_and_explicit_routes_parse() {
         Some("Human Review")
     );
     validate(&config).expect("complete automatic review configuration should validate");
+}
+
+#[test]
+fn review_blocking_severity_parses_all_supported_values() {
+    for (value, expected) in [
+        ("blocking", ReviewSeverity::Blocking),
+        ("major", ReviewSeverity::Major),
+        ("minor", ReviewSeverity::Minor),
+        ("nit", ReviewSeverity::Nit),
+    ] {
+        let mut raw = raw_review_workflow();
+        raw["review"]["blocking_severity"] = serde_yaml::Value::String(value.to_string());
+        let config = from_workflow(&raw).expect("blocking severity should parse");
+        assert_eq!(config.review.blocking_severity, expected);
+    }
+
+    let config = review_config();
+    assert_eq!(config.review.blocking_severity, ReviewSeverity::Blocking);
+}
+
+#[test]
+fn review_blocking_severity_rejects_invalid_values() {
+    let mut raw = raw_review_workflow();
+    raw["review"]["blocking_severity"] = serde_yaml::Value::String("critical".to_string());
+    let error = from_workflow(&raw).expect_err("invalid blocking severity should fail");
+    match error {
+        SymphonyError::InvalidWorkflowConfig(message) => {
+            assert!(message.contains(
+                "review.blocking_severity must be 'blocking', 'major', 'minor', or 'nit'"
+            ));
+            assert!(message.contains("got 'critical'"));
+        }
+        other => panic!("expected workflow config error, got {other}"),
+    }
+}
+
+#[test]
+fn review_config_deserialization_defaults_blocking_severity() {
+    let config = review_config();
+    let mut serialized =
+        serde_json::to_value(&config.review).expect("review config should serialize");
+    serialized
+        .as_object_mut()
+        .expect("serialized config should be an object")
+        .remove("blocking_severity");
+    let restored: symphony::review::domain::ReviewConfig =
+        serde_json::from_value(serialized).expect("old review config should deserialize");
+    assert_eq!(restored.blocking_severity, ReviewSeverity::Blocking);
 }
 
 #[test]

--- a/docs/adrs/0005-a4-review-publication-fencing.md
+++ b/docs/adrs/0005-a4-review-publication-fencing.md
@@ -1,0 +1,44 @@
+---
+type: ADR
+title: A4 durable review publication fencing
+status: Accepted
+description: Active leases and head-bound publication identities fence concurrent formal review publication, routing, recovery, and supersession writes.
+tags: [symphony, software-factory, a4, review, durability]
+timestamp: 2026-08-02T21:10:00Z
+---
+
+# ADR-0005 A4 durable review publication fencing
+
+## Status
+
+Accepted for A4 PR2 on `feat/a4-review-publication`.
+
+## Context
+
+Formal review publication spans GitHub review creation, durable identity and finding records, Projects v2 routing, and finalization. A restart or concurrent coordinator can observe the same pending intent while an earlier publisher is still completing a forge operation. Changed PR heads also invalidate an in-progress review cycle.
+
+## Decision
+
+1. Every worker-owned publication-row mutation uses a compare-and-set requiring `status = 'pending'`, the caller's lease owner, and an unexpired lease. Terminal rows reject stale step, identity, route, completion, error, and supersession writes.
+2. Formal, preview, and Projects v2 operations claim the intent before forge I/O. A one-second heartbeat renews the 900-second lease during each operation. Durable predicates remain authoritative when renewal fails or ownership changes.
+3. Changed-head supersession claims the same lease before terminalizing the stale intent as `conflict`. It preserves the retry budget and clears the lease only in the successful terminal update.
+4. Review identity recovery validates the authenticated publisher, marker ownership, and live PR head before recording `review_created`. Missing durable PR identity fails closed.
+5. The blocked/conflict reset endpoint remains an explicit operator recovery command. It uses a status CAS, clears the prior lease, preserves completed steps and forge identities, and records the operator event.
+6. Mainline and maintained UAT workflows stay preview-only. Automatic publication is exercised only in isolated formal UAT workflows.
+
+## Consequences
+
+- Concurrent coordinators cannot overwrite a pending intent owned by another active publisher or resurrect a terminal intent.
+- A healthy slow forge request renews its lease while the request is in flight. An external request already accepted by GitHub or Projects v2 cannot be cancelled by SQLite; marker ownership, live-head checks, reconciliation, and idempotent route writes provide recovery after process failure or provider delay.
+- Explicit operator reset is auditable and separate from worker publication ownership. HTTP control authentication remains a later platform slice.
+
+## Verification
+
+- Serial `cargo fmt --check`, Clippy with `-D warnings`, and the full Symphony suite pass.
+- Store tests cover active and expired leases, terminal stale writers, retry preservation, and supersession ownership.
+- Formal UAT against `gannonh/uat-symphony` PR #46 produced one `COMMENTED` review, applied all four durable steps, routed to `Human Review`, and restored the Project item to `Agent Review`. Evidence is under `/tmp/kata-symphony-current-uat-evidence/a4-pr2/formal-latest/`.
+
+## Links
+
+- [A4 Agent Review Stage](../specs/2026-07-30-a4-agent-review-stage-design.md)
+- [A4 PR2 verify report](../specs/2026-08-02-a4-pr2-verify-report.md)

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -10,6 +10,7 @@ When `/domain-modeling` or architecture work records a decision, place it under 
 * [ADR-0002 Triage process recovery identity](0002-triage-process-recovery-identity.md) - PID, process group, and OS start token authorize recovery; executable identity is diagnostic
 * [ADR-0003 A2 spec-stage artifacts and human gates](0003-a2-spec-stage-artifacts-and-gates.md) - stage-scoped attempts, isolated review turns, immutable versions, tracker decisions, pinned implementation handoff
 * [ADR-0004 A3 implementation durability and bundles](0004-a3-implementation-durability-and-bundles.md) - stage-scoped A3 records, content-addressed Git bundles, credential-isolated local execution, preview-only publication
+* [ADR-0005 A4 durable review publication fencing](0005-a4-review-publication-fencing.md) - active lease CAS fencing, heartbeat renewal, changed-head supersession, and explicit operator recovery
 
 # Proposed
 

--- a/docs/adrs/log.md
+++ b/docs/adrs/log.md
@@ -1,6 +1,9 @@
 # ADRs Update Log
 
 ## 2026-08-02
+* **Accepted**: [ADR-0005 A4 durable review publication fencing](0005-a4-review-publication-fencing.md) records active lease CAS writes, heartbeat renewal during forge calls, changed-head supersession ownership, and the explicit operator reset boundary.
+
+## 2026-08-02
 * **Updated**: [ADR-0004](/adrs/0004-a3-implementation-durability-and-bundles.md) records the additive typed factory snapshot used by the TUI and the completed direct draft-PR, Agent Review preview, and Ratatui UAT evidence on Project #16. Restart-during-publication, cleanup, and Docker coverage remain residuals.
 
 ## 2026-07-30

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,6 +1,6 @@
 ---
 type: Guide
-title: Issue tracker: GitHub
+title: "Issue tracker: GitHub"
 description: GitHub Issues conventions for gannonh/kata; PRs are not a triage surface.
 tags: [github, issues, agents]
 timestamp: 2026-07-15T20:00:00Z

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,10 +11,10 @@ Open Knowledge Format (OKF) bundle for the Kata monorepo: Kata CLI (`apps/cli`) 
 * [Symphony Software Factory Platform PRD](specs/symphony-software-factory-platform-prd.md) - product direction and vertical-slice roadmap (Active; A1+A2+A3 completed; A4 PR1 active)
 * [Specs roadmap](specs/) - active, planned, and completed work (links into historical Superpowers plans/specs)
 * [A3 Implementation Stage](specs/2026-07-26-a3-implementation-stage-design.md) - Complete; PR1+PR2 shipped ([#606](https://github.com/gannonh/kata-symphony/pull/606), [#607](https://github.com/gannonh/kata-symphony/pull/607)); direct draft-PR, Agent Review preview, and Ratatui TUI UAT verified on Project #16; restart/Docker residuals remain
-* [A4 Agent Review Stage](specs/2026-07-30-a4-agent-review-stage-design.md) - Active; PR1 review findings preview and typed TUI state are implemented; PR2 formal review publication and routing remain planned
+* [A4 Agent Review Stage](specs/2026-07-30-a4-agent-review-stage-design.md) - Active; PR1 preview and typed TUI state are implemented; PR2 formal publication, active-lease fencing, restart recovery, and live routing are verified with credential-isolation and Docker residuals
 * [A1 GitHub Issue Triage](specs/2026-07-16-a1-github-issue-triage-design.md) - completed GitHub path (PR1–PR3 shipped: [#587](https://github.com/gannonh/kata-symphony/pull/587), [#598](https://github.com/gannonh/kata-symphony/pull/598), [#599](https://github.com/gannonh/kata-symphony/pull/599)); Linear triage deferred
 * [A2 Spec Stage](specs/2026-07-18-a2-spec-stage-design.md) - completed; live UAT accepted ([verify](specs/2026-07-26-a2-uat-verify-report.md))
-* [ADRs](adrs/) - architecture decision records ([ADR-0001](adrs/0001-a1-triage-durability-and-isolation.md), [ADR-0002](adrs/0002-triage-process-recovery-identity.md), [ADR-0003](adrs/0003-a2-spec-stage-artifacts-and-gates.md), [ADR-0004](adrs/0004-a3-implementation-durability-and-bundles.md))
+* [ADRs](adrs/) - architecture decision records ([ADR-0001](adrs/0001-a1-triage-durability-and-isolation.md), [ADR-0002](adrs/0002-triage-process-recovery-identity.md), [ADR-0003](adrs/0003-a2-spec-stage-artifacts-and-gates.md), [ADR-0004](adrs/0004-a3-implementation-durability-and-bundles.md), [ADR-0005](adrs/0005-a4-review-publication-fencing.md))
 
 # Guides
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -4,6 +4,7 @@
 * **OKF frontmatter repaired**: Quoted colon-bearing titles and descriptions in the issue-tracker guide, active Wave 4 plan, and retained historical Superpowers plans/specs. Both standard and strict-link OKF validation now pass.
 
 ## 2026-08-02
+* **A4 PR2 manual formal UAT completed**: The [PR2 verify report](specs/2026-08-02-a4-pr2-verify-report.md) records live blocking-finding publication, `Rework` routing, restart reconciliation, one remote review, and cleanup for issue #47 / PR #48. Evidence is under `/tmp/kata-symphony-current-uat-evidence/a4-pr2/manual-47/`.
 * **A4 PR2 verified with residuals**: The [A4 design](specs/2026-07-30-a4-agent-review-stage-design.md) and [PR2 verify report](specs/2026-08-02-a4-pr2-verify-report.md) now record live automatic publication, restart-matrix recovery, active-lease fencing, and latest-branch formal UAT evidence. [ADR-0005](adrs/0005-a4-review-publication-fencing.md) records the lease and supersession decision. Live worker credential-isolation and broader Docker evidence remain residuals.
 
 ## 2026-08-02

--- a/docs/log.md
+++ b/docs/log.md
@@ -1,6 +1,9 @@
 # Docs Update Log
 
 ## 2026-08-02
+* **OKF frontmatter repaired**: Quoted colon-bearing titles and descriptions in the issue-tracker guide, active Wave 4 plan, and retained historical Superpowers plans/specs. Both standard and strict-link OKF validation now pass.
+
+## 2026-08-02
 * **A4 PR2 verified with residuals**: The [A4 design](specs/2026-07-30-a4-agent-review-stage-design.md) and [PR2 verify report](specs/2026-08-02-a4-pr2-verify-report.md) now record live automatic publication, restart-matrix recovery, active-lease fencing, and latest-branch formal UAT evidence. [ADR-0005](adrs/0005-a4-review-publication-fencing.md) records the lease and supersession decision. Live worker credential-isolation and broader Docker evidence remain residuals.
 
 ## 2026-08-02

--- a/docs/log.md
+++ b/docs/log.md
@@ -1,6 +1,8 @@
 # Docs Update Log
 
 ## 2026-08-02
+* **A4 PR2 implementation verification started**: Added the [PR2 verify report](specs/2026-08-02-a4-pr2-verify-report.md), updated the A4 roadmap/design status, and documented formal review permission probing and preview-only Ratatui evidence. Automatic formal-review UAT and restart evidence remain open.
+
 * **Direct draft-PR, review-preview, and TUI UAT completed**: The real `gannonh/uat-symphony` Project #16 run for issue [#45](https://github.com/gannonh/uat-symphony/issues/45) created draft PR [#46](https://github.com/gannonh/uat-symphony/pull/46), reached `Agent Review` after publication, posted structured review findings, and showed typed factory sessions in the Ratatui TUI. Restart-during-publication, cleanup, and Docker evidence remain residuals.
 
 ## 2026-08-01

--- a/docs/log.md
+++ b/docs/log.md
@@ -1,6 +1,9 @@
 # Docs Update Log
 
 ## 2026-08-02
+* **A4 PR2 verified with residuals**: The [A4 design](specs/2026-07-30-a4-agent-review-stage-design.md) and [PR2 verify report](specs/2026-08-02-a4-pr2-verify-report.md) now record live automatic publication, restart-matrix recovery, active-lease fencing, and latest-branch formal UAT evidence. [ADR-0005](adrs/0005-a4-review-publication-fencing.md) records the lease and supersession decision. Live worker credential-isolation and broader Docker evidence remain residuals.
+
+## 2026-08-02
 * **A4 PR2 implementation verification started**: Added the [PR2 verify report](specs/2026-08-02-a4-pr2-verify-report.md), updated the A4 roadmap/design status, and documented formal review permission probing and preview-only Ratatui evidence. Automatic formal-review UAT and restart evidence remain open.
 
 * **Direct draft-PR, review-preview, and TUI UAT completed**: The real `gannonh/uat-symphony` Project #16 run for issue [#45](https://github.com/gannonh/uat-symphony/issues/45) created draft PR [#46](https://github.com/gannonh/uat-symphony/pull/46), reached `Agent Review` after publication, posted structured review findings, and showed typed factory sessions in the Ratatui TUI. Restart-during-publication, cleanup, and Docker evidence remain residuals.

--- a/docs/specs/2026-07-30-a4-agent-review-stage-design.md
+++ b/docs/specs/2026-07-30-a4-agent-review-stage-design.md
@@ -11,7 +11,7 @@ timestamp: 2026-07-30T14:45:39Z
 
 ## Status
 
-Active — PR1 review findings preview and typed TUI state are implemented in the current mainline after [#610](https://github.com/gannonh/kata-symphony/pull/610) (`233caf88`). PR2 formal review publication and routing are implemented on `feat/a4-review-publication`; automated gates, doctor permission probing, and preview-only Ratatui verification passed. Automatic formal-review UAT, restart-during-publication evidence, full cleanup, and Docker evidence remain residuals. See the [PR2 verify report](2026-08-02-a4-pr2-verify-report.md).
+Active — PR1 review findings preview and typed TUI state are implemented in the current mainline after [#610](https://github.com/gannonh/kata-symphony/pull/610) (`233caf88`). PR2 formal review publication and routing are implemented on `feat/a4-review-publication`; automated gates, active-lease fencing, doctor permission probing, automatic formal-review UAT, and restart-matrix evidence pass. Credential-isolation proof for a live worker and broader Docker evidence remain residuals. See the [PR2 verify report](2026-08-02-a4-pr2-verify-report.md) and [ADR-0005](../adrs/0005-a4-review-publication-fencing.md).
 
 ## Goal
 
@@ -28,6 +28,7 @@ A4 is **read-only with respect to the change under review**. It never edits code
 - [Symphony Software Factory Platform PRD, A4](/specs/symphony-software-factory-platform-prd.md)
 - [A3 Implementation Stage](2026-07-26-a3-implementation-stage-design.md)
 - [ADR-0004 A3 implementation durability and bundles](/adrs/0004-a3-implementation-durability-and-bundles.md)
+- [ADR-0005 A4 durable review publication fencing](/adrs/0005-a4-review-publication-fencing.md)
 - [A3 PR2 build report](2026-07-29-a3-pr2-build-report.md) / [verify report](2026-07-29-a3-pr2-verify-report.md)
 - [A4 PR2 verify report](2026-08-02-a4-pr2-verify-report.md)
 - [A2 Spec Stage](2026-07-18-a2-spec-stage-design.md)
@@ -44,7 +45,7 @@ A4 is **read-only with respect to the change under review**. It never edits code
 - The review worker receives the diff, PR description, approved specification, implementation manifest, and read-only repository context. It receives no forge, tracker-helper, SSH, or Git push credentials — the A3 worker boundary applies unchanged.
 - The worker emits a typed **review findings manifest**. Unknown fields are rejected. A malformed manifest is a bounded re-prompt, not a partial publish.
 - Symphony alone publishes to GitHub, as a **single atomic review** (summary body plus inline comments) rather than N independent comments, so a partial failure cannot leave half a review on the PR.
-- Publication is idempotent and restart-safe using the marker and create-before-record recovery A3 established.
+- Publication is idempotent and restart-safe using the marker and create-before-record recovery A3 established. Every worker-owned durable publication mutation is fenced by a pending status, an active owner lease, and a one-second lease heartbeat during forge and Projects v2 calls. Changed-head supersession claims the same lease before terminalizing the stale cycle; the explicit operator reset path remains separately auditable.
 - A new head SHA opens a **new review cycle**. Prior findings are carried forward and classified as resolved, persisting, or new by comparing anchors and finding identity.
 - The routing decision is derived from findings, not from the worker's own claim: blocking findings route to the configured changes-requested state; otherwise the item advances toward A5.
 - A4 does not apply fixes, approve PRs, run acceptance verification, merge, or deploy. Those remain A5 and A6.
@@ -242,13 +243,13 @@ apps/symphony/src/{doctor,http_server}.rs
 
 **PR1 — review stage and findings preview.** **Implemented** in [#610](https://github.com/gannonh/kata-symphony/pull/610) (`233caf88`): eligibility, dispatch ownership, stage attempts, worker invocation and boundary, manifest schema and validation, bounded re-prompt, durable findings artifacts, preview comment, HTTP/events, and typed TUI state. No PR review, no routing.
 
-**PR2 — deterministic review publication and routing.** **Implemented on `feat/a4-review-publication`; verification pending.** Atomic review creation, create-before-record recovery, progressive publication steps, routing decision, re-review cycles and carry-forward, retry/waiting/terminal semantics, doctor validation, and operator recovery path are present. Automatic formal-review UAT and restart evidence remain open.
+**PR2 — deterministic review publication and routing.** **Implemented on `feat/a4-review-publication`; verified with residuals.** Atomic review creation, create-before-record recovery, active-lease fencing, progressive publication steps, routing decision, re-review cycles and carry-forward, retry/waiting/terminal semantics, doctor validation, and operator recovery path are present. Live formal UAT and restart-matrix evidence pass; live worker credential-isolation proof and broader Docker evidence remain residuals.
 
 ## Risks and mitigations
 
-### Residual risk from the incomplete A3 recovery matrix
+### Residual risk from provider-side operation windows
 
-Direct A3 draft-PR, Agent Review preview, and Ratatui TUI UAT are now verified on Project #16. Restart-during-publication recovery, full cleanup proof, and Docker execution remain unverified. A4 PR1 continues to treat malformed or unresolvable draft-PR artifacts as explicit blocked states with actionable errors.
+Durable publication writes are fenced by active leases and the publisher renews its lease during forge and Projects v2 calls. A provider request already accepted before a process failure cannot be cancelled by SQLite; marker ownership, live-head validation, reconciliation, and idempotent route writes handle recovery. A live worker credential-isolation proof and broader Docker execution evidence remain unverified. A4 continues to treat malformed or unresolvable draft-PR artifacts as explicit blocked states with actionable errors.
 
 ### No operator recovery from `blocked`
 

--- a/docs/specs/2026-07-30-a4-agent-review-stage-design.md
+++ b/docs/specs/2026-07-30-a4-agent-review-stage-design.md
@@ -11,7 +11,7 @@ timestamp: 2026-07-30T14:45:39Z
 
 ## Status
 
-Active — PR1 review findings preview and typed TUI state are implemented in the current mainline after [#610](https://github.com/gannonh/kata-symphony/pull/610) (`233caf88`). Direct draft-PR, Agent Review preview, and Ratatui TUI UAT passed on Project #16 with issue [#45](https://github.com/gannonh/uat-symphony/issues/45) and draft PR [#46](https://github.com/gannonh/uat-symphony/pull/46). PR2 formal review publication and routing remain planned. Restart-during-publication, full cleanup, and Docker evidence remain residuals.
+Active — PR1 review findings preview and typed TUI state are implemented in the current mainline after [#610](https://github.com/gannonh/kata-symphony/pull/610) (`233caf88`). PR2 formal review publication and routing are implemented on `feat/a4-review-publication`; automated gates, doctor permission probing, and preview-only Ratatui verification passed. Automatic formal-review UAT, restart-during-publication evidence, full cleanup, and Docker evidence remain residuals. See the [PR2 verify report](2026-08-02-a4-pr2-verify-report.md).
 
 ## Goal
 
@@ -29,6 +29,7 @@ A4 is **read-only with respect to the change under review**. It never edits code
 - [A3 Implementation Stage](2026-07-26-a3-implementation-stage-design.md)
 - [ADR-0004 A3 implementation durability and bundles](/adrs/0004-a3-implementation-durability-and-bundles.md)
 - [A3 PR2 build report](2026-07-29-a3-pr2-build-report.md) / [verify report](2026-07-29-a3-pr2-verify-report.md)
+- [A4 PR2 verify report](2026-08-02-a4-pr2-verify-report.md)
 - [A2 Spec Stage](2026-07-18-a2-spec-stage-design.md)
 - [GitHub REST pull request reviews API](https://docs.github.com/en/rest/pulls/reviews)
 - [GitHub REST pull request files API](https://docs.github.com/en/rest/pulls/pulls#list-pull-requests-files)
@@ -241,7 +242,7 @@ apps/symphony/src/{doctor,http_server}.rs
 
 **PR1 — review stage and findings preview.** **Implemented** in [#610](https://github.com/gannonh/kata-symphony/pull/610) (`233caf88`): eligibility, dispatch ownership, stage attempts, worker invocation and boundary, manifest schema and validation, bounded re-prompt, durable findings artifacts, preview comment, HTTP/events, and typed TUI state. No PR review, no routing.
 
-**PR2 — deterministic review publication and routing.** Atomic review creation, create-before-record recovery, progressive publication steps, routing decision, re-review cycles and carry-forward, retry/waiting/terminal semantics, doctor validation, operator recovery path.
+**PR2 — deterministic review publication and routing.** **Implemented on `feat/a4-review-publication`; verification pending.** Atomic review creation, create-before-record recovery, progressive publication steps, routing decision, re-review cycles and carry-forward, retry/waiting/terminal semantics, doctor validation, and operator recovery path are present. Automatic formal-review UAT and restart evidence remain open.
 
 ## Risks and mitigations
 

--- a/docs/specs/2026-08-02-a4-pr2-verify-report.md
+++ b/docs/specs/2026-08-02-a4-pr2-verify-report.md
@@ -1,8 +1,8 @@
 ---
 type: Verify Report
 title: A4 PR2 Formal Review Publication Verify Report
-status: In verification
-description: Automated and preview-only Ratatui verification for A4 PR2 formal review publication and routing; live automatic publication and full restart matrix remain open.
+status: Verified with residuals
+description: Automated, live automatic, restart-matrix, and Ratatui verification for A4 PR2 formal review publication and routing; live worker credential-isolation and broader Docker evidence remain residual.
 tags: [symphony, review-stage, a4, pr2, verify]
 timestamp: 2026-08-02T16:40:00Z
 ---
@@ -11,7 +11,7 @@ timestamp: 2026-08-02T16:40:00Z
 
 ## Status
 
-**In verification** — the feature branch implements deterministic formal review publication, durable routing, changed-head cycles, operator recovery, and doctor permission probing. Automated validation and a fresh preview-only Ratatui run passed. Automatic formal-review UAT remains separate from the mainline/UAT preview workflow.
+**Verified with residuals** — the feature branch implements deterministic formal review publication, durable routing, changed-head cycles, operator recovery, active lease fencing, and doctor permission probing. Automated validation, live automatic reconciliation, restart-boundary recovery, and a direct Ratatui run passed. Mainline and the maintained UAT workflow remain preview-only.
 
 Branch: `feat/a4-review-publication`
 
@@ -19,11 +19,12 @@ Branch: `feat/a4-review-publication`
 
 - `cargo fmt --check` — Pass
 - `cargo clippy -- -D warnings` — Pass
-- `cargo test -- --test-threads=1` — Pass: 403 library tests plus all integration suites. An unconstrained parallel run showed intermittent pre-existing Codex/mock-server timing failures in `orchestrator_tests`; the serial gate passed all tests.
-- `pnpm run validate:affected` — Pass: 2 Turborepo tasks, including the Symphony suite
+- `cargo test -- --test-threads=1` — Pass: 410 library tests plus all integration suites.
+- `pnpm run validate:affected` — Pass: 2 Turborepo tasks, including the Symphony suite; no TypeScript files changed in the final fencing fix.
 - Formal review client tests cover multiline anchors, marker adoption, foreign identity conflicts, stale heads, invalid permission probes, and unexpected successful permission probes.
-- Store tests cover draft-PR eligibility, changed-head retry budgets, conflict recovery, publication leases, migration reapplication, and publication-step persistence.
-- Coordinator tests cover retry-ceiling classification and live revision guards.
+- Store tests cover draft-PR eligibility, changed-head retry budgets, conflict recovery, active and expired publication leases, terminal stale writers, supersession retry preservation, migration reapplication, and publication-step persistence.
+- Publisher tests cover marker adoption, foreign identity conflicts, stale heads, preview lease ownership, and restart-safe progressive publication.
+- Coordinator paths claim before failure recording, changed-head supersession, Projects v2 routing, and finalization.
 
 ## Doctor evidence
 
@@ -49,9 +50,16 @@ Evidence bundle: `/tmp/kata-symphony-current-uat-evidence/a4-pr2/`
 - `logs/log/symphony.log` contains startup, HTTP binding, TUI enablement, and review poll events.
 - The SQLite lock was available after shutdown.
 
+A latest-branch automatic reconciliation used commit `5cd42db1` and a seeded copy of the formal SQLite database. It adopted the existing marker-owned review `4839451136`, applied all four publication steps, moved the Project item to `Human Review`, then restored it to `Agent Review`. Evidence bundle: `/tmp/kata-symphony-current-uat-evidence/a4-pr2/formal-latest/`.
+
+- `uat-summary.json` records the applied durable projection, single remote review, route restoration, head/base SHAs, and known warnings.
+- `db-summary.json`, `pull-request.json`, and `project-item-after-restore.json` provide durable/API read-backs.
+- `doctor-latest.txt` exits `0`; its explicit warnings are documented in `uat-summary.json`.
+- `symphony.log` and `tui-session.ansi` capture the direct Ratatui run with HTTP observability and the active supervisor.
+
 ## Acceptance coverage
 
-Implemented and automated:
+Implemented, automated, and live-verified where marked:
 
 1. Durable A3 draft and draft-only eligibility
 2. Review attempt ownership and per-head retry accounting
@@ -64,13 +72,16 @@ Implemented and automated:
 9. Changed-head waiting semantics and stale-creation protection
 10. Finding carry-forward and persisting-finding suppression
 11. Doctor validation of formal review endpoint authorization
+12. Live automatic formal review reconciliation on `gannonh/uat-symphony` PR #46, with one existing marker-owned review adopted and no duplicate review created
+13. Live restart matrix for `create-before-record`, `after-review-created`, and `after-findings-recorded`, each recovering to `applied` with `retry_count=0`
+14. Live Projects v2 route mutation to `Human Review`, followed by restoration to `Agent Review`
+15. Active-lease CAS fencing for identity, route, step, error, preview completion, finalization, and changed-head supersession
 
-## Open verification work
+## Residual verification work
 
-1. Run automatic formal-review UAT on an isolated feature workflow with a disposable or explicitly approved UAT issue/PR.
-2. Capture restart evidence at each publication boundary: after review creation, findings recording, route update, and before finalization.
-3. Exercise a real changed-head re-review and verify resolved, persisting, and new findings on the remote PR.
+1. Capture a dedicated live worker credential-isolation proof bundle across the formal worker process boundary.
+2. Capture broader Docker execution evidence for the review worker; the existing Rust Docker integration suite passes.
+3. Exercise a real changed-head re-review with changed remote content and verify resolved, persisting, and new findings on the remote PR.
 4. Confirm foreign-review conflict listing and reset over the live HTTP operator path.
-5. Update the A4 design and roadmap to Completed only after these checks pass.
 
-Mainline and the maintained UAT workflow remain preview-only until the automatic path is accepted.
+Mainline and the maintained UAT workflow remain preview-only. Formal evidence is isolated under `/tmp/kata-symphony-current-uat-evidence/a4-pr2/formal-latest/`.

--- a/docs/specs/2026-08-02-a4-pr2-verify-report.md
+++ b/docs/specs/2026-08-02-a4-pr2-verify-report.md
@@ -19,7 +19,7 @@ Branch: `feat/a4-review-publication`
 
 - `cargo fmt --check` — Pass
 - `cargo clippy -- -D warnings` — Pass
-- `cargo test` — Pass: 402 library tests plus all integration suites
+- `cargo test -- --test-threads=1` — Pass: 403 library tests plus all integration suites. An unconstrained parallel run showed intermittent pre-existing Codex/mock-server timing failures in `orchestrator_tests`; the serial gate passed all tests.
 - `pnpm run validate:affected` — Pass: 2 Turborepo tasks, including the Symphony suite
 - Formal review client tests cover multiline anchors, marker adoption, foreign identity conflicts, stale heads, invalid permission probes, and unexpected successful permission probes.
 - Store tests cover draft-PR eligibility, changed-head retry budgets, conflict recovery, publication leases, migration reapplication, and publication-step persistence.
@@ -43,7 +43,7 @@ A fresh direct Ratatui run used the feature binary and the existing preview-only
 
 Evidence bundle: `/tmp/kata-symphony-current-uat-evidence/a4-pr2/`
 
-- `state.json` contains the Project #16 URL, empty active queues, and `supervisor.status=active`.
+- `state.json` contains the Project #16 URL, empty active queues, and `supervisor.status=active` after the current feature binary reached its first poll.
 - `doctor.txt` contains the complete preflight output.
 - `tui-session.ansi` and `tui-session-initial.ansi` contain the direct Ratatui terminal captures.
 - `logs/log/symphony.log` contains startup, HTTP binding, TUI enablement, and review poll events.

--- a/docs/specs/2026-08-02-a4-pr2-verify-report.md
+++ b/docs/specs/2026-08-02-a4-pr2-verify-report.md
@@ -57,6 +57,8 @@ A latest-branch automatic reconciliation used commit `5cd42db1` and a seeded cop
 - `doctor-latest.txt` exits `0`; its explicit warnings are documented in `uat-summary.json`.
 - `symphony.log` and `tui-session.ansi` capture the direct Ratatui run with HTTP observability and the active supervisor.
 
+A fresh manual formal UAT used the current branch binary and UAT workflow with issue [#47](https://github.com/gannonh/uat-symphony/issues/47) and draft PR [#48](https://github.com/gannonh/uat-symphony/pull/48). The real review worker produced one blocking scope finding. Symphony published one authenticated `COMMENTED` review (`4839847481`), applied `review_created`, `findings_recorded`, `route_applied`, and `comment_final` with `retry_count=0`, and routed Project #16 to `Rework`. After a stop/start restart, reconciliation kept one remote review and the applied intent; no duplicate publication occurred. The fixture, branch, issue, and Project item were cleaned up after capture. Evidence bundle: `/tmp/kata-symphony-current-uat-evidence/a4-pr2/manual-47/`.
+
 ## Acceptance coverage
 
 Implemented, automated, and live-verified where marked:
@@ -76,6 +78,7 @@ Implemented, automated, and live-verified where marked:
 13. Live restart matrix for `create-before-record`, `after-review-created`, and `after-findings-recorded`, each recovering to `applied` with `retry_count=0`
 14. Live Projects v2 route mutation to `Human Review`, followed by restoration to `Agent Review`
 15. Active-lease CAS fencing for identity, route, step, error, preview completion, finalization, and changed-head supersession
+16. Live formal blocking-finding publication, `Rework` routing, and restart reconciliation with one remote review
 
 ## Residual verification work
 

--- a/docs/specs/2026-08-02-a4-pr2-verify-report.md
+++ b/docs/specs/2026-08-02-a4-pr2-verify-report.md
@@ -1,0 +1,76 @@
+---
+type: Verify Report
+title: A4 PR2 Formal Review Publication Verify Report
+status: In verification
+description: Automated and preview-only Ratatui verification for A4 PR2 formal review publication and routing; live automatic publication and full restart matrix remain open.
+tags: [symphony, review-stage, a4, pr2, verify]
+timestamp: 2026-08-02T16:40:00Z
+---
+
+# A4 PR2 Formal Review Publication — Verify Report
+
+## Status
+
+**In verification** — the feature branch implements deterministic formal review publication, durable routing, changed-head cycles, operator recovery, and doctor permission probing. Automated validation and a fresh preview-only Ratatui run passed. Automatic formal-review UAT remains separate from the mainline/UAT preview workflow.
+
+Branch: `feat/a4-review-publication`
+
+## Automated evidence
+
+- `cargo fmt --check` — Pass
+- `cargo clippy -- -D warnings` — Pass
+- `cargo test` — Pass: 402 library tests plus all integration suites
+- `pnpm run validate:affected` — Pass: 2 Turborepo tasks, including the Symphony suite
+- Formal review client tests cover multiline anchors, marker adoption, foreign identity conflicts, stale heads, invalid permission probes, and unexpected successful permission probes.
+- Store tests cover draft-PR eligibility, changed-head retry budgets, conflict recovery, publication leases, migration reapplication, and publication-step persistence.
+- Coordinator tests cover retry-ceiling classification and live revision guards.
+
+## Doctor evidence
+
+A fresh `symphony doctor` run against `gannonh/uat-symphony` Project #16 passed the formal review permission probe against pull request #46:
+
+- `GitHub Review Auth` — Pass
+- `GitHub Review Project` — Pass
+- `GitHub Review Routes` — Pass
+- `GitHub Review API` — Pass: review endpoint authorization verified
+- Exit status: `0`
+
+The probe posts an intentionally invalid review event and accepts GitHub's validation response (`422`) as endpoint authorization without creating a review.
+
+## Ratatui UAT evidence
+
+A fresh direct Ratatui run used the feature binary and the existing preview-only UAT workflow. Symphony started with the HTTP observability server and active supervisor, completed startup workspace scanning, and reported zero active candidates without mutating the configured preview workflow.
+
+Evidence bundle: `/tmp/kata-symphony-current-uat-evidence/a4-pr2/`
+
+- `state.json` contains the Project #16 URL, empty active queues, and `supervisor.status=active`.
+- `doctor.txt` contains the complete preflight output.
+- `tui-session.ansi` and `tui-session-initial.ansi` contain the direct Ratatui terminal captures.
+- `logs/log/symphony.log` contains startup, HTTP binding, TUI enablement, and review poll events.
+- The SQLite lock was available after shutdown.
+
+## Acceptance coverage
+
+Implemented and automated:
+
+1. Durable A3 draft and draft-only eligibility
+2. Review attempt ownership and per-head retry accounting
+3. Worker credential boundary and manifest validation from PR1
+4. Atomic formal review payloads with marker ownership
+5. Create-before-record adoption and durable publication steps
+6. Cross-process publication claim lease
+7. Foreign-marker conflict recovery through the existing operator API
+8. Route selection, Projects v2 read-back, and HTTP projections
+9. Changed-head waiting semantics and stale-creation protection
+10. Finding carry-forward and persisting-finding suppression
+11. Doctor validation of formal review endpoint authorization
+
+## Open verification work
+
+1. Run automatic formal-review UAT on an isolated feature workflow with a disposable or explicitly approved UAT issue/PR.
+2. Capture restart evidence at each publication boundary: after review creation, findings recording, route update, and before finalization.
+3. Exercise a real changed-head re-review and verify resolved, persisting, and new findings on the remote PR.
+4. Confirm foreign-review conflict listing and reset over the live HTTP operator path.
+5. Update the A4 design and roadmap to Completed only after these checks pass.
+
+Mainline and the maintained UAT workflow remain preview-only until the automatic path is accepted.

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -6,13 +6,13 @@ Roadmap for planned and completed work. Historical Superpowers designs and plans
 
 * [Symphony Software Factory Platform PRD](symphony-software-factory-platform-prd.md) - product requirements and vertical-slice roadmap for the full software factory platform
 * [A3 Implementation Stage](2026-07-26-a3-implementation-stage-design.md) - Complete; **PR1+PR2 shipped** (PR1 [#606](https://github.com/gannonh/kata-symphony/pull/606); PR2 [#607](https://github.com/gannonh/kata-symphony/pull/607) (`d456c051`); [build](2026-07-29-a3-pr2-build-report.md), [verify](2026-07-29-a3-pr2-verify-report.md) Verified with residuals; [ADR-0004](../adrs/0004-a3-implementation-durability-and-bundles.md)); direct draft-PR, Agent Review preview, and Ratatui TUI UAT verified on Project #16
-* [A4 Agent Review Stage](2026-07-30-a4-agent-review-stage-design.md) - **Active**; PR1 is implemented and PR2 is implemented on `feat/a4-review-publication`; [PR2 verify report](2026-08-02-a4-pr2-verify-report.md) is In verification pending automatic formal-review UAT
+* [A4 Agent Review Stage](2026-07-30-a4-agent-review-stage-design.md) - **Active**; PR1 is implemented and PR2 is implemented on `feat/a4-review-publication`; live automatic publication, restart-matrix recovery, and active-lease fencing are verified with worker credential-isolation and broader Docker evidence residuals ([PR2 verify report](2026-08-02-a4-pr2-verify-report.md); [ADR-0005](../adrs/0005-a4-review-publication-fencing.md))
 * [Pi Symphony Extension Design](../superpowers/specs/2026-05-14-pi-symphony-extension-design.md) - Pi extension to init, launch, monitor, and steer Symphony
 * [Wave 4 Shared Context and Diagnostics Plan](../superpowers/plans/2026-05-17-wave-4-symphony-shared-context-diagnostics.md) - dashboard parity for shared context + diagnostics
 
 # Planned
 
-* A4 PR2 formal review publication and routing — implemented on `feat/a4-review-publication`; automatic formal-review UAT and restart evidence pending ([design](2026-07-30-a4-agent-review-stage-design.md); [verify](2026-08-02-a4-pr2-verify-report.md); [PRD A4](symphony-software-factory-platform-prd.md))
+* A4 PR2 formal review publication and routing — implemented and verified with residuals on `feat/a4-review-publication`; worker credential-isolation proof and broader Docker evidence remain ([design](2026-07-30-a4-agent-review-stage-design.md); [verify](2026-08-02-a4-pr2-verify-report.md); [ADR-0005](../adrs/0005-a4-review-publication-fencing.md); [PRD A4](symphony-software-factory-platform-prd.md))
 
 # Blocked
 

--- a/docs/specs/index.md
+++ b/docs/specs/index.md
@@ -6,13 +6,13 @@ Roadmap for planned and completed work. Historical Superpowers designs and plans
 
 * [Symphony Software Factory Platform PRD](symphony-software-factory-platform-prd.md) - product requirements and vertical-slice roadmap for the full software factory platform
 * [A3 Implementation Stage](2026-07-26-a3-implementation-stage-design.md) - Complete; **PR1+PR2 shipped** (PR1 [#606](https://github.com/gannonh/kata-symphony/pull/606); PR2 [#607](https://github.com/gannonh/kata-symphony/pull/607) (`d456c051`); [build](2026-07-29-a3-pr2-build-report.md), [verify](2026-07-29-a3-pr2-verify-report.md) Verified with residuals; [ADR-0004](../adrs/0004-a3-implementation-durability-and-bundles.md)); direct draft-PR, Agent Review preview, and Ratatui TUI UAT verified on Project #16
-* [A4 Agent Review Stage](2026-07-30-a4-agent-review-stage-design.md) - **Active**; PR1 review findings preview and typed TUI state are implemented; PR2 formal review publication and routing remain planned
+* [A4 Agent Review Stage](2026-07-30-a4-agent-review-stage-design.md) - **Active**; PR1 is implemented and PR2 is implemented on `feat/a4-review-publication`; [PR2 verify report](2026-08-02-a4-pr2-verify-report.md) is In verification pending automatic formal-review UAT
 * [Pi Symphony Extension Design](../superpowers/specs/2026-05-14-pi-symphony-extension-design.md) - Pi extension to init, launch, monitor, and steer Symphony
 * [Wave 4 Shared Context and Diagnostics Plan](../superpowers/plans/2026-05-17-wave-4-symphony-shared-context-diagnostics.md) - dashboard parity for shared context + diagnostics
 
 # Planned
 
-* A4 PR2 formal review publication and routing — planned ([design](2026-07-30-a4-agent-review-stage-design.md); [PRD A4](symphony-software-factory-platform-prd.md))
+* A4 PR2 formal review publication and routing — implemented on `feat/a4-review-publication`; automatic formal-review UAT and restart evidence pending ([design](2026-07-30-a4-agent-review-stage-design.md); [verify](2026-08-02-a4-pr2-verify-report.md); [PRD A4](symphony-software-factory-platform-prd.md))
 
 # Blocked
 

--- a/docs/specs/log.md
+++ b/docs/specs/log.md
@@ -1,6 +1,8 @@
 # Specs Update Log
 
 ## 2026-08-02
+* **A4 PR2 implementation verification started**: `feat/a4-review-publication` now contains atomic formal review publication, durable publication leases, changed-head waiting, conflict recovery, draft-only eligibility, retry ceilings, and doctor review-write permission probing. Automated gates and preview-only Ratatui verification pass; automatic formal-review UAT and restart evidence remain open in the [PR2 verify report](2026-08-02-a4-pr2-verify-report.md).
+
 * **Direct draft-PR, review-preview, and TUI UAT completed**: The real `gannonh/uat-symphony` Project #16 run for issue [#45](https://github.com/gannonh/uat-symphony/issues/45) created draft PR [#46](https://github.com/gannonh/uat-symphony/pull/46), reached `Agent Review` after publication, posted structured review findings, and showed typed factory sessions in the Ratatui TUI. Restart-during-publication, cleanup, and Docker evidence remain residuals.
 
 ## 2026-08-01

--- a/docs/specs/log.md
+++ b/docs/specs/log.md
@@ -1,6 +1,9 @@
 # Specs Update Log
 
 ## 2026-08-02
+* **A4 PR2 verification completed with residuals**: The [verify report](2026-08-02-a4-pr2-verify-report.md) records 410 passing Rust tests, live automatic marker adoption and route restoration on PR #46, all three restart-matrix cases, active lease CAS fencing, and the latest-branch evidence bundle. Credential-isolation and broader Docker proof remain open.
+
+## 2026-08-02
 * **A4 PR2 implementation verification started**: `feat/a4-review-publication` now contains atomic formal review publication, durable publication leases, changed-head waiting, conflict recovery, draft-only eligibility, retry ceilings, and doctor review-write permission probing. Automated gates and preview-only Ratatui verification pass; automatic formal-review UAT and restart evidence remain open in the [PR2 verify report](2026-08-02-a4-pr2-verify-report.md).
 
 * **Direct draft-PR, review-preview, and TUI UAT completed**: The real `gannonh/uat-symphony` Project #16 run for issue [#45](https://github.com/gannonh/uat-symphony/issues/45) created draft PR [#46](https://github.com/gannonh/uat-symphony/pull/46), reached `Agent Review` after publication, posted structured review findings, and showed typed factory sessions in the Ratatui TUI. Restart-during-publication, cleanup, and Docker evidence remain residuals.

--- a/docs/specs/log.md
+++ b/docs/specs/log.md
@@ -1,6 +1,7 @@
 # Specs Update Log
 
 ## 2026-08-02
+* **A4 PR2 manual formal UAT completed**: The [verify report](2026-08-02-a4-pr2-verify-report.md) records a real blocking finding published as one `COMMENTED` review on PR #48, durable four-step publication, `Rework` routing, and stop/start reconciliation with no duplicate review. Evidence is under `/tmp/kata-symphony-current-uat-evidence/a4-pr2/manual-47/`; credential-isolation and broader Docker proof remain open.
 * **A4 PR2 verification completed with residuals**: The [verify report](2026-08-02-a4-pr2-verify-report.md) records 410 passing Rust tests, live automatic marker adoption and route restoration on PR #46, all three restart-matrix cases, active lease CAS fencing, and the latest-branch evidence bundle. Credential-isolation and broader Docker proof remain open.
 
 ## 2026-08-02

--- a/docs/specs/symphony-software-factory-platform-prd.md
+++ b/docs/specs/symphony-software-factory-platform-prd.md
@@ -250,9 +250,11 @@ Implementation consumes the approved artifact version, runs repository validatio
 
 #### A4. Draft PR → structured, read-only agent review
 
-A review stage consumes the PR description, diff, repository context, and approved spec. It emits schema-validated findings. PR1 is implemented as a preview-only issue comment flow with typed TUI state; formal GitHub review publication and routing remain planned.
+A review stage consumes the PR description, diff, repository context, and approved spec. It emits schema-validated findings. PR1 is implemented as a preview-only issue comment flow with typed TUI state. PR2 adds deterministic formal GitHub review publication, active-lease fencing, changed-head recovery, and Projects v2 routing; it is verified with residual live worker credential-isolation and broader Docker evidence.
 
 **Demo:** Open or update a PR, receive a review summary and inline findings, push a correction, and see contextual re-review.
+
+**Progress (2026-08-02):** PR2 formal publication and routing are implemented on `feat/a4-review-publication` and verified through isolated live UAT against [PR #46](https://github.com/gannonh/uat-symphony/pull/46), including restart-boundary recovery and Project restoration. See the [A4 verify report](/specs/2026-08-02-a4-pr2-verify-report.md) and [ADR-0005](/adrs/0005-a4-review-publication-fencing.md).
 
 **Measure:** accepted finding rate, dismissed finding rate, review cycles, escaped sampled defects, and review cost.
 

--- a/docs/superpowers/plans/2026-05-17-wave-4-symphony-shared-context-diagnostics.md
+++ b/docs/superpowers/plans/2026-05-17-wave-4-symphony-shared-context-diagnostics.md
@@ -1,7 +1,7 @@
 ---
 type: Plan
 title: Wave 4 Symphony Shared Context and Diagnostics
-description: Implementation plan for Wave 4 dashboard parity: shared context and diagnostics.
+description: "Implementation plan for Wave 4 dashboard parity: shared context and diagnostics."
 tags: [symphony, pi, dashboard]
 timestamp: 2026-07-15T20:00:00Z
 ---

--- a/docs/superpowers/plans/_archive/2026-04-26-kata-cli-skill-platform.md
+++ b/docs/superpowers/plans/_archive/2026-04-26-kata-cli-skill-platform.md
@@ -1,7 +1,7 @@
 ---
 type: Plan
 title: Kata Cli Skill Platform
-description: Archived implementation plan: Kata Cli Skill Platform.
+description: "Archived implementation plan: Kata Cli Skill Platform."
 tags: [archive]
 timestamp: 2026-07-15T20:00:00Z
 ---

--- a/docs/superpowers/plans/_archive/2026-04-27-kata-cli-recovery-stabilization.md
+++ b/docs/superpowers/plans/_archive/2026-04-27-kata-cli-recovery-stabilization.md
@@ -1,7 +1,7 @@
 ---
 type: Plan
 title: Kata Cli Recovery Stabilization
-description: Archived implementation plan: Kata Cli Recovery Stabilization.
+description: "Archived implementation plan: Kata Cli Recovery Stabilization."
 tags: [archive]
 timestamp: 2026-07-15T20:00:00Z
 ---

--- a/docs/superpowers/plans/_archive/2026-04-28-kata-cli-phase-a-real-backend.md
+++ b/docs/superpowers/plans/_archive/2026-04-28-kata-cli-phase-a-real-backend.md
@@ -1,7 +1,7 @@
 ---
 type: Plan
 title: Kata Cli Phase A Real Backend
-description: Archived implementation plan: Kata Cli Phase A Real Backend.
+description: "Archived implementation plan: Kata Cli Phase A Real Backend."
 tags: [archive]
 timestamp: 2026-07-15T20:00:00Z
 ---

--- a/docs/superpowers/plans/_archive/2026-04-28-kata-skills-migration-recovery.md
+++ b/docs/superpowers/plans/_archive/2026-04-28-kata-skills-migration-recovery.md
@@ -1,7 +1,7 @@
 ---
 type: Plan
 title: Kata Skills Migration Recovery
-description: Archived implementation plan: Kata Skills Migration Recovery.
+description: "Archived implementation plan: Kata Skills Migration Recovery."
 tags: [archive]
 timestamp: 2026-07-15T20:00:00Z
 ---

--- a/docs/superpowers/plans/_archive/2026-05-06-cli-linear-core-implementation-plan.md
+++ b/docs/superpowers/plans/_archive/2026-05-06-cli-linear-core-implementation-plan.md
@@ -1,7 +1,7 @@
 ---
 type: Plan
 title: Cli Linear Core Implementation Plan
-description: Archived implementation plan: Cli Linear Core Implementation Plan.
+description: "Archived implementation plan: Cli Linear Core Implementation Plan."
 tags: [archive]
 timestamp: 2026-07-15T20:00:00Z
 ---

--- a/docs/superpowers/plans/_archive/2026-05-06-github-projects-v2-state-source-of-truth-implementation-plan.md
+++ b/docs/superpowers/plans/_archive/2026-05-06-github-projects-v2-state-source-of-truth-implementation-plan.md
@@ -1,7 +1,7 @@
 ---
 type: Plan
 title: Github Projects V2 State Source Of Truth Implementation Plan
-description: Archived implementation plan: Github Projects V2 State Source Of Truth Implementation Plan.
+description: "Archived implementation plan: Github Projects V2 State Source Of Truth Implementation Plan."
 tags: [archive]
 timestamp: 2026-07-15T20:00:00Z
 ---

--- a/docs/superpowers/plans/_archive/2026-05-06-symphony-linear-execution-implementation-plan.md
+++ b/docs/superpowers/plans/_archive/2026-05-06-symphony-linear-execution-implementation-plan.md
@@ -1,7 +1,7 @@
 ---
 type: Plan
 title: Symphony Linear Execution Implementation Plan
-description: Archived implementation plan: Symphony Linear Execution Implementation Plan.
+description: "Archived implementation plan: Symphony Linear Execution Implementation Plan."
 tags: [archive]
 timestamp: 2026-07-15T20:00:00Z
 ---

--- a/docs/superpowers/plans/_archive/2026-05-07-symphony-linear-execution-and-backend-uat-implementation-plan.md
+++ b/docs/superpowers/plans/_archive/2026-05-07-symphony-linear-execution-and-backend-uat-implementation-plan.md
@@ -1,7 +1,7 @@
 ---
 type: Plan
 title: Symphony Linear Execution And Backend Uat Implementation Plan
-description: Archived implementation plan: Symphony Linear Execution And Backend Uat Implementation Plan.
+description: "Archived implementation plan: Symphony Linear Execution And Backend Uat Implementation Plan."
 tags: [archive]
 timestamp: 2026-07-15T20:00:00Z
 ---

--- a/docs/superpowers/plans/_archive/2026-05-14-pi-symphony-extension-slice-1.md
+++ b/docs/superpowers/plans/_archive/2026-05-14-pi-symphony-extension-slice-1.md
@@ -1,7 +1,7 @@
 ---
 type: Plan
 title: Pi Symphony Extension Slice 1
-description: Archived implementation plan: Pi Symphony Extension Slice 1.
+description: "Archived implementation plan: Pi Symphony Extension Slice 1."
 tags: [archive]
 timestamp: 2026-07-15T20:00:00Z
 ---

--- a/docs/superpowers/plans/_archive/2026-05-14-slice-2-worker-operations.md
+++ b/docs/superpowers/plans/_archive/2026-05-14-slice-2-worker-operations.md
@@ -1,7 +1,7 @@
 ---
 type: Plan
 title: Slice 2 Worker Operations
-description: Archived implementation plan: Slice 2 Worker Operations.
+description: "Archived implementation plan: Slice 2 Worker Operations."
 tags: [archive]
 timestamp: 2026-07-15T20:00:00Z
 ---

--- a/docs/superpowers/plans/_archive/2026-05-15-symphony-progress-indicators.md
+++ b/docs/superpowers/plans/_archive/2026-05-15-symphony-progress-indicators.md
@@ -1,7 +1,7 @@
 ---
 type: Plan
 title: Symphony Progress Indicators
-description: Archived implementation plan: Symphony Progress Indicators.
+description: "Archived implementation plan: Symphony Progress Indicators."
 tags: [archive]
 timestamp: 2026-07-15T20:00:00Z
 ---

--- a/docs/superpowers/plans/_archive/2026-05-16-wave-3-symphony-console-escalations.md
+++ b/docs/superpowers/plans/_archive/2026-05-16-wave-3-symphony-console-escalations.md
@@ -1,7 +1,7 @@
 ---
 type: Plan
 title: Wave 3 Symphony Console Escalations
-description: Archived implementation plan: Wave 3 Symphony Console Escalations.
+description: "Archived implementation plan: Wave 3 Symphony Console Escalations."
 tags: [archive]
 timestamp: 2026-07-15T20:00:00Z
 ---

--- a/docs/superpowers/plans/_archive/pi-skills-migraqtion.md
+++ b/docs/superpowers/plans/_archive/pi-skills-migraqtion.md
@@ -1,7 +1,7 @@
 ---
 type: Plan
 title: Pi Skills Migraqtion
-description: Archived implementation plan: Pi Skills Migraqtion.
+description: "Archived implementation plan: Pi Skills Migraqtion."
 tags: [archive]
 timestamp: 2026-07-15T20:00:00Z
 ---

--- a/docs/superpowers/specs/_archive/2026-04-26-kata-cli-skill-platform-design.md
+++ b/docs/superpowers/specs/_archive/2026-04-26-kata-cli-skill-platform-design.md
@@ -1,7 +1,7 @@
 ---
 type: Spec
 title: Kata Cli Skill Platform Design
-description: Archived spec document: Kata Cli Skill Platform Design.
+description: "Archived spec document: Kata Cli Skill Platform Design."
 tags: [archive, cli]
 timestamp: 2026-07-15T20:00:00Z
 ---

--- a/docs/superpowers/specs/_archive/2026-04-27-kata-cli-capability-matrix.md
+++ b/docs/superpowers/specs/_archive/2026-04-27-kata-cli-capability-matrix.md
@@ -1,7 +1,7 @@
 ---
 type: Reference
 title: Kata Cli Capability Matrix
-description: Archived reference document: Kata Cli Capability Matrix.
+description: "Archived reference document: Kata Cli Capability Matrix."
 tags: [archive, cli]
 timestamp: 2026-07-15T20:00:00Z
 ---

--- a/docs/superpowers/specs/_archive/2026-04-27-kata-cli-manual-validation-runbook.md
+++ b/docs/superpowers/specs/_archive/2026-04-27-kata-cli-manual-validation-runbook.md
@@ -1,7 +1,7 @@
 ---
 type: Runbook
 title: Kata Cli Manual Validation Runbook
-description: Archived runbook document: Kata Cli Manual Validation Runbook.
+description: "Archived runbook document: Kata Cli Manual Validation Runbook."
 tags: [archive, cli]
 timestamp: 2026-07-15T20:00:00Z
 ---

--- a/docs/superpowers/specs/_archive/2026-04-27-kata-cli-recovery-stabilization-design.md
+++ b/docs/superpowers/specs/_archive/2026-04-27-kata-cli-recovery-stabilization-design.md
@@ -1,7 +1,7 @@
 ---
 type: Spec
 title: Kata Cli Recovery Stabilization Design
-description: Archived spec document: Kata Cli Recovery Stabilization Design.
+description: "Archived spec document: Kata Cli Recovery Stabilization Design."
 tags: [archive, cli]
 timestamp: 2026-07-15T20:00:00Z
 ---

--- a/docs/superpowers/specs/_archive/2026-04-27-kata-cli-skill-platform-gap-assessment.md
+++ b/docs/superpowers/specs/_archive/2026-04-27-kata-cli-skill-platform-gap-assessment.md
@@ -1,7 +1,7 @@
 ---
 type: Reference
 title: Kata Cli Skill Platform Gap Assessment
-description: Archived reference document: Kata Cli Skill Platform Gap Assessment.
+description: "Archived reference document: Kata Cli Skill Platform Gap Assessment."
 tags: [archive, cli]
 timestamp: 2026-07-15T20:00:00Z
 ---

--- a/docs/superpowers/specs/_archive/2026-04-27-kata-cli-skill-platform-realignment-design.md
+++ b/docs/superpowers/specs/_archive/2026-04-27-kata-cli-skill-platform-realignment-design.md
@@ -1,7 +1,7 @@
 ---
 type: Spec
 title: Kata Cli Skill Platform Realignment Design
-description: Archived spec document: Kata Cli Skill Platform Realignment Design.
+description: "Archived spec document: Kata Cli Skill Platform Realignment Design."
 tags: [archive, cli]
 timestamp: 2026-07-15T20:00:00Z
 ---

--- a/docs/superpowers/specs/_archive/2026-04-28-kata-skills-migration-recovery-design.md
+++ b/docs/superpowers/specs/_archive/2026-04-28-kata-skills-migration-recovery-design.md
@@ -1,7 +1,7 @@
 ---
 type: Spec
 title: Kata Skills Migration Recovery Design
-description: Archived spec document: Kata Skills Migration Recovery Design.
+description: "Archived spec document: Kata Skills Migration Recovery Design."
 tags: [archive]
 timestamp: 2026-07-15T20:00:00Z
 ---

--- a/docs/superpowers/specs/_archive/2026-05-06-cli-linear-core-design.md
+++ b/docs/superpowers/specs/_archive/2026-05-06-cli-linear-core-design.md
@@ -1,7 +1,7 @@
 ---
 type: Spec
 title: Cli Linear Core Design
-description: Archived spec document: Cli Linear Core Design.
+description: "Archived spec document: Cli Linear Core Design."
 tags: [archive, cli]
 timestamp: 2026-07-15T20:00:00Z
 ---

--- a/docs/superpowers/specs/_archive/2026-05-06-github-projects-v2-state-source-of-truth-design.md
+++ b/docs/superpowers/specs/_archive/2026-05-06-github-projects-v2-state-source-of-truth-design.md
@@ -1,7 +1,7 @@
 ---
 type: Spec
 title: Github Projects V2 State Source Of Truth Design
-description: Archived spec document: Github Projects V2 State Source Of Truth Design.
+description: "Archived spec document: Github Projects V2 State Source Of Truth Design."
 tags: [archive]
 timestamp: 2026-07-15T20:00:00Z
 ---

--- a/docs/superpowers/specs/_archive/2026-05-06-symphony-linear-execution-design.md
+++ b/docs/superpowers/specs/_archive/2026-05-06-symphony-linear-execution-design.md
@@ -1,7 +1,7 @@
 ---
 type: Spec
 title: Symphony Linear Execution Design
-description: Archived spec document: Symphony Linear Execution Design.
+description: "Archived spec document: Symphony Linear Execution Design."
 tags: [archive, symphony]
 timestamp: 2026-07-15T20:00:00Z
 ---

--- a/docs/superpowers/specs/_archive/2026-05-07-symphony-linear-execution-and-backend-uat-design.md
+++ b/docs/superpowers/specs/_archive/2026-05-07-symphony-linear-execution-and-backend-uat-design.md
@@ -1,7 +1,7 @@
 ---
 type: Spec
 title: Symphony Linear Execution And Backend Uat Design
-description: Archived spec document: Symphony Linear Execution And Backend Uat Design.
+description: "Archived spec document: Symphony Linear Execution And Backend Uat Design."
 tags: [archive, symphony]
 timestamp: 2026-07-15T20:00:00Z
 ---

--- a/docs/superpowers/specs/_archive/2026-05-15-symphony-progress-indicators-design.md
+++ b/docs/superpowers/specs/_archive/2026-05-15-symphony-progress-indicators-design.md
@@ -1,7 +1,7 @@
 ---
 type: Spec
 title: Symphony Progress Indicators Design
-description: Archived spec document: Symphony Progress Indicators Design.
+description: "Archived spec document: Symphony Progress Indicators Design."
 tags: [archive, symphony]
 timestamp: 2026-07-15T20:00:00Z
 ---


### PR DESCRIPTION
## Summary
- Add durable formal GitHub review publication with marker ownership, progressive steps, restart recovery, and Projects v2 routing.
- Fence publication identity, route, step, error, completion, and changed-head supersession writes with active leases and heartbeats.
- Fail closed on stale heads and missing pull-request identity, with live-head validation and idempotent reconciliation.
- Update A4 documentation, OKF frontmatter, ADRs, verification reports, and UAT guidance.

## Verification
- `cargo fmt --manifest-path apps/symphony/Cargo.toml --check`
- `cargo clippy --manifest-path apps/symphony/Cargo.toml -- -D warnings`
- `cargo test --manifest-path apps/symphony/Cargo.toml -- --test-threads=1` (410 library tests, 6 binary tests, and integration suites)
- Pre-push gate: 15 Turbo lint/typecheck/test tasks passed
- Live Ratatui formal UAT published review `4839847481`, routed a blocking finding to `Rework`, and confirmed restart reconciliation without a duplicate review.

## Evidence
- `/tmp/kata-symphony-current-uat-evidence/a4-pr2/manual-47/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic GitHub pull-request reviews with inline findings, severity-based blocking, and formal review summaries.
  * Added project-status routing for review outcomes.
  * Review results now include cycles, finding counts, review links, publication states, and automatic publication metrics.
* **Bug Fixes**
  * Improved recovery, retries, duplicate prevention, and handling of changed pull-request revisions.
  * Added diagnostics for invalid review settings and insufficient permissions.
* **Tests**
  * Expanded coverage for review creation, configuration validation, recovery, and reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This change adds durable formal-review publication state, restart reconciliation, lease-fenced publication mutations, configurable review outcome routing, and supporting diagnostics and documentation.

A focused restart test created a pending automatic-review intent for an older pull-request head, then reconciled it after the pull request advanced. The old intent was superseded with no stale GitHub review publication and no Projects v2 status mutation. No defects remain.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; no blocking failure remains.

The durable restart path was exercised with a changed pull-request head and correctly prevented stale external side effects. No review comments remain.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the requested verification for proof 0 and noted that local artifact references were not uploaded.
- T-Rex ran the requested verification for proof 1 and noted that local artifact references were not uploaded.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(review): address PR 611 review feedb..."](https://github.com/gannonh/kata-symphony/commit/557a9e75be79f7b55b46432bc7183f11d1607b12) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49529173)</sub>

<!-- /greptile_comment -->