### PR TITLE
Add skills bootstrap script and retire OKF from AGENTS.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/spec.md
+++ b/.github/ISSUE_TEMPLATE/spec.md
@@ -1,0 +1,62 @@
+---
+name: Spec
+about: Spec-driven work for plan-build-verify. GitHub Issues are the source of truth.
+title: ""
+labels: ["kind:spec", "status:draft", "phase:plan"]
+---
+
+## Status
+
+Draft
+
+## Goal
+
+<the outcome, in one or two sentences>
+
+## Context
+
+<current state, verified facts about the repo, links to related issues, PRs, ADRs, or designs>
+
+## Constraints and non-goals
+
+<explicit boundaries, governing rules, and what this spec will not do>
+
+## Acceptance criteria
+
+- [ ] <observable pass/fail outcome>
+- [ ] <observable pass/fail outcome>
+
+## Architecture
+
+<component relationships, boundaries, data flow, Mermaid diagram when relationships matter>
+
+## Delivery slices
+
+1. <user-observable outcome>: end-to-end behavior, likely layers/files, acceptance tie-in, and demo
+2. <next user-observable outcome>: end-to-end behavior, likely layers/files, acceptance tie-in, and demo
+
+## Demonstration
+
+- Consumer: <human, operator, or API/SDK client>
+- Action or input: <what they do>
+- Observable result: <what becomes visible or usable>
+- Evidence: <how to exercise, inspect, or capture it>
+
+<For an unavoidable technical-enablement exception, instead record the blocker, minimum scope, contract/integration evidence, and immediate user-facing slice unlocked.>
+
+## Verification
+
+<required public-boundary E2E command; additional unit/integration checks; required screenshot checkpoints for visual targets; preferred video recorder or expected environment limitation; manual UAT steps>
+
+## Risks and mitigations
+
+<specific risks with practical mitigations>
+
+## Build handoff
+
+- Approved scope: <...>
+- Non-goals: <...>
+- Ordered slices: <...>
+- Required verification commands: <...>
+- Fixtures or credentials needed: <...>
+- Blocking open questions: None

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,21 @@ Release workflows are manually dispatched (Symphony also has a scheduled nightly
 - `CLAUDE.md` files in this repo are symlinks to `AGENTS.md`. Always edit `AGENTS.md`.
 - Asset paths: use `getBundledAssetsDir(subfolder)` for bundled assets, never `import.meta.dir`.
 
-## Agent skills
+## Skills
+
+Project agent skills live under `.agents/skills/`. Bootstrap the shared skills with:
+
+```bash
+./scripts/install-skills.sh
+```
+
+Or equivalently:
+
+```bash
+npx skills add gannonh/skills --skill plan-build-verify --skill address-pr-comments -y
+```
+
+Install only those skills — do not add the full `gannonh/skills` pack or `okf`. Cursor engineering execution uses the pstack plugin; do not npx-install a `ps` skill.
 
 ### Issue tracker
 
@@ -106,18 +120,9 @@ Triage uses the default five-label vocabulary. See `docs/agents/triage-labels.md
 
 Domain docs use a single-context layout. See `docs/agents/domain.md`.
 
-## Open Knowledge Format docs
+## Documentation
 
-This repository maintains an [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) bundle at `./docs`.
-
-- Use `/okf read` when available, or read `./docs/index.md` directly before substantial work, to understand the current documentation map.
-- Follow cross-links into relevant specs, ADRs, runbooks, guides, architecture notes, reference docs, and domain docs before changing related code.
-- Specs are GitHub Issues, not files. See `## Specs live in GitHub Issues` below. `./docs/specs/index.md` is a pointer to the issue roadmap.
-- Historical Superpowers plans/specs remain under `./docs/superpowers/`; the roadmap indexes them rather than relocating them.
-- Add or update ADRs in `./docs/adrs` for durable architecture decisions.
-- After substantial work, PRs, behavior changes, architecture decisions, migrations, or documentation moves, update the OKF bundle and add concise entries to the relevant `log.md` files.
-- Maintain Markdown cross-links between related OKF concepts so future agents can traverse decisions, specs, architecture, runbooks, guides, and references.
-- Every non-reserved Markdown file under `./docs` should have OKF frontmatter with at least a non-empty `type` field. `index.md` and `log.md` are reserved navigation/history files.
+Project docs live under `./docs` (guides, ADRs, runbooks, historical archives). Specs are GitHub Issues — see below. Do not treat `docs/specs/index.md` as the live roadmap; use `gh issue list --label kind:spec --state open`. Historical Superpowers plans/specs remain under `./docs/superpowers/`. Add or update ADRs in `docs/adrs/` for durable architecture decisions.
 
 ## Specs live in GitHub Issues
 
@@ -125,7 +130,7 @@ Specs for this repository are GitHub Issues, not files. `docs/specs/` holds only
 
 - Read the roadmap with `gh issue list --label kind:spec --state open`.
 - Read a spec with `gh issue view <N>`; read an epic's phases with `gh sub-issue list <N>`.
-- Do not create spec files under `docs/specs/`. Use the `plan-build-verify-github` skill, which publishes specs as issues.
+- Do not create spec files under `docs/specs/`. Use the `plan-build-verify` skill, which publishes specs as issues.
 - Never build an issue that is not labeled `status:approved` without explicit maintainer approval.
 - Post build reports and acceptance evidence as comments on the spec issue.
 - ADRs remain files under `docs/adrs/`. Cross-link them with the issues they constrain.

--- a/scripts/install-skills.sh
+++ b/scripts/install-skills.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+npx skills add gannonh/skills --skill plan-build-verify --skill address-pr-comments -y


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a per-project skills bootstrap, retires OKF from agent instructions, and copies the canonical Spec issue template from `gannonh/skills` so new specs use the shared GitHub Issues form.

## Scope

- [ ] `apps/cli` - Kata CLI
- [ ] `apps/symphony` - Kata Symphony
- [ ] `packages/core`
- [ ] `packages/shared`
- [ ] `packages/ui`
- [ ] `packages/mermaid`
- [x] CI, release, or repository tooling
- [x] Documentation

## Change Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Test coverage
- [ ] Dependency update
- [ ] Release or packaging
- [x] Documentation

## What changed

- Added executable `scripts/install-skills.sh` that installs only `plan-build-verify` and `address-pr-comments` from `gannonh/skills` (no `-g`, no full pack, no `okf`).
- Updated `AGENTS.md`:
  - New **Skills** section with the script and equivalent `npx` command
  - Notes that Cursor engineering execution is the pstack plugin (do not npx-install `ps`)
  - Replaced the OKF section with plain **Documentation** guidance (no `/okf`, no treating `docs/specs/index.md` as the live roadmap)
  - Renamed `plan-build-verify-github` → `plan-build-verify` in the Specs section
  - Kept **Specs live in GitHub Issues**
- Added `.github/ISSUE_TEMPLATE/spec.md` — verbatim copy of the canonical template from [`gannonh/skills`](https://github.com/gannonh/skills/blob/main/.github/ISSUE_TEMPLATE/spec.md) (merged via gannonh/skills#3), including frontmatter labels `kind:spec`, `status:draft`, and `phase:plan`

## Verification

- [ ] `pnpm run validate:affected`
- [ ] `pnpm run lint`
- [ ] `pnpm run typecheck`
- [ ] `pnpm run test`
- [ ] `cargo test` in `apps/symphony`
- [x] Manual verification:
  - `bash -n scripts/install-skills.sh` — OK
  - Mode `755` executable
  - `AGENTS.md` has no `/okf`, no "Open Knowledge Format", no `plan-build-verify-github`
  - `CLAUDE.md` still symlinks to `AGENTS.md`
  - `docs/specs/archive` and `docs/adrs` preserved
  - Smoke-ran `./scripts/install-skills.sh` — exit 0; installed exactly `address-pr-comments` and `plan-build-verify` (install artifacts discarded)
  - Spec template fetched from `raw.githubusercontent.com/gannonh/skills/main/.github/ISSUE_TEMPLATE/spec.md`; labels frontmatter present; no OKF content

## Risk

- [ ] Touches shared contracts, prompts, config, auth, daemon, or MCP behavior
- [ ] Touches persistence, migrations, filesystem paths, or bundled assets
- [ ] Touches release packaging or install/update flows
- [ ] Requires follow-up work

Notes: Docs and tooling only. Skill trees are not vendored. `install-skills.sh` unchanged by the template commit.

## Reviewer Notes

Diff stays small: bootstrap script, `AGENTS.md`, and the Spec issue template. Existing vendored `.agents/skills/okf` and `plan-build-verify-github` trees are left in place for a later cleanup if desired.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ea4d356e-1fbd-49eb-8e56-1df1ea82ab74?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea4d356e-1fbd-49eb-8e56-1df1ea82ab74&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated setup script that installs the project’s recommended skills.
  * Supports non-interactive installation for streamlined environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->