### PR TITLE
fix(symphony): unblock nightly Preflight Clippy failures

### DIFF
--- a/apps/symphony/src/orchestrator.rs
+++ b/apps/symphony/src/orchestrator.rs
@@ -654,7 +654,7 @@ async fn run_codex_turns_in_session<E, EFut, EventCallback>(
     tracker_config: &TrackerConfig,
     graphql_executor: E,
     mut stream_event: EventCallback,
-) -> std::result::Result<SessionTurnLoopSuccess, SessionTurnLoopFailure>
+) -> std::result::Result<SessionTurnLoopSuccess, Box<SessionTurnLoopFailure>>
 where
     E: Fn(String, serde_json::Value) -> EFut + Clone + Send,
     EFut: Future<Output = Result<serde_json::Value>> + Send,
@@ -694,11 +694,11 @@ where
                 );
             }
             Err(err) => {
-                return Err(SessionTurnLoopFailure {
+                return Err(Box::new(SessionTurnLoopFailure {
                     error: err,
                     events: observed_events,
                     metrics,
-                });
+                }));
             }
         }
 
@@ -759,7 +759,7 @@ async fn run_pi_turns_in_session<EventCallback>(
     tracker_config: &TrackerConfig,
     steer_rx: &mut Option<tokio::sync::mpsc::UnboundedReceiver<rpc_bridge::FollowUpRequest>>,
     mut stream_event: EventCallback,
-) -> std::result::Result<SessionTurnLoopSuccess, SessionTurnLoopFailure>
+) -> std::result::Result<SessionTurnLoopSuccess, Box<SessionTurnLoopFailure>>
 where
     EventCallback: FnMut(AgentEvent) + Send,
 {
@@ -797,11 +797,11 @@ where
                 );
             }
             Err(err) => {
-                return Err(SessionTurnLoopFailure {
+                return Err(Box::new(SessionTurnLoopFailure {
                     error: err,
                     events: observed_events,
                     metrics,
-                });
+                }));
             }
         }
 

--- a/apps/symphony/src/verification/publisher.rs
+++ b/apps/symphony/src/verification/publisher.rs
@@ -59,7 +59,7 @@ pub fn render_verification_preview_comment(context: &PreviewCommentContext<'_>) 
     } = context;
     let marker = verification_marker(run_id, reviewed_head_sha);
     let mut lines = vec![
-        format!("{marker}"),
+        marker,
         "## Verification evidence preview".to_string(),
         String::new(),
         format!(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Nightly Symphony Release Preflight on `main` failed at **Symphony clippy** (`cargo clippy -- -D warnings`) in run [32777838984](https://github.com/gannonh/kata-symphony/actions/runs/32777838984). This PR fixes the three Clippy errors that caused the failure so the next scheduled Preflight can pass.

Confirmed from job logs (no other Preflight failures — later steps were skipped after clippy):

1. `clippy::useless_format` in `apps/symphony/src/verification/publisher.rs:62` — `format!("{marker}")` where `marker` is already a `String`
2. `clippy::result_large_err` in `apps/symphony/src/orchestrator.rs:657` and `:762` — `SessionTurnLoopFailure` Err variant ≥136 bytes

## Scope

- [ ] `apps/cli` - Kata CLI
- [x] `apps/symphony` - Kata Symphony
- [ ] `packages/core`
- [ ] `packages/shared`
- [ ] `packages/ui`
- [ ] `packages/mermaid`
- [ ] CI, release, or repository tooling
- [ ] Documentation

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Test coverage
- [ ] Dependency update
- [ ] Release or packaging
- [ ] Documentation

## Verification

- [ ] `pnpm run validate:affected`
- [ ] `pnpm run lint`
- [ ] `pnpm run typecheck`
- [ ] `pnpm run test`
- [ ] `cargo test` in `apps/symphony`
- [x] Manual verification: `cd apps/symphony && cargo clippy -- -D warnings` — **passes** after this fix (same command as Preflight “Symphony clippy”)

## Risk

- [ ] Touches shared contracts, prompts, config, auth, daemon, or MCP behavior
- [ ] Touches persistence, migrations, filesystem paths, or bundled assets
- [ ] Touches release packaging or install/update flows
- [ ] Requires follow-up work

Notes: Behavioral no-op. Uses the owned marker `String` directly; boxes `SessionTurnLoopFailure` in the turn-loop `Result` Err variants so Clippy’s `result_large_err` lint is satisfied. Does not change release workflow, versioning, or dispatch a nightly.

## Reviewer Notes

- Failed job logs: Preflight → Symphony clippy only (tests had already passed).
- Diff is two files / ~7 lines.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ed010c5-722c-47cc-9e26-b3dd0f0b09e5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ed010c5-722c-47cc-9e26-b3dd0f0b09e5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal error handling for session turn processing.
  * Simplified verification preview comment generation without changing its visible output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->